### PR TITLE
Prevent the user from `undo'-ing system messages

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -139,6 +139,7 @@ append at the bottom like a traditional IRC client."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (let ((inhibit-read-only t)
+            (buffer-undo-list t)
             (oldest-first (eq clatter-message-order 'oldest-first)))
         (save-excursion
           (goto-char (if oldest-first
@@ -302,7 +303,8 @@ SERVER-TIME overrides the current time for the timestamp."
 (defun clatter--setup-prompt (buffer)
   "Set up the input prompt at the top of BUFFER."
   (with-current-buffer buffer
-    (let ((inhibit-read-only t))
+    (let ((inhibit-read-only t)
+          (buffer-undo-list t))
       (clatter-input-ring-setup)
       (goto-char (point-min))
       (setq clatter--prompt-marker (point-marker))
@@ -379,6 +381,7 @@ If the input contains multiple lines and exceeds
                                nlines (or clatter--target "?")))))
             (message "[clatter] Paste cancelled")
           (clatter--clear-input)
+          (setq buffer-undo-list nil)
           (if (string-prefix-p "/" (car lines))
               (clatter--handle-command (car lines))
             (dolist (line lines)


### PR DESCRIPTION
Whenever we insert system messages (or anything outside the input prompt, really), we must ensure that these messages are not added to the `buffer-undo-list`.

This can be done in a controlled and scoped way by binding `buffer-undo-list` to `t`.

Doing this ensures that *M-x undo* & friends will only affect the text in the input prompt.

Additionally, also clear the `buffer-undo-list` whenever a message is sent. The message is already over the wire at that point, so it can't be "undo"-ed in any meaningful sense.