### PR TITLE
Interpret formatting codes in MOTDs

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -283,13 +283,12 @@ SERVER-TIME overrides the current time for the timestamp."
                             (propertize text 'face 'clatter-notice))))
     (clatter--insert-message buffer formatted)))
 
-(defun clatter-insert-system (buffer text &optional invisible verbatim)
+(defun clatter-insert-system (buffer text &optional invisible)
   "Insert a system message TEXT into BUFFER."
   (let* ((prefix (clatter--format-system-prefix "***"))
          (formatted (concat prefix " "
-                            (if verbatim
-                                text
-                              (propertize text 'face 'clatter-system)))))
+                            (prog1 (setq text (copy-sequence text))
+                              (add-face-text-property 0 (length text) 'clatter-system t text)))))
     (clatter--insert-message buffer formatted nil nil nil invisible)))
 
 (defun clatter-insert-error (buffer text)
@@ -671,7 +670,7 @@ Emacs requires `set-window-margins' on the window, not just
     (clatter-ui-setup-buffer-if-needed buf)
     (clatter-insert-system buf "--- MOTD ---")
     (dolist (line lines)
-      (clatter-insert-system buf (clatter-format-parse line) nil t))
+      (clatter-insert-system buf (clatter-hl-urls-in-string (clatter-format-parse line)) nil))
     (clatter-insert-system buf "--- End of MOTD ---")))
 
 (defun clatter-ui--on-whois (_conn nick data)

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -283,11 +283,13 @@ SERVER-TIME overrides the current time for the timestamp."
                             (propertize text 'face 'clatter-notice))))
     (clatter--insert-message buffer formatted)))
 
-(defun clatter-insert-system (buffer text &optional invisible)
+(defun clatter-insert-system (buffer text &optional invisible verbatim)
   "Insert a system message TEXT into BUFFER."
   (let* ((prefix (clatter--format-system-prefix "***"))
          (formatted (concat prefix " "
-                            (propertize text 'face 'clatter-system))))
+                            (if verbatim
+                                text
+                              (propertize text 'face 'clatter-system)))))
     (clatter--insert-message buffer formatted nil nil nil invisible)))
 
 (defun clatter-insert-error (buffer text)
@@ -669,7 +671,7 @@ Emacs requires `set-window-margins' on the window, not just
     (clatter-ui-setup-buffer-if-needed buf)
     (clatter-insert-system buf "--- MOTD ---")
     (dolist (line lines)
-      (clatter-insert-system buf line))
+      (clatter-insert-system buf (clatter-format-parse line) nil t))
     (clatter-insert-system buf "--- End of MOTD ---")))
 
 (defun clatter-ui--on-whois (_conn nick data)


### PR DESCRIPTION
The server MOTD may contain formatting codes, so make sure to parse & interpret them

e.g.: The `testnet.ergo.chat` MOTD (before, after):

<img width="2466" height="1902" alt="testnet.ergo.chat without format code parsing" src="https://github.com/user-attachments/assets/3c3560c5-df87-4575-b760-369ccb8c406c" />

<img width="2264" height="1770" alt="testnet.ergo.chat with format code parsing" src="https://github.com/user-attachments/assets/19da6f5c-77d8-4da6-b39a-e79eb973352f" />

