### PR TITLE
add support for +reply tag

### DIFF
--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -297,6 +297,7 @@ Called with (CONN BATCH-TYPE TARGET MESSAGES).")
               (is-bot (assoc "bot" parsed-tags))
               (msgid (cdr (assoc "msgid" parsed-tags)))
               (reply-to (or (cdr (assoc "+draft/reply" parsed-tags))
+                            (cdr (assoc "+reply" parsed-tags))
                             (cdr (assoc "draft/reply" parsed-tags))))
               ;; STATUSMSG: detect prefix like @#channel or +#channel
               (statusmsg-chars (let ((isup (clatter-connection-isupport conn)))


### PR DESCRIPTION
The IRCv3 +reply spec has been officially released, and is no longer in WIP status since https://github.com/ircv3/ircv3-specifications/commit/a74e3b0407609fbc94685eef3856c1cbfabde3ac