### PR TITLE
Add SOCKS5 / Tor proxy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BATCH = $(EMACS) --batch -L . -L tests
 
 TEST_FILES = $(wildcard tests/test-*.el)
 
-.PHONY: test test-protocol test-handlers test-scram test-sts test-dcc clean
+.PHONY: test test-protocol test-handlers test-scram test-sts test-dcc test-socks clean
 
 test: ## Run all tests
 	$(BATCH) -l test-helper $(foreach f,$(TEST_FILES),-l $(f)) -f ert-run-tests-batch-and-exit
@@ -22,6 +22,9 @@ test-sts: ## Run STS tests
 
 test-dcc: ## Run DCC tests
 	$(BATCH) -l test-helper -l tests/test-dcc.el -f ert-run-tests-batch-and-exit
+
+test-socks: ## Run SOCKS5 proxy tests
+	$(BATCH) -l test-helper -l tests/test-socks.el -f ert-run-tests-batch-and-exit
 
 lint: ## Byte-compile all files (warnings as errors)
 	$(BATCH) --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile *.el

--- a/README.org
+++ b/README.org
@@ -47,6 +47,25 @@ Spiritual successor to [[https://github.com/glenneth1/CLatter][CLatter]] (the Co
 - =/close= command to kill current buffer (PARTs from channels first)
 - Reconnect/disconnect status shown inline in channel buffers
 
+*** SOCKS5 / Tor Proxy (clatter-socks)
+- Route connections through any SOCKS5 proxy (RFC 1928), including Tor
+- =:tor t= shorthand for Tor's local proxy (127.0.0.1:9050); .onion supported
+- Username/password auth (RFC 1929); password via plist or auth-source
+- Per-network =:proxy= plist, or a global =clatter-proxy= default
+- Fail-closed: never falls back to a direct connection if the proxy fails
+- Remote DNS (SOCKS5h): the proxy resolves the target, so DNS is not leaked
+- Requires builtin TLS (=clatter-tls-method 'builtin=); external-TLS users can
+  wrap the client with =torsocks= at the OS level instead
+
+Example:
+
+#+BEGIN_SRC emacs-lisp
+(setopt clatter-networks
+  '(("libera-tor"
+     :server "irc.libera.chat" :port 6697 :tls t :nick "yournick"
+     :tor t)))               ;; or :proxy (:type socks5 :host "..." :port 1080)
+#+END_SRC
+
 *** Nick Highlighting (clatter-hl-nicks)
 - 40-color palette optimized for dark themes
 - Hash-based stable colors (same nick = same color across sessions)
@@ -408,6 +427,7 @@ With Evil, =SPC= only triggers the leader in *normal state*. When you press =i= 
 | =clatter-search.el=     | Full-text search across IRC log history        |
 | =clatter-org.el=        | Org-mode integration (links, capture, export)  |
 | =clatter-dcc.el=        | DCC file transfer (XDCC receive, resume)       |
+| =clatter-socks.el=      | SOCKS5 / Tor proxy support                     |
 
 ** Companion Packages
 

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -31,6 +31,10 @@ Each entry is a list of (NAME . PLIST) where PLIST contains:
   :client-cert - Path to client certificate for SASL EXTERNAL
   :autojoin  - List of channels to join on connect
   :password  - Server password (or use auth-source)
+  :proxy     - SOCKS5 proxy plist (:type socks5 :host H :port P
+               [:user U] [:pass P]); see `clatter-proxy'
+  :tor       - When non-nil, shorthand for Tor's local SOCKS5
+               proxy (127.0.0.1:9050)
 
 Example:
   \\='((\"libera\"
@@ -61,6 +65,16 @@ Example:
 (defcustom clatter-default-tls t
   "Use TLS by default."
   :type 'boolean
+  :group 'clatter)
+
+(defcustom clatter-proxy nil
+  "Default SOCKS5 proxy for networks without a per-network `:proxy'.
+A plist of the form (:type socks5 :host HOST :port PORT [:user U] [:pass P]),
+or nil to connect directly.  A network's own `:proxy' (or `:tor t') takes
+precedence.  When a proxy is configured the connection is fail-closed: if the
+handshake fails clatter will not fall back to a direct connection.  The target
+hostname is always resolved by the proxy (remote DNS), so .onion works."
+  :type '(choice (const :tag "No proxy" nil) (plist :tag "Proxy plist"))
   :group 'clatter)
 
 (defcustom clatter-tls-method 'builtin
@@ -356,6 +370,14 @@ Checks the network config first, then auth-source."
           (let ((secret (plist-get found :secret)))
             (if (functionp secret) (funcall secret) secret)))))
      (t nil))))
+
+(defun clatter-proxy-config (config)
+  "Return the resolved SOCKS5 proxy plist for network CONFIG, or nil for direct.
+Precedence: per-network `:proxy', then `:tor' shorthand, then `clatter-proxy'."
+  (or (plist-get config :proxy)
+      (and (plist-get config :tor)
+           '(:type socks5 :host "127.0.0.1" :port 9050))
+      clatter-proxy))
 
 (provide 'clatter-config)
 

--- a/clatter-connection.el
+++ b/clatter-connection.el
@@ -346,6 +346,9 @@ ARGS are keyword arguments that override `clatter-networks' config:
           (setq port (plist-get sts-policy :port))
           (clatter--debug "STS: enforcing TLS on port %d for %s" port server))))
 
