### PR TITLE
Highlight replies to us as mentions + notify when somebody replies to us

### DIFF
--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -13,6 +13,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'ring)
 (require 'clatter-config)
 (require 'clatter-protocol)
 (require 'clatter-connection)
@@ -114,6 +115,31 @@ Called with (CONN BATCH-TYPE TARGET MESSAGES).")
 (defvar clatter-invite-hook nil
   "Hook for INVITE events.
 Called with (CONN SENDER NICK CHANNEL).")
+
+;; --- Sent message tracking ---
+
+(defvar clatter-sent (make-hash-table :test #'equal)
+  "Sent messages, keyed by network ID.")
+
+(defun clatter-sent-add (network msgid)
+  "Record MSGID as a sent message within NETWORK."
+  (let* ((messages-and-ring (or (gethash network clatter-sent)
+                                (puthash network (cons (make-hash-table :test #'equal)
+                                                       (make-ring clatter-buffer-max-lines))
+                                         clatter-sent)))
+         (messages (car messages-and-ring))
+         (inserted (cdr messages-and-ring)))
+    ;; Evict older entries
+    (unless (gethash msgid messages)
+      (when (= (ring-length inserted) (ring-size inserted))
+        (remhash (ring-ref inserted 0) messages))
+      (ring-insert-at-beginning inserted msgid)
+      (puthash msgid t messages))))
+
+(defun clatter-sent-p (network msgid)
+  "Returns whether we sent MSGID to NETWORK."
+  (let ((messages-and-ring (gethash network clatter-sent)))
+    (and messages-and-ring (gethash msgid (car messages-and-ring)))))
 
 ;; --- Main Dispatch ---
 
@@ -308,7 +334,9 @@ Return the trimmed character."
 
       ;; --- PRIVMSG ---
       ("PRIVMSG"
-       (let* ((target (nth 0 params))
+       (let* ((parsed-tags (clatter-parse-tags tags))
+              (msgid (cdr (assoc "msgid" parsed-tags)))
+              (target (nth 0 params))
               (raw-text (nth 1 params))
               (parsed-prefix (clatter-parse-prefix prefix))
               (sender-nick (clatter-prefix-nick parsed-prefix))
@@ -317,6 +345,10 @@ Return the trimmed character."
               (statusmsg-chars (let ((isup (clatter-connection-isupport conn)))
                                  (when isup (gethash "STATUSMSG" isup))))
               (status-prefix (clatter--set-unprefixed target statusmsg-chars)))
+         ;; Record sent message
+         (when (and msgid
+                    (string-equal-ignore-case (clatter-connection-nick conn) sender-nick))
+           (clatter-sent-add (clatter-connection-network-id conn) msgid))
          ;; CTCP
          (if (and (> (length raw-text) 1)
                   (= (aref raw-text 0) 1)
@@ -324,13 +356,14 @@ Return the trimmed character."
              (clatter--handle-ctcp conn sender-nick target raw-text)
            (let* ((text (clatter--prepend-status-prefix status-prefix raw-text))
                   (server-time (clatter-get-server-time tags))
-                  (parsed-tags (clatter-parse-tags tags))
                   (batch-id (cdr (assoc "batch" parsed-tags)))
                   (is-bot (assoc "bot" parsed-tags))
-                  (msgid (cdr (assoc "msgid" parsed-tags)))
                   (reply-to (or (cdr (assoc "+draft/reply" parsed-tags))
                                 (cdr (assoc "+reply" parsed-tags))
-                                (cdr (assoc "draft/reply" parsed-tags)))))
+                                (cdr (assoc "draft/reply" parsed-tags))))
+                  (is-reply-to-me (and reply-to
+                                       (clatter-sent-p
+                                        (clatter-connection-network-id conn) reply-to))))
              ;; Mark sender as bot if draft/bot tag present
              (when is-bot
                (setq sender-nick (propertize sender-nick 'clatter-bot t)))
@@ -339,6 +372,8 @@ Return the trimmed character."
                (setq text (propertize text 'clatter-msgid msgid)))
              (when reply-to
                (setq text (propertize text 'clatter-reply-to reply-to)))
+             (when is-reply-to-me
+               (setq text (propertize text 'clatter-reply-to-me t)))
              (cond
               ;; Batched message
               (batch-id

--- a/clatter-notify.el
+++ b/clatter-notify.el
@@ -250,6 +250,7 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
            (is-muted-channel (and is-channel
                                   (member target clatter-notify-muted-channels)))
            (is-muted-nick (member sender clatter-notify-muted-nicks))
+           (is-reply-to-me (get-text-property 0 'clatter-reply-to-me text))
            (text-lower (downcase (or text ""))))
       (let ((reason
              (cond
@@ -264,8 +265,10 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
               ((and is-dm clatter-notify-on-dm) 'dm)
               ;; Mention
               ((and clatter-notify-on-mention
-                    my-nick
-                    (string-match-p (regexp-quote (downcase my-nick)) text-lower))
+                    (or is-reply-to-me
+                        (and my-nick
+                             (string-match-p (regexp-quote (downcase my-nick))
+                                             text-lower))))
                'mention)
               ;; Keyword
               ((and clatter-notify-on-keyword

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -231,10 +231,12 @@ Returns (sender . text) or nil."
 SERVER-TIME overrides the current time for the timestamp."
   (let* ((nick-face (clatter-hl-nick-face sender conn))
          (my-nick (clatter-connection-nick conn))
+         (is-reply-to-me (get-text-property 0 'clatter-reply-to-me text))
          (is-mention (and my-nick
-                          (string-match-p
-                           (regexp-quote (downcase my-nick))
-                           (downcase text))))
+                          (or is-reply-to-me
+                              (string-match-p
+                               (regexp-quote (downcase my-nick))
+                               (downcase text)))))
          (reply-to (get-text-property 0 'clatter-reply-to text))
          (msgid (get-text-property 0 'clatter-msgid text))
          (reply-context (when reply-to


### PR DESCRIPTION
It would be nice if replies to our own messages via IRCv3 the `+reply` tag were also highlighted and notified.

This changeset implements this, formatting/notifying replies to us as mentions.

Since this information is used by multiple modules (ui, notify), we implement this in -handlers. We use a two-level *NETWORK → {MSGID0, MSGID1, … MSGIDn}* tree where *n* is bounded¹ for the implementation.

If we receive a message where the `+reply` tag references a known message ID we sent, we mark the message accordingly as a reply to us.

Note that tracking IDs per network (as opposed to (network, channel) pairs) is fine and collision-free, as the spec guarantees that msgids are unique per-network:

https://ircv3.net/specs/extensions/message-ids

>The tag value MUST be a unique ID chosen by the originating server. Uniqueness in this context means that any other message transmitted on the entire network at any time MUST NOT share the same value.

¹) I chose `clatter-buffer-max-lines` but this might be a bit too defensive. The chosen bound could be significantly smaller.