### PR TITLE
Show nicks with server/network-defined prefixes in nicklist

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -233,6 +233,11 @@ types at runtime without losing any history."
                          (const :tag "TOPIC" topic)))
   :group 'clatter)
 
+(defcustom clatter-prefix-rank "~&@%+"
+  "Default prefix ranking. This may be overriden by the server."
+  :type 'string
+  :group 'clatter)
+
 ;; --- IRCv3 capabilities we want to negotiate ---
 
 (defconst clatter-wanted-capabilities

--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -45,42 +45,41 @@
 
 (defun clatter-nicklist--render (buf)
   "Render the nicklist for source buffer BUF into the current buffer."
-  (let ((inhibit-read-only t)
-        (nicks (clatter-nick-list buf))
-        (conn (when (buffer-live-p buf)
-                (with-current-buffer buf
-                  (when clatter--network
-                    (clatter-get-connection clatter--network))))))
+  (let* ((inhibit-read-only t)
+         (nicks (clatter-nick-list buf))
+         (conn (when (buffer-live-p buf)
+                 (with-current-buffer buf
+                   (when clatter--network
+                     (clatter-get-connection clatter--network)))))
+         (rank (or (let ((isup (clatter-connection-isupport conn)))
+                     (when isup
+                       (let ((prefix (gethash "PREFIX" isup)))
+                         (and prefix
+                              (string-match (rx bol ?\( (+ alpha) ?\) (group (+ anything) eol))
+                                            prefix)
+                              (match-string 1 prefix)))))
+                   clatter-prefix-rank)))
     (erase-buffer)
     (insert (propertize (format " %d members\n"
                                 (length nicks))
                         'face 'bold))
     (insert (propertize (make-string (1- clatter-nicklist-width) ?-) 'face 'shadow)
             "\n")
-    ;; Group by prefix: ops (@), other (&%...). voiced (+), regular
-    (let ((ops (cl-remove-if-not (lambda (n) (string-equal (cdr n) "@")) nicks))
-          (other (cl-remove-if-not (lambda (n) (not (or (string-equal (cdr n) "@")
-                                                   (string-equal (cdr n) "+")
-                                                   (string-equal (cdr n) "")))) nicks))
-          (voiced (cl-remove-if-not (lambda (n) (string-equal (cdr n) "+")) nicks))
-          (regular (cl-remove-if-not (lambda (n) (string-equal (cdr n) "")) nicks)))
-      (when ops
-        (dolist (n ops)
-          (clatter-nicklist--insert-nick (car n) (cdr n) conn)))
-      (when other
-        (setq other (sort other
-                          :lessp (lambda (a b) (if (string-equal (cdr a) (cdr b))
-                                              (string-lessp (car a) (car b))
-                                            (string-greaterp (cdr a) (cdr b))))
-                          :in-place t))
-        (dolist (n other)
-          (clatter-nicklist--insert-nick (car n) (cdr n) conn)))
-      (when voiced
-        (dolist (n voiced)
-          (clatter-nicklist--insert-nick (car n) (cdr n) conn)))
-      (when regular
-        (dolist (n regular)
-          (clatter-nicklist--insert-nick (car n) (cdr n) conn))))
+    ;; Display sorted nicks by rank
+    (setq nicks
+          (sort nicks
+                :key (lambda (n) (cons (car n)
+                                  (or (cl-loop for p being the elements of (cdr n)
+                                               sum (- (length rank)
+                                                      (string-search (char-to-string p) rank)))
+                                      0)))
+                :lessp (lambda (a b)
+                         (if (= (cdr a) (cdr b))
+                             (string< (car a) (car b))
+                           (> (cdr a) (cdr b))))
+                :in-place t))
+    (dolist (n nicks)
+      (clatter-nicklist--insert-nick (car n) (cdr n) conn))
     (goto-char (point-min))))
 
 (defun clatter-nicklist--insert-nick (nick prefix conn)

--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -55,7 +55,7 @@
                      (when isup
                        (let ((prefix (gethash "PREFIX" isup)))
                          (and prefix
-                              (string-match (rx bol ?\( (+ alpha) ?\) (group (+ anything) eol))
+                              (string-match (rx bol ?\( (+ alpha) ?\) (group (+ anything)) eol)
                                             prefix)
                               (match-string 1 prefix)))))
                    clatter-prefix-rank)))

--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -69,8 +69,9 @@
           (clatter-nicklist--insert-nick (car n) (cdr n) conn)))
       (when other
         (setq other (sort other
-                          :lessp (lambda (a b) (or (string-greaterp (cdr a) (cdr b))
-                                              (string-lessp (car a) (car b))))
+                          :lessp (lambda (a b) (if (string-equal (cdr a) (cdr b))
+                                              (string-lessp (car a) (car b))
+                                            (string-greaterp (cdr a) (cdr b))))
                           :in-place t))
         (dolist (n other)
           (clatter-nicklist--insert-nick (car n) (cdr n) conn)))