+    (when (and proxy (not (and (plist-get proxy :host) (plist-get proxy :port))))
+      (error "Invalid SOCKS proxy: both :host and :port are required"))
+
     (when (and proxy use-tls (eq clatter-tls-method 'external))
       (error "SOCKS proxy requires builtin TLS (set `clatter-tls-method' to \\='builtin)"))
 

--- a/clatter-connection.el
+++ b/clatter-connection.el
@@ -15,6 +15,7 @@
 (require 'cl-lib)
 (require 'clatter-config)
 (require 'clatter-protocol)
+(require 'clatter-socks)
 
 (declare-function gnutls-negotiate "gnutls")
 
@@ -274,6 +275,43 @@ Begins IRC registration once the subprocess is spawned."
                        (delete-process wp)))))
     conn))
 
+(defun clatter--connect-abort (proc reason)
+  "Report REASON and delete in-progress PROC.
+Deleting PROC triggers its sentinel, which sets the disconnected state and
+schedules any reconnect, so callers must not duplicate that work here."
+  (message "[clatter] %s" reason)
+  (when (process-live-p proc)
+    (delete-process proc)))
+
+(defun clatter--after-tcp-open (conn proc config server use-tls)
+  "Continue connecting CONN once the TCP/tunnel to SERVER is open on PROC.
+Negotiate TLS when USE-TLS, then begin IRC registration.  CONFIG is the merged
+network configuration."
+  (let ((network-id (clatter-connection-network-id conn))
+        (ok t))
+    (when use-tls
+      (clatter--watchdog "TLS-START %s" network-id)
+      (condition-case tls-err
+          (with-timeout (10
+                         (clatter--watchdog "TLS-TIMEOUT %s" network-id)
+                         (error "TLS handshake timed out (10s)"))
+            (gnutls-negotiate
+             :process proc
+             :hostname server
+             :keylist (let ((client-cert (plist-get config :client-cert)))
+                        (when (and client-cert (file-exists-p client-cert))
+                          (list (list client-cert client-cert))))))
+        (error
+         (setq ok nil)
+         (clatter--watchdog "TLS-FAIL %s %s" network-id
+                            (error-message-string tls-err))
+         (clatter--connect-abort
+          proc (format "TLS failed: %s" (error-message-string tls-err))))))
+    (when (and ok (process-live-p proc))
+      (clatter--watchdog "TLS-OK %s" network-id)
+      (set-process-sentinel proc #'clatter--process-sentinel)
+      (clatter--begin-registration conn config))))
+
 ;; --- Connect ---
 
 (defun clatter-connect (network-id &rest args)
@@ -292,7 +330,8 @@ ARGS are keyword arguments that override `clatter-networks' config:
          (use-tls (if (plist-member config :tls)
                       (plist-get config :tls)
                     clatter-default-tls))
-         (nick (or (plist-get config :nick) clatter-default-nick)))
+         (nick (or (plist-get config :nick) clatter-default-nick))
+         (proxy (clatter-proxy-config config)))
     (unless server
       (error "No server specified for network %s" network-id))
     (unless nick
@@ -306,6 +345,9 @@ ARGS are keyword arguments that override `clatter-networks' config:
           (setq use-tls t)
           (setq port (plist-get sts-policy :port))
           (clatter--debug "STS: enforcing TLS on port %d for %s" port server))))
