### PR TITLE
ui: Parse formatting codes in realname/gecos fields

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -715,7 +715,7 @@ Emacs requires `set-window-margins' on the window, not just
       (display-buffer buf))
     (clatter-insert-system buf
                            (if (and realname (not (string= nick realname)))
-                               (format "%s (%s) has joined %s" nick realname channel)
+                               (format "%s (%s) has joined %s" nick (clatter-format-parse realname) channel)
                              (format "%s has joined %s" nick channel))
                            (cons 'join
                                  (and (not (string-equal-ignore-case my-nick nick))
@@ -911,7 +911,7 @@ Emacs requires `set-window-margins' on the window, not just
                   (or (plist-get data :host) "?"))
           parts)
     (when (plist-get data :realname)
-      (push (format "  Realname: %s" (plist-get data :realname)) parts))
+      (push (format "  Realname: %s" (clatter-format-parse (plist-get data :realname))) parts))
     (when (plist-get data :account)
       (push (format "  Account: %s" (plist-get data :account)) parts))
     (when (plist-get data :regnick)


### PR DESCRIPTION
Many people still apparently do this. In my opinion, parsing the control codes is still a better option than displaying a bunch of ^C ^B etc. control characters in the buffer.

If people complain, I guess we can add a knob to control whether to strip the codes later. Although I doubt it's really an issue - people just lived with this on Hexchat, mIRC etc.