### PR TITLE
Implement RPL_TOPIC (332), RPL_TOPICWHOTIME (333)

### DIFF
--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -584,7 +584,7 @@ Called with (CONN BATCH-TYPE TARGET MESSAGES).")
       ("333"  ; RPL_TOPICWHOTIME
        (let* ((channel (nth 1 params))
               (nick (nth 2 params))
-              (at (nth 3 params))
+              (at (string-to-number (nth 3 params)))
               (network (clatter-connection-network-id conn))
               (buf (clatter-get-buffer network channel))
               (topic (clatter-get-topic buf)))

--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -51,7 +51,7 @@ Called with (CONN TARGET SETTER MODES).")
 
 (defvar clatter-topic-hook nil
   "Hook for TOPIC events.
-Called with (CONN CHANNEL NICK TOPIC).")
+Called with (CONN CHANNEL NICK TOPIC AT).")
 
 (defvar clatter-kick-hook nil
   "Hook for KICK events.
@@ -410,7 +410,7 @@ Called with (CONN BATCH-TYPE TARGET MESSAGES).")
               (topic (nth 1 params))
               (parsed-prefix (clatter-parse-prefix prefix))
               (nick (clatter-prefix-nick parsed-prefix)))
-         (run-hook-with-args 'clatter-topic-hook conn channel nick topic)))
+         (run-hook-with-args 'clatter-topic-hook conn channel nick topic nil)))
 
       ;; --- KICK ---
       ("KICK"
@@ -573,6 +573,22 @@ Called with (CONN BATCH-TYPE TARGET MESSAGES).")
          (clatter-list--on-entry conn channel users topic)))
       ("323"  ; RPL_LISTEND
        (clatter-list--on-end conn))
+
+      ;; --- TOPIC numerics ---
+      ("332"  ; RPL_TOPIC
+       (let* ((channel (nth 1 params))
+              (topic (nth 2 params))
+              (network (clatter-connection-network-id conn))
+              (buf (clatter-get-buffer network channel)))
+         (clatter-set-topic buf topic)))
+      ("333"  ; RPL_TOPICWHOTIME
+       (let* ((channel (nth 1 params))
+              (nick (nth 2 params))
+              (at (nth 3 params))
+              (network (clatter-connection-network-id conn))
+              (buf (clatter-get-buffer network channel))
+              (topic (clatter-get-topic buf)))
+         (run-hook-with-args 'clatter-topic-hook conn channel nick topic at)))
 
       ;; --- MONITOR numerics ---
       ("730"  ; RPL_MONONLINE

--- a/clatter-log.el
+++ b/clatter-log.el
@@ -237,11 +237,19 @@ FILE is stored for flushing."
                                (format "*** %s is now known as %s"
                                        old-nick new-nick)))))))
 
-(defun clatter-log--on-topic (conn channel _nick topic)
+(defun clatter-log--on-topic (conn channel nick topic at)
   "Log TOPIC change in CHANNEL on CONN."
   (when clatter-log-system-messages
     (clatter-log--write (clatter-connection-network-id conn) channel
-                         (format "*** Topic: %s" topic))))
+                        (let ((prefix "Topic"))
+                          (cond
+                           ((and nick at)
+                            (setq prefix (format "%s set at %s by %s"
+                                                 prefix
+                                                 (format-time-string "%F %T" at)
+                                                 nick)))
+                           (nick (setq prefix (format "%s set by %s" prefix nick))))
+                          (format "*** %s: %s" prefix topic)))))
 
 (defun clatter-log--on-kick (conn channel nick kicked reason)
   "Log KICK of KICKED by NICK in CHANNEL on CONN."

--- a/clatter-model.el
+++ b/clatter-model.el
@@ -226,6 +226,12 @@ Handles prefixes like @nick, +nick, ~nick."
     (with-current-buffer buffer
       (setq clatter--topic topic))))
 
+(defun clatter-get-topic (buffer)
+  "Get TOPIC for BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      clatter--topic)))
+
 ;; --- Channel modes ---
 
 (defun clatter-set-channel-modes (buffer modes)

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -586,7 +586,7 @@ Emacs requires `set-window-margins' on the window, not just
                                        old-nick new-nick)
                                'nick)))))
 
-(defun clatter-ui--on-topic (conn channel _nick topic)
+(defun clatter-ui--on-topic (conn channel _nick topic _at)
   "Handle TOPIC event for UI."
   (let* ((network (clatter-connection-network-id conn))
          (buf (clatter-get-buffer network channel)))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -287,7 +287,8 @@ SERVER-TIME overrides the current time for the timestamp."
   "Insert a system message TEXT into BUFFER."
   (let* ((prefix (clatter--format-system-prefix "***"))
          (formatted (concat prefix " "
-                            (propertize text 'face 'clatter-system))))
+                            (prog1 (setq text (copy-sequence text))
+                              (add-face-text-property 0 (length text) 'clatter-system t text)))))
     (clatter--insert-message buffer formatted nil nil nil invisible)))
 
 (defun clatter-insert-error (buffer text)
@@ -592,7 +593,8 @@ Emacs requires `set-window-margins' on the window, not just
          (buf (clatter-get-buffer network channel)))
     (when buf
       (clatter-set-topic buf topic)
-      (clatter-insert-system buf (format "Topic: %s" topic) 'topic))))
+      (let ((hl-text (clatter-hl-format-text topic buf conn)))
+        (clatter-insert-system buf (format "Topic: %s" hl-text) 'topic)))))
 
 (defun clatter-ui--on-kick (conn channel nick kicked reason)
   "Handle KICK event for UI."

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -587,14 +587,22 @@ Emacs requires `set-window-margins' on the window, not just
                                        old-nick new-nick)
                                'nick)))))
 
-(defun clatter-ui--on-topic (conn channel _nick topic _at)
+(defun clatter-ui--on-topic (conn channel nick topic at)
   "Handle TOPIC event for UI."
   (let* ((network (clatter-connection-network-id conn))
          (buf (clatter-get-buffer network channel)))
     (when buf
       (clatter-set-topic buf topic)
-      (let ((hl-text (clatter-hl-format-text topic buf conn)))
-        (clatter-insert-system buf (format "Topic: %s" hl-text) 'topic)))))
+      (let ((prefix "Topic")
+            (hl-text (clatter-hl-format-text topic buf conn)))
+        (cond
+         ((and nick at)
+          (setq prefix (format "%s set at %s by %s"
+                               prefix
+                               (format-time-string "%F %T" at)
+                               nick)))
+         (nick (setq prefix (format "%s set by %s" prefix nick))))
+        (clatter-insert-system buf (format "%s: %s" prefix hl-text) 'topic)))))
 
 (defun clatter-ui--on-kick (conn channel nick kicked reason)
   "Handle KICK event for UI."


### PR DESCRIPTION
Additional topic numerics. Needed for the channel topic to be displayed when joining.

https://modern.ircdocs.horse/#rpltopic-332
https://modern.ircdocs.horse/#rpltopicwhotime-333

This is also needed for the zero-argument `/topic` command to work, since the response is typically sent via the 332/333 numerics.