### PR TITLE
Fix WHOIS plist key conflict

### DIFF
--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -641,7 +641,7 @@ Return the trimmed character."
       ("378"  ; RPL_WHOISHOST
        (let ((data (clatter-connection--whois-data conn)))
          (when data
-           (plist-put data :host (string-join (cddr params) " ")))))
+           (plist-put data :conn (string-join (cddr params) " ")))))
       ("379"  ; RPL_WHOISMODES
        (let ((data (clatter-connection--whois-data conn)))
          (when data

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -922,8 +922,8 @@ Emacs requires `set-window-margins' on the window, not just
       (push (format "  Server: %s (%s)"
                     (plist-get data :server)
                     (or (plist-get data :server-info) "")) parts))
-    (when (plist-get data :host)
-      (push (format "  Host: %s" (plist-get data :host)) parts))
+    (when (plist-get data :conn)
+      (push (format "  Host: %s" (plist-get data :conn)) parts))
     (when (plist-get data :actually)
       (push (format "  Details: %s" (plist-get data :actually)) parts))
     (when (plist-get data :channels)


### PR DESCRIPTION
Fix plist key collision between RPL_WHOISUSER (311) and RPL_WHOISHOST (378).

RPL_WHOISHOST (378) actually contains different data¹ than RPL_WHOISUSER (311). Different plist keys should be used.

¹) *"\<nick\> is connecting from ..."* etc. - https://modern.ircdocs.horse/#rplwhoishost-378