### PR TITLE
Implement more informational and MODE-related numerics required to display user/channel modes

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -820,6 +820,32 @@ COMMAND is the CTCP type (VERSION, PING, etc.), REPLY-TEXT is the response."
       (clatter-insert-system
        buf (format "CTCP %s reply from %s: %s" command sender reply-text)))))
 
+;; --- Handlers for other numerics ---
+
+(defun clatter-ui--on-numeric (conn command params)
+  (pcase command
+    ;; -- MODE numerics ---
+    ("221"   ; RPL_UMODEIS
+     (let* ((network (clatter-connection-network-id conn))
+            (buf (clatter-get-server-buffer network))
+            (nick (nth 0 params))
+            (modes (nth 1 params)))
+       (clatter-insert-system "%s is %s" nick modes)))
+    ("324"   ; RPL_CHANNELMODEIS
+     (let* ((network (clatter-connection-network-id conn))
+            (channel (nth 1 params))
+            (buf (clatter-get-buffer network channel))
+            (modes (nth 2 params)))
+       (clatter-insert-system buf (format "%s is %s" channel modes))))
+    ("329"   ; RPL_CREATIONTIME
+     (let* ((network (clatter-connection-network-id conn))
+            (channel (nth 1 params))
+            (buf (clatter-get-buffer network channel))
+            (ctime (string-to-number (nth 2 params))))
+       (clatter-insert-system
+        buf (format "%s was created at %s"
+                    channel (format-time-string "%F %T" ctime)))))))
+
 ;; --- Channel preview on hover (eldoc) ---
 
 (defun clatter-ui--eldoc-function (callback &rest _)
@@ -1021,6 +1047,7 @@ Requires the server to support the message-tags capability."
   (add-hook 'clatter-react-hook #'clatter-ui--on-react)
   (add-hook 'clatter-batch-complete-hook #'clatter-ui--on-batch-complete)
   (add-hook 'clatter-ctcp-reply-hook #'clatter-ui--on-ctcp-reply)
+  (add-hook 'clatter-numeric-hook #'clatter-ui--on-numeric)
   (add-hook 'clatter-typing-hook #'clatter-ui--on-typing)
   (add-hook 'clatter-mode-hook #'clatter-ui--setup-eldoc))
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -824,6 +824,12 @@ COMMAND is the CTCP type (VERSION, PING, etc.), REPLY-TEXT is the response."
 
 (defun clatter-ui--on-numeric (conn command params)
   (pcase command
+    ;; -- Informational numerics ---
+    ((or "001" "002" "003" "004" "242" "251" "252" "253" "254" "255"
+         "265" "266" "305" "306")
+     (let* ((network (clatter-connection-network-id conn))
+            (buf (clatter-get-server-buffer network)))
+       (clatter-insert-system buf (string-join (cdr params) " "))))
     ;; -- MODE numerics ---
     ("221"   ; RPL_UMODEIS
      (let* ((network (clatter-connection-network-id conn))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -654,7 +654,8 @@ Emacs requires `set-window-margins' on the window, not just
 (defun clatter-ui--on-mode (conn target setter modes)
   "Handle MODE event for UI."
   (let* ((network (clatter-connection-network-id conn))
-         (buf (clatter-get-buffer network target)))
+         (buf (or (clatter-get-buffer network target)
+                  (clatter-get-server-buffer network))))
     (when buf
       (clatter-insert-system buf
                              (format "%s sets mode %s"


### PR DESCRIPTION
The server may send `MODE nick …` to indicate user modes being set on our nick -- these can be displayed in the server buffer.

Additionally, a number of trivial numerics have to be handled for `/MODE` (i.e. zero-argument `MODE`) to show us the channel modes. These don't seem to be worth their own specialized hooks to me. I'm not entirely sure if protocol-level details are supposed to be in -ui but perhaps this can be moved somewhere else later if `clatter-ui--on-numeric` becomes too large.

Finally, the informational numerics 001, 002, 003, 004, 242, 251, 252, 253, 254, 255, 265, 266, 305, 306 are handled. These just contain server-related information and statistics, and can be output as-is. See https://modern.ircdocs.horse/#numerics for reference.