### PR TITLE
ui: Do not highlight self-mentions

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -281,6 +281,8 @@ SERVER-TIME overrides the current time for the timestamp."
          (my-nick (clatter-connection-nick conn))
          (is-reply-to-me (get-text-property 0 'clatter-reply-to-me text))
          (is-mention (and my-nick
+                          ;; do not highlight self-mentions
+                          (not (string-equal-ignore-case sender my-nick))
                           (or is-reply-to-me
                               (string-match-p
                                (regexp-quote (downcase my-nick))


### PR DESCRIPTION
clatter-notify doesn't notify about self-mentions either, so maybe we should do the same in clatter-ui and behave symmetrically?

Just noticed this when I said something like "https://codeberg.org/alcor/" and saw clatter highlight it because the URL mentions my own nick.