### PR TITLE
Set up some cleanup hooks to allow clean teardown of channel/server buffers when killed

### DIFF
--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -114,14 +114,18 @@
   (interactive)
   (let ((source (or clatter-nicklist--source-buffer (current-buffer))))
     (when source
-      (with-current-buffer source
-        (when (and clatter--target clatter--nick-list)
-          (let* ((target clatter--target)
-                 (nl-name (clatter-nicklist--buffer-name target))
-                 (existing (get-buffer nl-name)))
-            (when (and existing (get-buffer-window existing))
-              (delete-window (get-buffer-window existing))
-              (kill-buffer existing))))))))
+      (cond
+       ((buffer-live-p source)
+        (with-current-buffer source
+          (when (and clatter--target clatter--nick-list)
+            (let* ((target clatter--target)
+                   (nl-name (clatter-nicklist--buffer-name target))
+                   (existing (get-buffer nl-name)))
+              (when (and existing (get-buffer-window existing))
+                (delete-window (get-buffer-window existing))
+                (kill-buffer existing))))))
+       ((eq source clatter-nicklist--source-buffer)
+        (delete-window (get-buffer-window (current-buffer))))))))
 
 (defun clatter-nicklist-query ()
   "Open a query (DM) with the nick at point."

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -709,8 +709,9 @@ Emacs requires `set-window-margins' on the window, not just
   (let* ((network (clatter-connection-network-id conn))
          (buf (or (clatter-get-server-buffer network)
                   (clatter-get-or-create-buffer network "*server*" 'server))))
-    (clatter-ui-setup-buffer-if-needed buf)
-    (clatter-insert-system buf text)))
+    (when (buffer-live-p buf)
+      (clatter-ui-setup-buffer-if-needed buf)
+      (clatter-insert-system buf text))))
 
 (defun clatter-ui--on-welcome (conn _nick)
   "Handle 001 welcome for UI on CONN."

--- a/clatter.el
+++ b/clatter.el
@@ -112,6 +112,32 @@ Creates a transient network entry."
         (message "clatter connections:\n%s" (string-join (nreverse lines) "\n"))
       (message "No clatter connections"))))
 
+(defun clatter--on-kill-buffer ()
+  "Close this clatter buffer."
+  ;; Avoid infinite recursion
+  (remove-hook 'kill-buffer-hook #'clatter--on-kill-buffer t)
+  (cond
+   ((not (boundp 'clatter--buffer-type)) nil)
+   ((eq 'channel clatter--buffer-type)
+    (clatter-cmd-close nil))
+   ((and (eq 'server clatter--buffer-type)
+         (boundp 'clatter--network)
+         clatter--network)
+    (clatter-disconnect clatter--network))))
+
+(defun clatter--setup-kill-buffer-hook ()
+  "Install hooks that clean-up killed clatter buffers."
+  (add-hook 'kill-buffer-hook #'clatter--on-kill-buffer nil t))
+
+(defun clatter--on-disconnect (network _event)
+  "Remove dead network buffers from the buffer list."
+  (let ((buf (clatter-get-server-buffer network)))
+    (when (and buf (not (buffer-live-p buf)))
+      (clatter-remove-buffer network "*server*"))))
+
+(add-hook 'clatter-mode-hook #'clatter--setup-kill-buffer-hook)
+(add-hook 'clatter-disconnect-hook #'clatter--on-disconnect)
+
 (provide 'clatter)
 
 ;;; clatter.el ends here


### PR DESCRIPTION
Adapted from https://gist.github.com/fmqa/6a3aae0a1d2d618d5bc68b71a6e65fbd#file-clatter-use-package-el

Clatter provides `/close` (for channels) and `/quit` (for server buffers), which can be used for clean & controlled exit of server and channel buffers.

Things get a bit hairy if the user uses the usual *C-x k* or some other mechanism (e.g. *M-x ibuffer*) to kill clatter buffers, however.

In this changeset, we register some cleanup functions:

- Clatter buffers get a (local) `kill-buffer-hook` which ensures they're closed (for channels) or disconnected (for network/server buffers).
- We add a disconnection hook to clean up any dead server buffers after kill+disconnects.

A `(buffer-live-p buf)` guard is added to `(clatter-ui--on-system)` to prevent the echoed ERROR message (which the server sends us after we send the QUIT) from raising an error or reviving the buffer we just killed. 