### PR TITLE
Fix query buffer creation in clatter-nicklist.el

### DIFF
--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -115,7 +115,7 @@ CONN is used for nick colorization."
                        (clatter-get-connection clatter--network))
               (let ((conn (clatter-get-connection clatter--network)))
                 (clatter-get-or-create-buffer
-                 clatter--network nick 'query conn)
+                 clatter--network nick 'query)
                 (pop-to-buffer
                  (clatter-get-buffer clatter--network nick))))))))))
 


### PR DESCRIPTION
When RET is pressed in the nicklist, `(wrong-number-of-arguments #<subr clatter-get-or-create-buffer> 4)` is thrown.

Remove the extra argument to fix the exception.