### PR TITLE
improve userhost-in-names and multi-prefix support

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -233,6 +233,11 @@ types at runtime without losing any history."
                          (const :tag "TOPIC" topic)))
   :group 'clatter)
 
+(defcustom clatter-prefix-rank "~&@%+"
+  "Default prefix ranking. This may be overriden by the server."
+  :type 'string
+  :group 'clatter)
+
 ;; --- IRCv3 capabilities we want to negotiate ---
 
 (defconst clatter-wanted-capabilities

--- a/clatter-model.el
+++ b/clatter-model.el
@@ -207,13 +207,15 @@ Uses format: WHO #channel %tcnuhraf,TOKEN to get account names."
   (clatter-send conn (format "WHO %s %%tcnuhraf,%s"
                               channel clatter-whox-token)))
 
-(defun clatter-parse-names (names-str)
+(defun clatter-parse-names (names-str &optional prefixes)
   "Parse NAMES reply string into list of (nick . prefix).
-Handles prefixes like @nick, +nick, ~nick, ~@nick, or ~@nick!user@host."
+Handles prefixes like @nick, +nick, ~nick."
+  (unless prefixes
+    (setq prefixes clatter-prefix-rank))
   (mapcar (lambda (entry)
             (cl-loop for character being the elements of (string-trim entry)
                      with boundary = 0
-                     while (memq character '(?@ ?+ ?~ ?& ?%))
+                     while (seq-contains-p prefixes character)
                      do (cl-incf boundary)
                      finally return (cons (car (split-string (substring entry boundary) (rx ?!)))
                                           (substring entry 0 boundary))))

--- a/clatter-model.el
+++ b/clatter-model.el
@@ -209,14 +209,15 @@ Uses format: WHO #channel %tcnuhraf,TOKEN to get account names."
 
 (defun clatter-parse-names (names-str)
   "Parse NAMES reply string into list of (nick . prefix).
-Handles prefixes like @nick, +nick, ~nick."
+Handles prefixes like @nick, +nick, ~nick, ~@nick, or ~@nick!user@host."
   (mapcar (lambda (entry)
-            (let ((entry (string-trim entry)))
-              (if (and (> (length entry) 0)
-                       (memq (aref entry 0) '(?@ ?+ ?~ ?& ?%)))
-                  (cons (substring entry 1) (string (aref entry 0)))
-                (cons entry ""))))
-          (split-string names-str)))
+            (cl-loop for character being the elements of (string-trim entry)
+                     with boundary = 0
+                     while (memq character '(?@ ?+ ?~ ?& ?%))
+                     do (cl-incf boundary)
+                     finally return (cons (car (split-string (substring entry boundary) (rx ?!)))
+                                          (substring entry 0 boundary))))
+              (split-string names-str)))
 
 ;; --- Topic management ---
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -608,9 +608,17 @@ Emacs requires `set-window-margins' on the window, not just
 (defun clatter-ui--on-names (conn channel names-str)
   "Handle NAMES reply for UI."
   (let* ((network (clatter-connection-network-id conn))
-         (buf (clatter-get-buffer network channel)))
+         (buf (clatter-get-buffer network channel))
+         (prefixes (or (let ((isup (clatter-connection-isupport conn)))
+                         (when isup
+                           (let ((prefix (gethash "PREFIX" isup)))
+                             (and prefix
+                                  (string-match (rx bol ?\( (+ alpha) ?\) (group (+ anything)) eol)
+                                                prefix)
+                                  (match-string 1 prefix)))))
+                       clatter-prefix-rank)))
     (when buf
-      (dolist (entry (clatter-parse-names names-str))
+      (dolist (entry (clatter-parse-names names-str prefixes))
         (clatter-nick-add buf (car entry) (cdr entry))))))
 
 (defun clatter-ui--on-system (conn text)


### PR DESCRIPTION
https://ircv3.net/specs/extensions/userhost-in-names 
https://ircv3.net/specs/extensions/multi-prefix

The NAMES message may contain the full nick+host combination, as well as multiple prefixes.

This changeset ensures that mostly everything works fine. But perhaps the nicklist might have to be adjusted to make it look even nicer - currently it assumes a single-prefix, unless https://github.com/parenworks/clatter.el/pull/8 is applied, in which case the "multi-prefix'ed" nicks will be displayed sorted by their rank.

A lot of servers have both extensions active: one.paranode.net:6697, testnet.ergo.chat:6697 and possibly irc.tilde.chat:6697 (I'm not sure about this one, but I think it does).