### PR TITLE
ui: use explicit (clatter-timestamp default) face list for timestamp

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -188,9 +188,12 @@ append at the bottom like a traditional IRC client."
               (when ts-str
                 (let ((ov (make-overlay start (1+ start) nil t)))
                   (overlay-put ov 'before-string
+                               ;; Apply 'default face after 'clatter-timestamp to ensure that no
+                               ;; unwanted face properties are inherited from text which might be
+                               ;; at point.
                                (propertize " " 'display
                                            `((margin right-margin)
-                                             ,(propertize ts-str 'face 'clatter-timestamp))))
+                                             ,(propertize ts-str 'face '(clatter-timestamp default)))))
                   (overlay-put ov 'clatter-timestamp t)
                   (overlay-put ov 'invisible invisible)))
               (add-text-properties start (point)


### PR DESCRIPTION
This works around an issue where *if* clatter-nick-column-width is exceeded, padding becomes 0 due to (max 0 (- width nick-len))), and the overlay ends up inheriting (:weight bold) from the nick at point.

The default face in the explicit face list is given last and sets all face attributes to their defaults, ensuring no unwanted attributes get inherited.

This is only noticable when clatter-nick-column-width is exceeded, because if it isn't, there's just empty unpropertized padding space at point (which is neutral wrt. property inheritance). If there is no padding, the nick will be immediately under the point and its properties get inherited.

Screenshot illustrating the issue (note the bold weight on *21:12* on the "aaaaaaaa…" line):

<img width="2858" height="1830" alt="Screenshot showing wrongly-formatted (bolded) timestamp" src="https://github.com/user-attachments/assets/efa18da3-81e2-415b-abce-f8a1a2d2dd29" />
