### PR TITLE
fix references to undefined function clatter-current-connection

### DIFF
--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -476,9 +476,9 @@ For channels, sends PART first."
 (clatter-defcommand "ignore" #'clatter-cmd-ignore)
 (clatter-defcommand "unignore" #'clatter-cmd-unignore)
 
-(defun clatter-cmd-list (_conn _args)
+(defun clatter-cmd-list (args)
   "Open the interactive channel list browser."
-  (let ((conn (clatter-current-connection)))
+  (let ((conn (clatter--current-conn)))
     (if conn
         (clatter-list-request conn)
       (message "Not connected."))))
@@ -508,7 +508,7 @@ Uses +draft/reply tag to thread the response."
   (let* ((text (string-trim args))
          (msgid (get-text-property (point) 'clatter-msgid))
          (target clatter--target)
-         (conn (clatter-current-connection)))
+         (conn (clatter--current-conn)))
     (cond
      ((string-empty-p text)
       (message "Usage: /reply <message>"))
@@ -533,7 +533,7 @@ Uses +draft/react tag via TAGMSG."
   (let* ((emoji (string-trim args))
          (msgid (get-text-property (point) 'clatter-msgid))
          (target clatter--target)
-         (conn (clatter-current-connection)))
+         (conn (clatter--current-conn)))
     (cond
      ((string-empty-p emoji)
       (message "Usage: /react <emoji>"))


### PR DESCRIPTION
`clatter-current-connection` isn't defined anywhere. This should be `clatter--current-conn`.

Also fixes `/list` & likely other commands as well.