### PR TITLE
Support optional argument in /list command

### DIFF
--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -475,7 +475,7 @@ For channels, sends PART first."
   "Open the interactive channel list browser."
   (let ((conn (clatter--current-conn)))
     (if conn
-        (clatter-list-request conn)
+        (clatter-list-request conn (string-trim args))
       (message "Not connected."))))
 
 (clatter-defcommand "list" #'clatter-cmd-list)

--- a/clatter-list.el
+++ b/clatter-list.el
@@ -135,12 +135,12 @@ Each entry is (CHANNEL USERS TOPIC).")
 
 ;; --- Entry point ---
 
-(defun clatter-list-request (conn)
+(defun clatter-list-request (conn &optional arg)
   "Send LIST on CONN and prepare to display results."
   (setq clatter-list--entries nil)
   (setq clatter-list--conn conn)
   (setq clatter-list--filter "")
-  (clatter-send conn "LIST")
+  (clatter-send conn (if (string-empty-p arg) "LIST" (format "LIST %s" arg)))
   (message "Fetching channel list..."))
 
 (provide 'clatter-list)


### PR DESCRIPTION
As per https://www.rfc-editor.org/info/rfc1459/#section-4.2.6, `LIST` may take an optional argument, which (per spec.) consists of a CSV list of one or more channel names.

In practice, servers & networks do however support various extensions to this - e.g. OFTC supports simple glob searches e.g. `/list #deb*` (useful for obtaining a listing of Debian-related channels). For this reason, it might be better to pass the argument string verbatim, which we do in this changeset.