### PR TITLE
Add input history support

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -191,6 +191,10 @@ before sending.  Set to nil to disable the warning."
   :type '(choice integer (const nil))
   :group 'clatter)
 
+(defcustom clatter-input-ring-size 1024
+  "Size of the input history ring."
+  :type 'integer)
+
 (defcustom clatter-message-order 'newest-first
   "Order in which messages appear in channel buffers.
 `newest-first' places new messages directly below the input line

--- a/clatter-model.el
+++ b/clatter-model.el
@@ -13,6 +13,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'ring)
 (require 'clatter-config)
 (require 'clatter-protocol)
 (require 'clatter-connection)
@@ -110,6 +111,31 @@ TYPE is server, channel, or query (auto-detected if nil)."
            when (with-current-buffer buf
                   (eq clatter--buffer-type 'channel))
            collect buf))
+
+;; --- Input ring ---
+
+(defvar-local clatter-input-ring nil
+  "Ring object for input history.")
+
+(defvar-local clatter-input-ring-index 0
+  "Current position in the input history.")
+
+(defun clatter-input-ring-setup ()
+  (setq clatter-input-ring
+        (if (and (ring-p clatter-input-ring)
+                 (= (ring-size clatter-input-ring)
+                    clatter-input-ring-size))
+            clatter-input-ring
+          (make-ring clatter-input-ring-size))))
+
+(defun clatter-input-ring-add (input)
+  "Add INPUT to the input history ring."
+  (ring-insert clatter-input-ring input)
+  (setq clatter-input-ring-index 0))
+
+(defun clatter-input-ring-nth (n)
+  "Get the Nth next element in the input history ring."
+  (ring-ref clatter-input-ring (+ clatter-input-ring-index n)))
 
 ;; --- Nick list management ---
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -301,6 +301,7 @@ SERVER-TIME overrides the current time for the timestamp."
   "Set up the input prompt at the top of BUFFER."
   (with-current-buffer buffer
     (let ((inhibit-read-only t))
+      (clatter-input-ring-setup)
       (goto-char (point-min))
       (setq clatter--prompt-marker (point-marker))
       (set-marker-insertion-type clatter--prompt-marker nil)
@@ -332,6 +333,22 @@ SERVER-TIME overrides the current time for the timestamp."
       (delete-region clatter--input-marker
                      (1- (marker-position clatter--messages-marker))))))
 
+(defun clatter--set-input (input)
+  (clatter--clear-input)
+  (insert input))
+
+(defun clatter-set-prev-input ()
+  "Insert the previous input history item at the prompt."
+  (interactive)
+  (clatter--set-input (clatter-input-ring-nth 0))
+  (setq clatter-input-ring-index (1+ clatter-input-ring-index)))
+
+(defun clatter-set-next-input ()
+  "Insert the next input history item at the prompt."
+  (interactive)
+  (setq clatter-input-ring-index (1- clatter-input-ring-index))
+  (clatter--set-input (clatter-input-ring-nth -1)))
+
 ;; --- Input handling ---
 
 (defun clatter-send-input ()
@@ -341,6 +358,7 @@ If the input contains multiple lines and exceeds
   (interactive)
   (let ((input (string-trim (or (clatter--get-input) ""))))
     (when (> (length input) 0)
+      (clatter-input-ring-add input)
       (let* ((lines (split-string input "\n"))
              (nlines (length lines))
              (flood (and clatter-paste-flood-threshold
@@ -423,6 +441,8 @@ If the input contains multiple lines and exceeds
       (set-keymap-parent map clatter-mode-map)
       (define-key map (kbd "RET") #'clatter-send-input)
       (define-key map (kbd "TAB") #'completion-at-point)
+      (define-key map (kbd "M-p") #'clatter-set-prev-input)
+      (define-key map (kbd "M-n") #'clatter-set-next-input)
       (use-local-map map))
     ;; Ensure window margins are synced for timestamp display
     (add-hook 'window-configuration-change-hook


### PR DESCRIPTION
Basic input history ring support for clatter.el

This is mostly ported over from rcirc.el with a few modifications. Cycling next/previous entries is bound to *M-p* and *M-n* respectively.