+
+    (when (and proxy use-tls (eq clatter-tls-method 'external))
+      (error "SOCKS proxy requires builtin TLS (set `clatter-tls-method' to \\='builtin)"))
 
     ;; Create or reuse connection struct
     (let ((conn (or (clatter-get-connection network-id)
@@ -349,15 +391,14 @@ ARGS are keyword arguments that override `clatter-networks' config:
               ;; External TLS subprocess path: TLS runs in a separate OS
               ;; process so a dead socket cannot block Emacs's event loop.
               (clatter--connect-external conn config network-id server port)
-          (let* ((client-cert (plist-get config :client-cert))
-                 ;; Always connect plain+nowait first - TLS handshake
+          (let* (;; Always connect plain+nowait first - TLS handshake
                  ;; happens async in the sentinel to avoid blocking Emacs
                  (proc (make-network-process
                         :name (format "clatter-%s" network-id)
-                        :host server
-                        :service port
+                        :host (if proxy (plist-get proxy :host) server)
+                        :service (if proxy (plist-get proxy :port) port)
                         :nowait t
-                        :coding '(utf-8 . utf-8)
+                        :coding (if proxy '(binary . binary) '(utf-8 . utf-8))
                         :filter #'clatter--process-filter
                         :sentinel
                         (lambda (p e)
@@ -365,35 +406,21 @@ ARGS are keyword arguments that override `clatter-networks' config:
                                              network-id (string-trim e)
                                              (process-status p))
                           (cond
-                           ;; TCP connected - upgrade to TLS if needed
+                           ;; TCP connected - run SOCKS handshake or go direct
                            ((string-match-p "open" e)
-                            (when use-tls
-                              (clatter--watchdog "TLS-START %s" network-id)
-                              (condition-case tls-err
-                                  (with-timeout
-                                      (10
-                                       (clatter--watchdog "TLS-TIMEOUT %s" network-id)
-                                       (error "TLS handshake timed out (10s)"))
-                                    (gnutls-negotiate
-                                     :process p
-                                     :hostname server
-                                     :keylist (when (and client-cert
-                                                        (file-exists-p client-cert))
-                                                (list (list client-cert client-cert)))))
-                                (error
-                                 (clatter--watchdog "TLS-FAIL %s %s"
-                                                     network-id
-                                                     (error-message-string tls-err))
-                                 (delete-process p)
-                                 (setf (clatter-connection-state conn) :disconnected)
-                                 (message "[clatter] TLS failed: %s"
-                                          (error-message-string tls-err))
-                                 (when (clatter-connection-reconnect-enabled conn)
-                                   (clatter--schedule-reconnect conn)))))
-                            (when (process-live-p p)
-                              (clatter--watchdog "TLS-OK %s" network-id)
-                              (set-process-sentinel p #'clatter--process-sentinel)
-                              (clatter--begin-registration conn config)))
+                            (if proxy
+                                (clatter-socks-begin
+                                 p server port proxy
+                                 (lambda ()
+                                   (set-process-coding-system p 'utf-8 'utf-8)
+                                   (set-process-filter p #'clatter--process-filter)
+                                   (clatter--watchdog "SOCKS-OK %s" network-id)
+                                   (clatter--after-tcp-open conn p config server use-tls))
+                                 (lambda (reason)
+                                   (clatter--watchdog "SOCKS-FAIL %s %s" network-id reason)
+                                   (clatter--connect-abort
+                                    p (format "SOCKS5: %s" reason))))
+                              (clatter--after-tcp-open conn p config server use-tls)))
                            ;; Connection failed or closed
                            (t
                             (clatter--process-sentinel p e)))))))

--- a/clatter-socks.el
+++ b/clatter-socks.el
@@ -160,6 +160,48 @@ input from the proxy.  SEND-FN is called with a unibyte string to transmit."
                      (clatter-socks--succeed session)
                    (clatter-socks--fail session (clatter-socks--rep-message rep))))))))))))
 
