### PR TITLE
Fix misplaced overlay position when reacting to a reply

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -827,45 +827,42 @@ Emacs requires `set-window-margins' on the window, not just
       (with-current-buffer buf
         (save-excursion
           (goto-char (point-min))
-          (let ((found nil))
-            (while (and (not found) (not (eobp)))
-              (when (equal msgid (get-text-property (point) 'clatter-msgid))
-                (setq found (point)))
-              (forward-line 1))
-            (when found
-              (goto-char found)
-              (end-of-line)
-              (let ((inhibit-read-only t)
-                    (existing (get-text-property found 'clatter-reactions)))
-                (unless existing (setq existing nil))
-                ;; Add this reaction
-                (let* ((key emoji)
-                       (entry (assoc key existing))
-                       (new-reactions
-                        (if entry
-                            (progn (setcdr entry (cons nick (cdr entry)))
-                                   existing)
-                          (append existing (list (list key nick)))))
-                       (display (mapconcat
-                                 (lambda (r)
-                                   (format "%s %d" (car r) (length (cdr r))))
-                                 new-reactions " ")))
-                  ;; Remove old reaction overlay if any
-                  (dolist (ov (overlays-at found))
-                    (when (overlay-get ov 'clatter-reaction)
-                      (delete-overlay ov)))
-                  ;; Add new overlay showing reactions
-                  (let ((ov (make-overlay (line-beginning-position)
-                                          (line-end-position))))
-                    (overlay-put ov 'clatter-reaction t)
-                    (overlay-put ov 'after-string
-                                 (concat "\n"
-                                         (make-string clatter-nick-column-width ?\s)
-                                         " "
-                                         (propertize display 'face 'clatter-notice))))
-                  ;; Store reactions as property
-                  (add-text-properties found (1+ found)
-                                       (list 'clatter-reactions new-reactions)))))))))))
+          (when-let* ((found (clatter--find-message-position-by-msgid buf msgid))
+                      (change (or (next-single-property-change found 'clatter-msgid)
+                                  (point-max))))
+            (setq found (- change 2))
+            (goto-char found)
+            (let ((inhibit-read-only t)
+                  (existing (get-text-property found 'clatter-reactions)))
+              (unless existing (setq existing nil))
+              ;; Add this reaction
+              (let* ((key emoji)
+                     (entry (assoc key existing))
+                     (new-reactions
+                      (if entry
+                          (progn (setcdr entry (cons nick (cdr entry)))
+                                 existing)
+                        (append existing (list (list key nick)))))
+                     (display (mapconcat
+                               (lambda (r)
+                                 (format "%s %d" (car r) (length (cdr r))))
+                               new-reactions " ")))
+                ;; Remove old reaction overlay if any
+                (dolist (ov (overlays-at found))
+                  (when (overlay-get ov 'clatter-reaction)
+                    (delete-overlay ov)))
+                ;; Add new overlay showing reactions
+                (let ((ov (make-overlay (line-beginning-position)
+                                        (line-end-position))))
+                  (overlay-put ov 'clatter-reaction t)
+                  (overlay-put ov 'after-string
+                               (concat "\n"
+                                       (make-string clatter-nick-column-width ?\s)
+                                       " "
+                                       (propertize display 'face 'clatter-notice))))
+                ;; Store reactions as property
+                (add-text-properties found (1+ found)
+                                     (list 'clatter-reactions new-reactions))))))))))
 
 (defun clatter-ui--on-batch-complete (conn _batch-type target messages)
   "Handle completed batch: render MESSAGES for TARGET on CONN.


### PR DESCRIPTION
Broken (💀 emoji above instead of below):
<img width="2710" height="1800" alt="Broken" src="https://github.com/user-attachments/assets/5691510e-4c60-4dfd-8091-ee5e1acb090b" />

Fixed (Entire reaction overlay is below the message)
<img width="2710" height="1800" alt="Fixed" src="https://github.com/user-attachments/assets/fe3e39c7-8af7-4b25-a9d3-7e7ad98a707b" />
