### PR TITLE
Display & notify channel invites

### DIFF
--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -111,6 +111,10 @@ Called with (CONN NICK).")
   "Hook for completed batch delivery.
 Called with (CONN BATCH-TYPE TARGET MESSAGES).")
 
+(defvar clatter-invite-hook nil
+  "Hook for INVITE events.
+Called with (CONN SENDER NICK CHANNEL).")
+
 ;; --- Main Dispatch ---
 
 (defun clatter-dispatch-message (conn msg)
@@ -354,6 +358,14 @@ Called with (CONN BATCH-TYPE TARGET MESSAGES).")
                                    conn sender-nick ctcp-cmd ctcp-args))
            (run-hook-with-args 'clatter-notice-hook
                                conn sender-nick target text))))
+
+      ;; --- INVITE ---
+      ("INVITE"
+       (let* ((nick (nth 0 params))
+              (channel (nth 1 params))
+              (parsed-prefix (clatter-parse-prefix prefix))
+              (sender-nick (clatter-prefix-nick parsed-prefix)))
+         (run-hook-with-args 'clatter-invite-hook conn sender-nick nick channel)))
 
       ;; --- JOIN ---
       ("JOIN"

--- a/clatter-notify.el
+++ b/clatter-notify.el
@@ -36,6 +36,11 @@
   :type 'boolean
   :group 'clatter)
 
+(defcustom clatter-notify-on-invite t
+  "Send notification for channel invitations."
+  :type 'boolean
+  :group 'clatter)
+
 (defcustom clatter-notify-on-keyword t
   "Send notification when a keyword from `clatter-notify-keywords' matches."
   :type 'boolean
@@ -289,6 +294,7 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
   (pcase reason
     ('dm (format "DM from %s" sender))
     ('mention (format "Mentioned in %s" target))
+    ('invite (format "Invite from %s" sender))
     ('keyword (format "Keyword in %s" target))
     (_ (format "%s in %s" sender target))))
 
@@ -315,6 +321,15 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
           (clatter-notify--send
            (clatter-notify--format-title reason sender target)
            (format "* %s %s" sender text)))))))
+
+(defun clatter-notify--on-invite (conn sender nick channel)
+  "Handle INVITE for notifications."
+  (when (and clatter-notify-on-invite
+             (string-equal (clatter-connection-nick conn) nick))
+    (when (clatter-notify--rate-ok-p sender)
+      (clatter-notify--send
+       (clatter-notify--format-title 'invite sender nick)
+       (format "%s invites you to join %s" sender channel)))))
 
 ;; --- Interactive commands ---
 
@@ -365,6 +380,7 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
   (interactive)
   (add-hook 'clatter-privmsg-hook #'clatter-notify--on-privmsg)
   (add-hook 'clatter-action-hook #'clatter-notify--on-action)
+  (add-hook 'clatter-invite-hook #'clatter-notify--on-invite)
   (message "[clatter-notify] Notification hooks enabled"))
 
 (defun clatter-notify-disable ()
@@ -372,6 +388,7 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
   (interactive)
   (remove-hook 'clatter-privmsg-hook #'clatter-notify--on-privmsg)
   (remove-hook 'clatter-action-hook #'clatter-notify--on-action)
+  (remove-hook 'clatter-invite-hook #'clatter-notify--on-invite)
   (message "[clatter-notify] Notification hooks disabled"))
 
 ;; --- Auto-enable ---

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -539,6 +539,20 @@ Emacs requires `set-window-margins' on the window, not just
     (clatter-ui-setup-buffer-if-needed buf)
     (clatter-insert-notice buf sender text)))
 
+(defun clatter-ui--on-invite (conn sender nick channel)
+  "Handle INVITE event for UI."
+  (let* ((network (clatter-connection-network-id conn))
+         (my-nick (clatter-connection-nick conn))
+         (buf (or (clatter-get-buffer network channel)
+                  (clatter-get-server-buffer network)
+                  (clatter-get-or-create-buffer network "*server*" 'server))))
+    (clatter-ui-setup-buffer-if-needed buf)
+    (clatter-insert-system buf (format "%s invites %s to join %s"
+                                       sender
+                                       (if (string-equal nick my-nick) "you" nick)
+                                       channel)
+                           'invite)))
+
 (defun clatter-ui--on-join (conn nick channel _account _realname)
   "Handle JOIN event for UI."
   (let* ((network (clatter-connection-network-id conn))
@@ -1002,6 +1016,7 @@ Requires the server to support the message-tags capability."
   (add-hook 'clatter-privmsg-hook #'clatter-ui--on-privmsg)
   (add-hook 'clatter-action-hook #'clatter-ui--on-action)
   (add-hook 'clatter-notice-hook #'clatter-ui--on-notice)
+  (add-hook 'clatter-invite-hook #'clatter-ui--on-invite)
   (add-hook 'clatter-join-hook #'clatter-ui--on-join)
   (add-hook 'clatter-part-hook #'clatter-ui--on-part)
   (add-hook 'clatter-quit-hook #'clatter-ui--on-quit)


### PR DESCRIPTION
Parse the `INVITE` message https://www.rfc-editor.org/info/rfc1459/#section-4.2.7 and notify if we are the target nick