+;; --- Proxy password ---
+
+(defun clatter-socks--password (proxy)
+  "Return the password for PROXY plist, from :pass or auth-source."
+  (or (plist-get proxy :pass)
+      (when (and clatter-use-auth-source (plist-get proxy :host))
+        (let ((found (car (auth-source-search
+                           :host (plist-get proxy :host)
+                           :user (plist-get proxy :user)
+                           :port (plist-get proxy :port)
+                           :max 1))))
+          (when found
+            (let ((secret (plist-get found :secret)))
+              (if (functionp secret) (funcall secret) secret)))))))
+
+;; --- Process glue ---
+
+(defun clatter-socks--filter (proc data)
+  "Process filter driving the SOCKS5 handshake on PROC with incoming DATA."
+  (when-let* ((session (process-get proc :socks-session)))
+    (setf (clatter-socks--session-buffer session)
+          (concat (clatter-socks--session-buffer session) data))
+    (clatter-socks--advance session)))
+
+(defun clatter-socks-begin (proc host port proxy on-success on-failure)
+  "Begin a SOCKS5 handshake on open PROC to reach HOST:PORT through PROXY.
+PROXY is a plist (:host :port [:user] [:pass]).  Call ON-SUCCESS (no args) once
+the tunnel is established, or ON-FAILURE with a reason string on any error.
+PROC must use binary coding for the duration of the handshake."
+  (let* ((user (plist-get proxy :user))
+         (auth (and user (> (length user) 0)))
+         (pass (and auth (clatter-socks--password proxy)))
+         (methods (if auth '(0 2) '(0)))
+         (session (clatter-socks--session-create
+                   :state :method :buffer (unibyte-string)
+                   :host host :port port :user user :pass pass
+                   :send-fn (lambda (s) (process-send-string proc s))
+                   :on-success on-success :on-failure on-failure)))
+    (process-put proc :socks-session session)
+    (set-process-filter proc #'clatter-socks--filter)
+    (clatter-socks--send session (clatter-socks--encode-greeting methods))))
+
 (provide 'clatter-socks)
 
 ;;; clatter-socks.el ends here

--- a/clatter-socks.el
+++ b/clatter-socks.el
@@ -81,6 +81,85 @@ Return nil if not enough bytes yet to know, or `invalid' for a bad ATYP."
   (or (cdr (assq code clatter-socks--rep-messages))
       (format "unknown reply code %d" code)))
 
+;; --- Handshake session driver ---
+
+(cl-defstruct (clatter-socks--session (:constructor clatter-socks--session-create))
+  "State for one in-progress SOCKS5 handshake.
+STATE is one of :method :auth :reply :done :failed.  BUFFER accumulates raw
+input from the proxy.  SEND-FN is called with a unibyte string to transmit."
+  state buffer host port user pass send-fn on-success on-failure)
+
+(defun clatter-socks--consume (session n)
+  "Drop the first N bytes from SESSION's input buffer."
+  (setf (clatter-socks--session-buffer session)
+        (substring (clatter-socks--session-buffer session) n)))
+
+(defun clatter-socks--send (session bytes)
+  "Transmit BYTES via SESSION's send function."
+  (funcall (clatter-socks--session-send-fn session) bytes))
+
+(defun clatter-socks--succeed (session)
+  "Mark SESSION done and invoke its success continuation."
+  (setf (clatter-socks--session-state session) :done)
+  (funcall (clatter-socks--session-on-success session)))
+
+(defun clatter-socks--fail (session reason)
+  "Mark SESSION failed and invoke its failure continuation with REASON."
+  (setf (clatter-socks--session-state session) :failed)
+  (funcall (clatter-socks--session-on-failure session) reason))
+
+(defun clatter-socks--send-auth (session)
+  "Send the RFC 1929 auth request and move SESSION to :auth."
+  (setf (clatter-socks--session-state session) :auth)
+  (clatter-socks--send session
+                       (clatter-socks--encode-auth
+                        (clatter-socks--session-user session)
+                        (clatter-socks--session-pass session))))
+
+(defun clatter-socks--send-connect (session)
+  "Send the CONNECT request, move SESSION to :reply, then drain the buffer."
+  (setf (clatter-socks--session-state session) :reply)
+  (clatter-socks--send session
+                       (clatter-socks--encode-connect
+                        (clatter-socks--session-host session)
+                        (clatter-socks--session-port session)))
+  (clatter-socks--advance session))
+
+(defun clatter-socks--advance (session)
+  "Advance SESSION's handshake using whatever input is buffered."
+  (unless (memq (clatter-socks--session-state session) '(:done :failed))
+    (let ((buf (clatter-socks--session-buffer session)))
+      (pcase (clatter-socks--session-state session)
+        (:method
+         (let ((method (clatter-socks--parse-method-selection buf)))
+           (when method
+             (clatter-socks--consume session 2)
+             (pcase method
+               (0 (clatter-socks--send-connect session))
+               (2 (clatter-socks--send-auth session))
+               (_ (clatter-socks--fail
+                   session
+                   "no acceptable auth method (does the proxy require credentials?)"))))))
+        (:auth
+         (let ((status (clatter-socks--parse-auth-status buf)))
+           (pcase status
+             ('nil nil)
+             (:ok (clatter-socks--consume session 2)
+                  (clatter-socks--send-connect session))
+             (_ (clatter-socks--consume session 2)
+                (clatter-socks--fail session "proxy authentication failed")))))
+        (:reply
+         (let ((total (clatter-socks--reply-length buf)))
+           (cond
+            ((eq total 'invalid)
+             (clatter-socks--fail session "malformed SOCKS reply (bad address type)"))
+            ((null total) nil)
+            ((< (length buf) total) nil)
+            (t (let ((rep (aref buf 1)))
+                 (if (= rep 0)
+                     (clatter-socks--succeed session)
+                   (clatter-socks--fail session (clatter-socks--rep-message rep))))))))))))
+
 (provide 'clatter-socks)
 
 ;;; clatter-socks.el ends here

--- a/clatter-socks.el
+++ b/clatter-socks.el
@@ -1,0 +1,86 @@
+;;; clatter-socks.el --- SOCKS5 proxy support for clatter.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Glenn Thompson
+;; Author: Glenn Thompson
+;; License: MIT
+
+;;; Commentary:
+
+;; SOCKS5 (RFC 1928) proxy support for clatter.el, with username/password
+;; authentication (RFC 1929).  Provides pure codec functions and a session
+;; based asynchronous handshake driver that runs over an already-open process.
+;; The CONNECT request always uses ATYP=domain (remote DNS / SOCKS5h), so the
+;; proxy resolves the target hostname; this avoids DNS leaks and supports
+;; .onion addresses.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'auth-source)
+(require 'clatter-config)
+
+;; --- Codec (pure) ---
+
+(defun clatter-socks--encode-greeting (methods)
+  "Encode a SOCKS5 client greeting offering auth METHODS (list of bytes)."
+  (apply #'unibyte-string 5 (length methods) methods))
+
+(defun clatter-socks--parse-method-selection (bytes)
+  "Return the method byte from a method-selection reply BYTES, or nil if short."
+  (when (>= (length bytes) 2)
+    (aref bytes 1)))
+
+(defun clatter-socks--encode-auth (user pass)
+  "Encode an RFC 1929 username/password auth request for USER and PASS."
+  (let ((u (encode-coding-string (or user "") 'utf-8))
+        (p (encode-coding-string (or pass "") 'utf-8)))
+    (when (or (> (length u) 255) (> (length p) 255))
+      (error "SOCKS5: username or password too long (max 255 bytes)"))
+    (concat (unibyte-string 1 (length u)) u
+            (unibyte-string (length p)) p)))
+
+(defun clatter-socks--parse-auth-status (bytes)
+  "Return :ok or :fail from an auth status reply BYTES, or nil if short."
+  (when (>= (length bytes) 2)
+    (if (= (aref bytes 1) 0) :ok :fail)))
+
+(defun clatter-socks--encode-connect (host port)
+  "Encode a SOCKS5 CONNECT request to HOST:PORT using ATYP=domain."
+  (let ((h (encode-coding-string host 'utf-8)))
+    (when (> (length h) 255)
+      (error "SOCKS5: hostname too long (%d > 255 bytes)" (length h)))
+    (concat (unibyte-string 5 1 0 3 (length h))
+            h
+            (unibyte-string (logand (ash port -8) 255) (logand port 255)))))
+
+(defun clatter-socks--reply-length (bytes)
+  "Total expected length of a SOCKS5 reply in BYTES.
+Return nil if not enough bytes yet to know, or `invalid' for a bad ATYP."
+  (when (>= (length bytes) 4)
+    (pcase (aref bytes 3)
+      (1 (+ 4 4 2))                                  ; IPv4
+      (4 (+ 4 16 2))                                 ; IPv6
+      (3 (when (>= (length bytes) 5)                 ; domain: header+len+name+port
+           (+ 4 1 (aref bytes 4) 2)))
+      (_ 'invalid))))
+
+(defconst clatter-socks--rep-messages
+  '((0 . "succeeded")
+    (1 . "general SOCKS server failure")
+    (2 . "connection not allowed by ruleset")
+    (3 . "network unreachable")
+    (4 . "host unreachable")
+    (5 . "connection refused")
+    (6 . "TTL expired")
+    (7 . "command not supported")
+    (8 . "address type not supported"))
+  "Map of SOCKS5 REP reply codes to human-readable messages.")
+
+(defun clatter-socks--rep-message (code)
+  "Human-readable message for SOCKS5 reply CODE."
+  (or (cdr (assq code clatter-socks--rep-messages))
+      (format "unknown reply code %d" code)))
+
+(provide 'clatter-socks)
+
+;;; clatter-socks.el ends here

--- a/clatter.el
+++ b/clatter.el
@@ -45,6 +45,7 @@
 (require 'clatter-config)
 (require 'clatter-protocol)
 (require 'clatter-connection)
+(require 'clatter-socks)
 (require 'clatter-cap)
 (require 'clatter-handlers)
 (require 'clatter-model)

--- a/tests/test-socks.el
+++ b/tests/test-socks.el
@@ -234,4 +234,30 @@ Returns (cons session state-box) where state-box is a plist with
     (should (equal (clatter-proxy-config '(:tor t))
                    '(:type socks5 :host "127.0.0.1" :port 9050)))))
 
+;; --- Connection-level guards ---
+
+(ert-deftest clatter-socks-test-external-tls-proxy-refused ()
+  "Configuring a proxy with external TLS must error, not connect."
+  (let ((clatter-tls-method 'external)
+        (clatter-networks nil))
+    (unwind-protect
+        (should-error
+         (clatter-connect "x-socks-test"
+                          :server "irc.example.org" :port 6697 :tls t
+                          :nick "n"
+                          :proxy '(:type socks5 :host "127.0.0.1" :port 9050)))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-socks-test-invalid-proxy-refused ()
+  "A proxy missing :host or :port must error."
+  (let ((clatter-tls-method 'builtin)
+        (clatter-networks nil))
+    (unwind-protect
+        (should-error
+         (clatter-connect "x-socks-test2"
+                          :server "irc.example.org" :port 6697 :tls t
+                          :nick "n"
+                          :proxy '(:type socks5 :host "127.0.0.1")))
+      (clatter-test-cleanup))))
+
 ;;; test-socks.el ends here

--- a/tests/test-socks.el
+++ b/tests/test-socks.el
@@ -77,4 +77,99 @@
   (should (equal "connection refused" (clatter-socks--rep-message 5)))
   (should (string-match-p "unknown" (clatter-socks--rep-message 42))))
 
+;; --- Driver (session-based, no real process) ---
+
+(defun clatter-socks-test--session (&rest overrides)
+  "Make a test session capturing sent bytes and the terminal result.
+Returns (cons session state-box) where state-box is a plist with
+:sent (list, newest-first) and :result (:ok or (cons :fail reason))."
+  (let* ((box (list :sent nil :result nil))
+         (session (apply #'clatter-socks--session-create
+                         :state :method :buffer (unibyte-string)
+                         :host "irc.example.org" :port 6697
+                         :send-fn (lambda (s) (push s (plist-get box :sent)))
+                         :on-success (lambda () (plist-put box :result :ok))
+                         :on-failure (lambda (r) (plist-put box :result (cons :fail r)))
+                         overrides)))
+    (cons session box)))
+
+(defun clatter-socks-test--feed (session bytes)
+  "Append BYTES to SESSION's buffer and advance the state machine."
+  (setf (clatter-socks--session-buffer session)
+        (concat (clatter-socks--session-buffer session) bytes))
+  (clatter-socks--advance session))
+
+(ert-deftest clatter-socks-test-driver-noauth-success ()
+  (pcase-let ((`(,session . ,box) (clatter-socks-test--session)))
+    (clatter-socks-test--feed session (unibyte-string 5 0))
+    (should (eq (clatter-socks--session-state session) :reply))
+    (should (equal (car (plist-get box :sent))
+                   (clatter-socks--encode-connect "irc.example.org" 6697)))
+    (clatter-socks-test--feed session (unibyte-string 5 0 0 1 0 0 0 0 0 0))
+    (should (eq (plist-get box :result) :ok))))
+
+(ert-deftest clatter-socks-test-driver-userpass-success ()
+  (pcase-let ((`(,session . ,box)
+               (clatter-socks-test--session :user "u" :pass "p")))
+    (clatter-socks-test--feed session (unibyte-string 5 2))
+    (should (eq (clatter-socks--session-state session) :auth))
+    (should (equal (car (plist-get box :sent)) (clatter-socks--encode-auth "u" "p")))
+    (clatter-socks-test--feed session (unibyte-string 1 0))
+    (should (eq (clatter-socks--session-state session) :reply))
+    (clatter-socks-test--feed session (unibyte-string 5 0 0 3 1 ?x 0 0))
+    (should (eq (plist-get box :result) :ok))))
+
+(ert-deftest clatter-socks-test-driver-auth-failure ()
+  (pcase-let ((`(,session . ,box)
+               (clatter-socks-test--session :user "u" :pass "p")))
+    (clatter-socks-test--feed session (unibyte-string 5 2))
+    (clatter-socks-test--feed session (unibyte-string 1 1))
+    (should (equal (plist-get box :result) '(:fail . "proxy authentication failed")))))
+
+(ert-deftest clatter-socks-test-driver-no-acceptable-method ()
+  (pcase-let ((`(,session . ,box) (clatter-socks-test--session)))
+    (clatter-socks-test--feed session (unibyte-string 5 255))
+    (should (eq (car (plist-get box :result)) :fail))
+    (should (string-match-p "no acceptable auth method"
+                            (cdr (plist-get box :result))))))
+
+(ert-deftest clatter-socks-test-driver-connect-refused ()
+  (pcase-let ((`(,session . ,box) (clatter-socks-test--session)))
+    (clatter-socks-test--feed session (unibyte-string 5 0))
+    (clatter-socks-test--feed session (unibyte-string 5 5 0 1 0 0 0 0 0 0))
+    (should (equal (plist-get box :result) '(:fail . "connection refused")))))
+
+(ert-deftest clatter-socks-test-driver-partial-reply ()
+  (pcase-let ((`(,session . ,box) (clatter-socks-test--session)))
+    (clatter-socks-test--feed session (unibyte-string 5 0))
+    (dolist (b '(5 0 0 1 0 0 0 0 0))
+      (clatter-socks-test--feed session (unibyte-string b))
+      (should (null (plist-get box :result))))
+    (clatter-socks-test--feed session (unibyte-string 0))
+    (should (eq (plist-get box :result) :ok))))
+
+(ert-deftest clatter-socks-test-driver-bad-atyp ()
+  (pcase-let ((`(,session . ,box) (clatter-socks-test--session)))
+    (clatter-socks-test--feed session (unibyte-string 5 0))
+    (clatter-socks-test--feed session (unibyte-string 5 0 0 9 0 0))
+    (should (string-match-p "malformed" (cdr (plist-get box :result))))))
+
+(ert-deftest clatter-socks-test-driver-no-reentry-after-terminal ()
+  (pcase-let ((`(,session . ,box) (clatter-socks-test--session)))
+    (clatter-socks-test--feed session (unibyte-string 5 0))
+    (clatter-socks-test--feed session (unibyte-string 5 0 0 1 0 0 0 0 0 0))
+    (should (eq (plist-get box :result) :ok))
+    (should (eq (clatter-socks--session-state session) :done))
+    ;; trailing bytes after a completed handshake must be ignored
+    (clatter-socks-test--feed session (unibyte-string 1 2 3 4))
+    (should (eq (plist-get box :result) :ok))
+    (should (eq (clatter-socks--session-state session) :done))))
+
+;; Hardening: explicit big-endian port packing (catches byte-swap regressions)
+(ert-deftest clatter-socks-test-encode-connect-port-bytes ()
+  (let ((out (clatter-socks--encode-connect "h" 256)))   ; 256 = 0x0100
+    (should (equal (substring out (- (length out) 2)) (unibyte-string 1 0))))
+  (let ((out (clatter-socks--encode-connect "h" 65535))) ; 0xFFFF
+    (should (equal (substring out (- (length out) 2)) (unibyte-string 255 255)))))
+
 ;;; test-socks.el ends here

--- a/tests/test-socks.el
+++ b/tests/test-socks.el
@@ -1,0 +1,80 @@
+;;; test-socks.el --- SOCKS5 tests for clatter.el -*- lexical-binding: t; -*-
+;;; Commentary:
+;; ERT tests for clatter-socks.el (SOCKS5 codec and handshake driver).
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'clatter-socks)
+
+;; --- Greeting ---
+
+(ert-deftest clatter-socks-test-greeting-noauth ()
+  (should (equal (clatter-socks--encode-greeting '(0))
+                 (unibyte-string 5 1 0))))
+
+(ert-deftest clatter-socks-test-greeting-userpass ()
+  (should (equal (clatter-socks--encode-greeting '(0 2))
+                 (unibyte-string 5 2 0 2))))
+
+;; --- Method selection ---
+
+(ert-deftest clatter-socks-test-method-incomplete ()
+  (should (null (clatter-socks--parse-method-selection (unibyte-string 5)))))
+
+(ert-deftest clatter-socks-test-method-noauth ()
+  (should (= 0 (clatter-socks--parse-method-selection (unibyte-string 5 0)))))
+
+(ert-deftest clatter-socks-test-method-userpass ()
+  (should (= 2 (clatter-socks--parse-method-selection (unibyte-string 5 2)))))
+
+(ert-deftest clatter-socks-test-method-rejected ()
+  (should (= 255 (clatter-socks--parse-method-selection (unibyte-string 5 255)))))
+
+;; --- Auth (RFC 1929) ---
+
+(ert-deftest clatter-socks-test-encode-auth ()
+  (should (equal (clatter-socks--encode-auth "ab" "xyz")
+                 (concat (unibyte-string 1 2) "ab" (unibyte-string 3) "xyz"))))
+
+(ert-deftest clatter-socks-test-encode-auth-too-long ()
+  (should-error (clatter-socks--encode-auth (make-string 256 ?a) "x")))
+
+(ert-deftest clatter-socks-test-auth-status ()
+  (should (null (clatter-socks--parse-auth-status (unibyte-string 1))))
+  (should (eq :ok (clatter-socks--parse-auth-status (unibyte-string 1 0))))
+  (should (eq :fail (clatter-socks--parse-auth-status (unibyte-string 1 1)))))
+
+;; --- CONNECT request ---
+
+(ert-deftest clatter-socks-test-encode-connect ()
+  ;; VER=5 CMD=1 RSV=0 ATYP=3 LEN host PORT(6697=0x1A29)
+  (should (equal (clatter-socks--encode-connect "a.bc" 6697)
+                 (concat (unibyte-string 5 1 0 3 4) "a.bc"
+                         (unibyte-string #x1a #x29)))))
+
+(ert-deftest clatter-socks-test-encode-connect-onion ()
+  (let* ((h (concat (make-string 16 ?a) ".onion"))
+         (out (clatter-socks--encode-connect h 6667)))
+    (should (= (aref out 3) 3))                 ; domain ATYP
+    (should (= (aref out 4) (length h)))        ; length byte
+    (should (equal (substring out 5 (+ 5 (length h))) h))))
+
+(ert-deftest clatter-socks-test-encode-connect-host-too-long ()
+  (should-error (clatter-socks--encode-connect (make-string 256 ?a) 1)))
+
+;; --- Reply length / parse ---
+
+(ert-deftest clatter-socks-test-reply-length ()
+  (should (= 10 (clatter-socks--reply-length (unibyte-string 5 0 0 1)))) ; IPv4
+  (should (= 22 (clatter-socks--reply-length (unibyte-string 5 0 0 4)))) ; IPv6
+  (should (= 11 (clatter-socks--reply-length (unibyte-string 5 0 0 3 4)))) ; domain len 4
+  (should (null (clatter-socks--reply-length (unibyte-string 5 0 0 3)))) ; domain, no len yet
+  (should (null (clatter-socks--reply-length (unibyte-string 5 0))))     ; too short
+  (should (eq 'invalid (clatter-socks--reply-length (unibyte-string 5 0 0 9)))))
+
+(ert-deftest clatter-socks-test-rep-message ()
+  (should (equal "connection refused" (clatter-socks--rep-message 5)))
+  (should (string-match-p "unknown" (clatter-socks--rep-message 42))))
+
+;;; test-socks.el ends here

--- a/tests/test-socks.el
+++ b/tests/test-socks.el
@@ -172,4 +172,36 @@ Returns (cons session state-box) where state-box is a plist with
   (let ((out (clatter-socks--encode-connect "h" 65535))) ; 0xFFFF
     (should (equal (substring out (- (length out) 2)) (unibyte-string 255 255)))))
 
+;; --- Password helper ---
+
+(ert-deftest clatter-socks-test-password-explicit ()
+  (should (equal "sekret"
+                 (clatter-socks--password '(:host "h" :user "u" :pass "sekret")))))
+
+(ert-deftest clatter-socks-test-password-none-without-auth-source ()
+  (let ((clatter-use-auth-source nil))
+    (should (null (clatter-socks--password '(:host "h" :user "u"))))))
+
+;; --- begin: greeting is sent and a session is stored on the process ---
+
+(ert-deftest clatter-socks-test-begin-sends-greeting ()
+  (let ((proc (make-network-process
+               :name "clatter-socks-test" :server t :host 'local :service t)))
+    (unwind-protect
+        (let (sent)
+          (cl-letf (((symbol-function 'process-send-string)
+                     (lambda (_p s) (push s sent))))
+            (clatter-socks-begin proc "irc.example.org" 6697
+                                 '(:host "127.0.0.1" :port 1080)
+                                 #'ignore #'ignore)
+            ;; greeting sent, session stored, the real filter installed
+            (should (equal (car (last sent)) (unibyte-string 5 1 0)))
+            (should (clatter-socks--session-p (process-get proc :socks-session)))
+            (should (eq (process-filter proc) #'clatter-socks--filter))
+            ;; drive one step through the real filter: method selection -> CONNECT
+            (funcall (process-filter proc) proc (unibyte-string 5 0))
+            (should (equal (car sent)
+                           (clatter-socks--encode-connect "irc.example.org" 6697)))))
+      (delete-process proc))))
+
 ;;; test-socks.el ends here

--- a/tests/test-socks.el
+++ b/tests/test-socks.el
@@ -204,4 +204,34 @@ Returns (cons session state-box) where state-box is a plist with
                            (clatter-socks--encode-connect "irc.example.org" 6697)))))
       (delete-process proc))))
 
+;; --- Proxy config resolution ---
+
+(ert-deftest clatter-socks-test-config-tor-sugar ()
+  (let ((clatter-proxy nil))
+    (should (equal (clatter-proxy-config '(:tor t))
+                   '(:type socks5 :host "127.0.0.1" :port 9050)))))
+
+(ert-deftest clatter-socks-test-config-explicit-overrides-tor ()
+  (let ((clatter-proxy nil)
+        (p '(:type socks5 :host "10.0.0.1" :port 1080)))
+    (should (equal (clatter-proxy-config (list :proxy p :tor t)) p))))
+
+(ert-deftest clatter-socks-test-config-global-fallback ()
+  (let ((clatter-proxy '(:type socks5 :host "g" :port 1)))
+    (should (equal (clatter-proxy-config nil) clatter-proxy))))
+
+(ert-deftest clatter-socks-test-config-direct ()
+  (let ((clatter-proxy nil))
+    (should (null (clatter-proxy-config '(:server "x"))))))
+
+(ert-deftest clatter-socks-test-config-proxy-overrides-global ()
+  (let ((clatter-proxy '(:type socks5 :host "g" :port 1))
+        (p '(:type socks5 :host "10.0.0.1" :port 1080)))
+    (should (equal (clatter-proxy-config (list :proxy p)) p))))
+
+(ert-deftest clatter-socks-test-config-tor-overrides-global ()
+  (let ((clatter-proxy '(:type socks5 :host "g" :port 1)))
+    (should (equal (clatter-proxy-config '(:tor t))
+                   '(:type socks5 :host "127.0.0.1" :port 9050)))))
+
 ;;; test-socks.el ends here


### PR DESCRIPTION
## Summary

Adds universal **SOCKS5 (RFC 1928) proxy support** for outbound IRC connections, with Tor as a first-class case (including `.onion` servers). This lets clatter reach bouncers/servers that are only accessible through a SOCKS5 proxy (an `ssh -D` dynamic forward, Tor at `127.0.0.1:9050`, or any standalone SOCKS5 proxy).

ERC enables this by swapping `erc-server-connect-function` to `socks-open-network-stream`, but clatter's connection layer uses `make-network-process :nowait t` with asynchronous TLS in the sentinel rather than `open-network-stream`, so that approach doesn't apply. This implements a small, pure-elisp SOCKS5 client that integrates with clatter's existing non-blocking connect model, watchdog, and reconnect logic.

## Two invariants (always enforced when a proxy is configured)

- **Remote DNS (SOCKS5h):** the CONNECT request always uses `ATYP=domain`; the target hostname is sent to the proxy and never resolved locally. No DNS leak; `.onion` works.
- **Fail-closed:** if the proxy handshake fails for any reason, clatter tears the connection down and reconnects *through the proxy* — it never falls back to a direct connection.

## Configuration

```elisp
;; Per network:
(setopt clatter-networks
  '(("libera-tor"
     :server "irc.libera.chat" :port 6697 :tls t :nick "yournick"
     :tor t)))                         ;; sugar for 127.0.0.1:9050

;; or an explicit proxy plist:
;;   :proxy (:type socks5 :host "127.0.0.1" :port 1080 :user "u" :pass "p")

;; or a global default for all networks:
(setopt clatter-proxy '(:type socks5 :host "127.0.0.1" :port 9050))
```

Precedence: per-network `:proxy` → `:tor` shorthand → global `clatter-proxy` → direct. Proxy password resolves from `:pass` or auth-source. Username/password auth (RFC 1929) and no-auth are both supported.

## Design

- **New module `clatter-socks.el`** — pure SOCKS5 codec (greeting / RFC 1929 auth / CONNECT / reply parsing), a session-based asynchronous handshake driver (a small `:method → :auth → :reply → :done/:failed` state machine that buffers partial reads), process glue, and the proxy password helper.
- **`clatter-connection.el`** — when a proxy is configured, dials the proxy with binary coding and, at the sentinel's `"open"` event, runs the SOCKS5 handshake before the normal flow; coding switches to UTF-8 on success. TLS is negotiated against the **real** server (correct SNI / certificate verification), not the proxy. The post-open logic was extracted into `clatter--after-tcp-open` and is shared by the direct and proxied paths (the no-proxy path is byte-for-byte unchanged).
- **External-TLS + proxy** is refused with a clear error (fail-closed forbids a silent direct connection); those users can wrap the client with `torsocks` at the OS level.

While wiring this in, I also fixed a latent **double-reconnect** bug on connect failure (a failure handler called `delete-process` — which re-enters the sentinel and schedules a reconnect — and *then* scheduled another, since `clatter--schedule-reconnect` isn't idempotent). Teardown/reconnect is now owned solely by the sentinel. This affected the pre-existing TLS-failure path too.

## Testing

- New `tests/test-socks.el`: 34 ERT tests covering the codec (incl. big-endian port packing, `.onion`, every reply code), the driver (auth, partial reads byte-by-byte, terminal-state re-entry guard, failure paths), config precedence, and the external-TLS / invalid-proxy connection guards.
- Full suite: **167/167 passing** (133 pre-existing + 34 new). Byte-compile clean with warnings-as-errors; checkdoc clean.
- `make test-socks` target added; the file also runs under `make test`.

A live smoke test through a real proxy (Tor / `ssh -D`) is recommended as a manual verification step.

## Known limitation

Bytes pipelined by the proxy *after* the CONNECT reply are not re-injected into the IRC stream. This is unreachable in practice for IRC: with builtin TLS the next bytes are the GnuTLS handshake, and IRC servers send nothing before client registration.
