### PR TITLE
Display realname in join messages

### DIFF
--- a/clatter-log.el
+++ b/clatter-log.el
@@ -200,11 +200,13 @@ FILE is stored for flushing."
       (clatter-log--write network log-target
                            (format "-%s- %s" sender text)))))
 
-(defun clatter-log--on-join (conn nick channel _account _realname)
+(defun clatter-log--on-join (conn nick channel _account realname)
   "Log JOIN of NICK to CHANNEL on CONN."
   (when clatter-log-system-messages
     (clatter-log--write (clatter-connection-network-id conn) channel
-                         (format "*** %s has joined %s" nick channel))))
+                        (if (and realname (not (string= nick realname)))
+                            (format "%s (%s) has joined %s" nick realname channel)
+                          (format "%s has joined %s" nick channel)))))
 
 (defun clatter-log--on-part (conn nick channel message)
   "Log PART of NICK from CHANNEL on CONN."

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -539,7 +539,7 @@ Emacs requires `set-window-margins' on the window, not just
     (clatter-ui-setup-buffer-if-needed buf)
     (clatter-insert-notice buf sender text)))
 
-(defun clatter-ui--on-join (conn nick channel _account _realname)
+(defun clatter-ui--on-join (conn nick channel _account realname)
   "Handle JOIN event for UI."
   (let* ((network (clatter-connection-network-id conn))
          (my-nick (clatter-connection-nick conn))
@@ -549,7 +549,11 @@ Emacs requires `set-window-margins' on the window, not just
     (when (string-equal nick my-nick)
       (clatter-send conn (clatter-irc-names channel))
       (display-buffer buf))
-    (clatter-insert-system buf (format "%s has joined %s" nick channel) 'join)))
+    (clatter-insert-system buf
+                           (if (and realname (not (string= nick realname)))
+                               (format "%s (%s) has joined %s" nick realname channel)
+                             (format "%s has joined %s" nick channel))
+                           'join)))
 
 (defun clatter-ui--on-part (conn nick channel message)
   "Handle PART event for UI."


### PR DESCRIPTION
The realname (i.e. GECOS field) might include useful information e.g. name, e-mail, pronouns, other contact info, pronouns, etc.

Display it in the UI and logs to make it more useful. This also makes us https://ircv3.net/specs/extensions/extended-join compliant.

The bracketed display (when nick != realname) is borrowed from https://codeberg.org/alcor/catgirl/src/commit/cd10fc083daba47fb0c559f43579f8f838aed37f/handle.c#L380-L388 