### PR TITLE
Enhanced/fixed target selection in replies and reactions

### DIFF
--- a/clatter-actions.el
+++ b/clatter-actions.el
@@ -37,6 +37,19 @@
 
 ;; --- Actions ---
 
+(defun clatter-select-message ()
+  "Select the message at point."
+  (interactive)
+  (when-let* ((msgid (get-text-property (point) 'clatter-msgid))
+              (begin (previous-single-property-change (point) 'clatter-msgid))
+              (end (next-single-property-change (point) 'clatter-msgid)))
+    (prog1 msgid
+      (save-mark-and-excursion
+        (goto-char begin)
+        (set-mark end)
+        (activate-mark)
+        (secondary-selection-from-region)))))
+
 (defun clatter-action-reply (&optional arg)
   "Reply to the message at point.
 Inserts the sender's nick at the input prompt.
@@ -44,16 +57,8 @@ With a prefix argument, uses a /reply command."
   (interactive "P")
   (let* ((props (clatter-action--msg-at-point))
          (sender (plist-get props :sender)))
-    (if (and sender (or (not arg) (get-text-property (point) 'clatter-msgid)))
+    (if (and sender (or (not arg) (clatter-select-message)))
         (progn
-          (when arg
-            (let ((begin (previous-single-property-change (point) 'clatter-msgid))
-                  (end (next-single-property-change (point) 'clatter-msgid)))
-              (save-mark-and-excursion
-                (goto-char begin)
-                (set-mark end)
-                (activate-mark)
-                (secondary-selection-from-region))))
           (goto-char clatter--input-marker)
           (goto-char (save-excursion
                        (goto-char clatter--input-marker)
@@ -65,15 +70,8 @@ With a prefix argument, uses a /reply command."
 (defun clatter-action-react ()
   "React to the message at point."
   (interactive)
-  (if (get-text-property (point) 'clatter-msgid)
+  (if (clatter-select-message)
       (progn
-        (let ((begin (previous-single-property-change (point) 'clatter-msgid))
-              (end (next-single-property-change (point) 'clatter-msgid)))
-          (save-mark-and-excursion
-            (goto-char begin)
-            (set-mark end)
-            (activate-mark)
-            (secondary-selection-from-region)))
         (goto-char clatter--input-marker)
         (goto-char (save-excursion
                      (goto-char clatter--input-marker)

--- a/clatter-actions.el
+++ b/clatter-actions.el
@@ -37,21 +37,50 @@
 
 ;; --- Actions ---
 
-(defun clatter-action-reply ()
+(defun clatter-action-reply (&optional arg)
   "Reply to the message at point.
-Inserts the sender's nick at the input prompt."
-  (interactive)
+Inserts the sender's nick at the input prompt.
+With a prefix argument, uses a /reply command."
+  (interactive "P")
   (let* ((props (clatter-action--msg-at-point))
          (sender (plist-get props :sender)))
-    (if sender
+    (if (and sender (or (not arg) (get-text-property (point) 'clatter-msgid)))
         (progn
+          (when arg
+            (let ((begin (previous-single-property-change (point) 'clatter-msgid))
+                  (end (next-single-property-change (point) 'clatter-msgid)))
+              (save-mark-and-excursion
+                (goto-char begin)
+                (set-mark end)
+                (activate-mark)
+                (secondary-selection-from-region))))
           (goto-char clatter--input-marker)
           (goto-char (save-excursion
                        (goto-char clatter--input-marker)
                        (line-end-position)))
           (let ((inhibit-read-only t))
-            (insert sender ": ")))
+            (if arg (insert "/reply " sender ": ") (insert sender ": "))))
       (message "No message at point"))))
+
+(defun clatter-action-react ()
+  "React to the message at point."
+  (interactive)
+  (if (get-text-property (point) 'clatter-msgid)
+      (progn
+        (let ((begin (previous-single-property-change (point) 'clatter-msgid))
+              (end (next-single-property-change (point) 'clatter-msgid)))
+          (save-mark-and-excursion
+            (goto-char begin)
+            (set-mark end)
+            (activate-mark)
+            (secondary-selection-from-region)))
+        (goto-char clatter--input-marker)
+        (goto-char (save-excursion
+                     (goto-char clatter--input-marker)
+                     (line-end-position)))
+        (let ((inhibit-read-only t))
+          (insert "/react ")))
+    (message "No message at point")))
 
 (defun clatter-action-copy-message ()
   "Copy the message text at point to kill ring."
@@ -198,6 +227,7 @@ Inserts the sender's nick at the input prompt."
 (defvar clatter-action-map
   (let ((map (make-sparse-keymap "Clatter Actions")))
     (define-key map (kbd "r") #'clatter-action-reply)
+    (define-key map (kbd "e") #'clatter-action-react)
     (define-key map (kbd "c") #'clatter-action-copy-message)
     (define-key map (kbd "n") #'clatter-action-copy-nick)
     (define-key map (kbd "u") #'clatter-action-copy-url)
@@ -214,6 +244,7 @@ Inserts the sender's nick at the input prompt."
   "Show the message action menu for the message at point.
 Key bindings:
   r  Reply (insert nick at prompt)
+  e  React (insert /react at prompt)
   c  Copy message text
   n  Copy nick
   u  Copy URL at point
@@ -229,6 +260,7 @@ Key bindings:
          (url (get-text-property (point) 'clatter-url))
          (parts nil))
     (push "[r]eply" parts)
+    (push "r[e]act" parts)
     (push "[c]opy msg" parts)
     (when sender (push (format "[n]ick(%s)" sender) parts))
     (when url (push "[u]rl copy" parts))
@@ -248,6 +280,7 @@ Key bindings:
   (define-key clatter-mode-map (kbd "C-c C-a") #'clatter-action-menu)
   (define-key clatter-mode-map (kbd "C-c a") #'clatter-action-menu)
   (define-key clatter-mode-map (kbd "C-c C-r") #'clatter-action-reply)
+  (define-key clatter-mode-map (kbd "C-c C-e") #'clatter-action-react)
   (define-key clatter-mode-map (kbd "C-c C-u") #'clatter-action-collect-urls)
   (define-key clatter-mode-map (kbd "C-c C-w") #'clatter-action-whois))
 

--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -498,22 +498,26 @@ For channels, sends PART first."
 (clatter-defcommand "searchhere" #'clatter-cmd-searchhere)
 
 (defun clatter-cmd-reply (args)
-  "Reply to the message at point.  Usage: /reply TEXT
+  "Reply to selected message.  Usage: /reply TEXT
 Uses +draft/reply tag to thread the response."
   (let* ((text (string-trim args))
-         (msgid (get-text-property (point) 'clatter-msgid))
+         (msgid (and mouse-secondary-overlay
+                     (eq (current-buffer) (overlay-buffer mouse-secondary-overlay))
+                     (get-text-property (overlay-start mouse-secondary-overlay) 'clatter-msgid)))
          (target clatter--target)
          (conn (clatter--current-conn)))
     (cond
      ((string-empty-p text)
       (message "Usage: /reply <message>"))
      ((null msgid)
-      (message "No message at point to reply to (move cursor to a message first)"))
+      (message "No message to reply to (select a message using the secondary selection i.e. M-<mouse-1>)"))
      ((null conn)
       (message "Not connected"))
      (t
       (clatter-send conn (format "@+draft/reply=%s PRIVMSG %s :%s"
                                  msgid target text))
+      ; Clear secondary selection
+      (save-mark-and-excursion (secondary-selection-to-region))
       ;; Echo if echo-message not enabled
       (unless (member "echo-message" (clatter-connection-cap-enabled conn))
         (clatter-insert-privmsg (current-buffer)
@@ -523,22 +527,26 @@ Uses +draft/reply tag to thread the response."
 (clatter-defcommand "reply" #'clatter-cmd-reply "r")
 
 (defun clatter-cmd-react (args)
-  "React to the message at point with an emoji.  Usage: /react EMOJI
+  "React to selected message with an emoji.  Usage: /react EMOJI
 Uses +draft/react tag via TAGMSG."
   (let* ((emoji (string-trim args))
-         (msgid (get-text-property (point) 'clatter-msgid))
+         (msgid (and mouse-secondary-overlay
+                     (eq (current-buffer) (overlay-buffer mouse-secondary-overlay))
+                     (get-text-property (overlay-start mouse-secondary-overlay) 'clatter-msgid)))
          (target clatter--target)
          (conn (clatter--current-conn)))
     (cond
      ((string-empty-p emoji)
       (message "Usage: /react <emoji>"))
      ((null msgid)
-      (message "No message at point to react to (move cursor to a message first)"))
+      (message "No message to react to (select a message using the secondary selection i.e. M-<mouse-1>)"))
      ((null conn)
       (message "Not connected"))
      (t
       (clatter-send conn (format "@+draft/react=%s;+draft/reply=%s TAGMSG %s"
-                                 emoji msgid target))))))
+                                 emoji msgid target))
+      ; Clear secondary selection
+      (save-mark-and-excursion (secondary-selection-to-region))))))
 
 (clatter-defcommand "react" #'clatter-cmd-react)
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -238,12 +238,13 @@ SERVER-TIME overrides the current time for the timestamp."
          (reply-line (when reply-context
                        (let* ((ref-sender (car reply-context))
                               (ref-text (cdr reply-context))
-                              (preview (if (> (length ref-text) 60)
-                                           (concat (substring ref-text 0 57) "...")
-                                         ref-text)))
-                         (concat (propertize (format "↳ %s: %s" ref-sender preview)
-                                             'face 'shadow)
-                                 "\n"))))
+                              (ref-text-formatted (clatter-format-parse ref-text))
+                              (preview (if (> (length ref-text-formatted) 60)
+                                           (concat (substring ref-text-formatted 0 57) "...")
+                                         ref-text-formatted))
+                              (front (propertize (format "↳ %s: " ref-sender) 'face 'shadow)))
+                         (add-face-text-property 0 (length preview) 'shadow nil preview)
+                         (concat front preview "\n"))))
          (formatted (concat (or reply-line "") nick-col " " msg-text))
          (props (list 'clatter-msg-type 'privmsg
                       'clatter-sender sender

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -198,9 +198,8 @@ Removes oldest messages from the appropriate end of the buffer."
             (delete-overlay ov))
           (delete-region (point) (point-max)))))))
 
-(defun clatter--find-message-by-msgid (buffer msgid)
-  "Find message text and sender in BUFFER by MSGID.
-Returns (sender . text) or nil."
+(defun clatter--find-message-position-by-msgid (buffer msgid)
+  "Find position of message in BUFFER identified by MSGID."
   (when (and (buffer-live-p buffer) msgid)
     (with-current-buffer buffer
       (save-excursion
@@ -208,24 +207,23 @@ Returns (sender . text) or nil."
         (let ((found nil))
           (while (and (not found) (not (eobp)))
             (when (string= msgid (get-text-property (point) 'clatter-msgid))
-              (setq found (cons (get-text-property (point) 'clatter-sender)
-                                (get-text-property (point) 'clatter-text))))
+              (setq found (point)))
             (forward-line 1))
           found)))))
 
+(defun clatter--find-message-by-msgid (buffer msgid)
+  "Find message text and sender in BUFFER by MSGID.
+Returns (sender . text) or nil."
+  (let ((found (clatter--find-message-position-by-msgid buffer msgid)))
+    (when found
+      (cons (get-text-property found 'clatter-sender)
+            (get-text-property found 'clatter-text)))))
+
 (defun clatter-jump-to-msgid (buffer msgid)
   "Jump to BUFFER message identified by MSGID."
-  (let (found)
-    (when (and (buffer-live-p buffer) msgid)
-      (with-current-buffer buffer
-        (save-excursion
-          (goto-char (point-min))
-          (while (and (not found) (not (eobp)))
-            (when (string= msgid (get-text-property (point) 'clatter-msgid))
-              (setq found (point)))
-            (forward-line 1))
-          found)))
-    (when found (goto-char found))))
+  (let ((found (clatter--find-message-position-by-msgid buffer msgid)))
+    (when found
+      (goto-char found))))
 
 (defun clatter-insert-privmsg (buffer sender text conn &optional server-time)
   "Insert a PRIVMSG from SENDER with TEXT into BUFFER using CONN context.

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -213,6 +213,20 @@ Returns (sender . text) or nil."
             (forward-line 1))
           found)))))
 
+(defun clatter-jump-to-msgid (buffer msgid)
+  "Jump to BUFFER message identified by MSGID."
+  (let (found)
+    (when (and (buffer-live-p buffer) msgid)
+      (with-current-buffer buffer
+        (save-excursion
+          (goto-char (point-min))
+          (while (and (not found) (not (eobp)))
+            (when (string= msgid (get-text-property (point) 'clatter-msgid))
+              (setq found (point)))
+            (forward-line 1))
+          found)))
+    (when found (goto-char found))))
+
 (defun clatter-insert-privmsg (buffer sender text conn &optional server-time)
   "Insert a PRIVMSG from SENDER with TEXT into BUFFER using CONN context.
 SERVER-TIME overrides the current time for the timestamp."
@@ -244,7 +258,19 @@ SERVER-TIME overrides the current time for the timestamp."
                                          ref-text-formatted))
                               (front (propertize (format "↳ %s: " ref-sender) 'face 'shadow)))
                          (add-face-text-property 0 (length preview) 'shadow nil preview)
-                         (concat front preview "\n"))))
+                         (let ((context (concat front preview "\n"))
+                               (map (make-sparse-keymap))
+                               (action (lambda () (interactive) (clatter-jump-to-msgid buffer reply-to))))
+                           (define-key map [mouse-2] action)
+                           (define-key map (kbd "RET") action)
+                           (add-text-properties 0 (length context)
+                                                (list 'keymap map
+                                                      'follow-link t
+                                                      'reply-to reply-to
+                                                      'mouse-face 'highlight
+                                                      'help-echo "Click or press RET to jump to reply context")
+                                                context)
+                           context))))
          (formatted (concat (or reply-line "") nick-col " " msg-text))
          (props (list 'clatter-msg-type 'privmsg
                       'clatter-sender sender


### PR DESCRIPTION
The `/react` and `/reply` commands are hard to use. They require the point to be placed on the message we're replying to. However - when typing a reply - the point *has to be on the prompt line*.

I might be missing something but I can't have the point be on the prompt line and on the target message at the same time.

This changeset attempts to solve this dilemma by leveraging the [secondary selection](https://www.gnu.org/software/emacs/manual/html_node/emacs/Secondary-Selection.html) (see `(info "(emacs) Secondary Selection")`).

If a secondary selection (accessible via *M-\<mouse-1\>*) is set, the target msgid is extracted from it. The new actions set the secondary selection and populate the input prompt accordingly.

Another small fix is included to ensure IRC formatting is also applied on the reply context, which is now linkified & enriched with a sparse keymap that makes it easy to jump to the reply context.