### PR TITLE
Preserve nick case & enable case-insensitive completion

### DIFF
--- a/clatter-completion.el
+++ b/clatter-completion.el
@@ -31,7 +31,7 @@
   "Return list of nicks from current buffer's nick list."
   (when clatter--nick-list
     (let (nicks)
-      (maphash (lambda (nick _prefix) (push nick nicks))
+      (maphash (lambda (nick prefix-and-nick) (push (cdr prefix-and-nick) nicks))
                clatter--nick-list)
       (sort nicks #'string<))))
 
@@ -54,7 +54,8 @@ Completes nick names from the current channel."
                 :annotation-function
                 (lambda (nick)
                   (when clatter--nick-list
-                    (let ((prefix-char (gethash nick clatter--nick-list)))
+                    (let* ((prefix-and-nick (gethash nick clatter--nick-list))
+                           (prefix-char (car prefix-and-nick)))
                       (when (and prefix-char (not (string= prefix-char "")))
                         (format " [%s]" prefix-char)))))
                 :exit-function
@@ -150,6 +151,7 @@ Dispatches to command, channel, or nick completion as appropriate."
 
 (defun clatter-completion-setup ()
   "Set up completion-at-point in the current clatter buffer."
+  (setq-local completion-ignore-case t)
   (add-hook 'completion-at-point-functions
             #'clatter-completion-at-point nil t))
 

--- a/clatter-model.el
+++ b/clatter-model.el
@@ -149,7 +149,7 @@ Return nil when the ring is empty or N is out of range."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (when clatter--nick-list
-        (puthash (downcase nick) (or prefix "") clatter--nick-list)))))
+        (puthash (downcase nick) (cons (or prefix "") nick) clatter--nick-list)))))
 
 (defun clatter-nick-remove (buffer nick)
   "Remove NICK from BUFFER's nick list."
@@ -163,9 +163,10 @@ Return nil when the ring is empty or N is out of range."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (when clatter--nick-list
-        (let ((prefix (gethash (downcase old-nick) clatter--nick-list)))
+        (let* ((prefix-and-nick (gethash (downcase old-nick) clatter--nick-list))
+               (prefix (car prefix-and-nick)))
           (remhash (downcase old-nick) clatter--nick-list)
-          (puthash (downcase new-nick) (or prefix "") clatter--nick-list))))))
+          (puthash (downcase new-nick) (cons (or prefix "") new-nick) clatter--nick-list))))))
 
 (defun clatter-nick-list (buffer)
   "Return sorted list of (nick . prefix) pairs for BUFFER."
@@ -173,7 +174,7 @@ Return nil when the ring is empty or N is out of range."
     (with-current-buffer buffer
       (when clatter--nick-list
         (let ((nicks nil))
-          (maphash (lambda (k v) (push (cons k v) nicks)) clatter--nick-list)
+          (maphash (lambda (_k v) (push (cons (cdr v) (car v)) nicks)) clatter--nick-list)
           (sort nicks (lambda (a b) (string< (car a) (car b)))))))))
 
 (defun clatter-nick-count (buffer)

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -488,7 +488,7 @@ Emacs requires `set-window-margins' on the window, not just
            (prefix (buffer-substring-no-properties start end))
            (nicks (cl-loop for k being the hash-keys of clatter--nick-list
                            when (string-prefix-p (downcase prefix) k)
-                           collect k)))
+                           collect (cdr (gethash k clatter--nick-list)))))
       (cond
        ((null nicks)
         (message "No matching nicks"))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -487,8 +487,9 @@ Emacs requires `set-window-margins' on the window, not just
                     (point)))
            (prefix (buffer-substring-no-properties start end))
            (nicks (cl-loop for k being the hash-keys of clatter--nick-list
+                           using (hash-values prefix-and-nick)
                            when (string-prefix-p (downcase prefix) k)
-                           collect (cdr (gethash k clatter--nick-list)))))
+                           collect (cdr prefix-and-nick))))
       (cond
        ((null nicks)
         (message "No matching nicks"))


### PR DESCRIPTION
This changeset ensures that nicks in the nicklist are displayed with their case preserved.

Completion remains case-insensitive via a buffer-local `(setq-local completion-ignore-case t)` setting.