### PR TITLE
Improve behavior of C-a and [home] when on the prompt line.

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -407,6 +407,13 @@ If the input contains multiple lines and exceeds
   ;; Forward to clatter-commands.el
   (clatter-execute-command input))
 
+(defun clatter-bol ()
+  "Move `point' to the beginning of the current line."
+  (interactive)
+  (and (forward-line 0)
+       (equal (point-marker) clatter--prompt-marker)
+       (goto-char clatter--input-marker)))
+
 ;; Forward declaration
 (declare-function clatter-execute-command "clatter-commands")
 
@@ -457,6 +464,8 @@ If the input contains multiple lines and exceeds
       (define-key map (kbd "TAB") #'completion-at-point)
       (define-key map (kbd "M-p") #'clatter-set-prev-input)
       (define-key map (kbd "M-n") #'clatter-set-next-input)
+      (define-key map (kbd "C-a") #'clatter-bol)
+      (define-key map [home] #'clatter-bol)
       (use-local-map map))
     ;; Ensure window margins are synced for timestamp display
     (add-hook 'window-configuration-change-hook


### PR DESCRIPTION
If point is on the prompt line, move to the beginning of the input area. Otherwise, behave the same way as the defaults.