--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -87,8 +87,8 @@
 CONN is used for nick colorization."
   (let* ((color (clatter-hl-nick-color nick))
          (prefix-face (cond
-                       ((string-equal prefix "@") 'clatter-system)
-                       ((string-equal prefix "+") 'clatter-notice)
+                       ((string-search "@" prefix) 'clatter-system)
+                       ((string-search "+" prefix) 'clatter-notice)
                        (t nil)))
          (prefix-str (if (string-empty-p prefix) " " prefix)))
     (insert (if prefix-face

--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -70,8 +70,8 @@
           (sort nicks
                 :key (lambda (n) (cons (car n)
                                   (or (cl-loop for p being the elements of (cdr n)
-                                               sum (- (length rank)
-                                                      (string-search (char-to-string p) rank)))
+                                               maximize (- (length rank)
+                                                           (string-search (char-to-string p) rank)))
                                       0)))
                 :lessp (lambda (a b)
                          (if (= (cdr a) (cdr b))

--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -57,12 +57,22 @@
                         'face 'bold))
     (insert (propertize (make-string (1- clatter-nicklist-width) ?-) 'face 'shadow)
             "\n")
-    ;; Group by prefix: ops (@), voiced (+), regular
+    ;; Group by prefix: ops (@), other (&%...). voiced (+), regular
     (let ((ops (cl-remove-if-not (lambda (n) (string-equal (cdr n) "@")) nicks))
+          (other (cl-remove-if-not (lambda (n) (not (or (string-equal (cdr n) "@")
+                                                   (string-equal (cdr n) "+")
+                                                   (string-equal (cdr n) "")))) nicks))
           (voiced (cl-remove-if-not (lambda (n) (string-equal (cdr n) "+")) nicks))
           (regular (cl-remove-if-not (lambda (n) (string-equal (cdr n) "")) nicks)))
       (when ops
         (dolist (n ops)
+          (clatter-nicklist--insert-nick (car n) (cdr n) conn)))
+      (when other
+        (setq other (sort other
+                          :lessp (lambda (a b) (or (string-greaterp (cdr a) (cdr b))
+                                              (string-lessp (car a) (car b))))
+                          :in-place t))
+        (dolist (n other)
           (clatter-nicklist--insert-nick (car n) (cdr n) conn)))
       (when voiced
         (dolist (n voiced)


### PR DESCRIPTION
Some networks have their own custom prefixes e.g. % & ~ etc; Show these in the nicklist between @ (ops) and + (voiced)

Here is an example showcasing this changeset on RektIRC:

<img width="335" height="535" alt="Bildschirmfoto vom 2026-06-07 11-10-49" src="https://github.com/user-attachments/assets/9356d888-faeb-4a46-ade0-eaf74ef5b469" />

The extra prefixes are server-defined, but we attempt to write the `:lessp` comparator in way that orders by prefix lexicographically (the relation `~ (admin) > & (half-admin) > % (halfop)` is correct in terms of privileges and follows the lexicographical order).