### PR TITLE
Cleanly exit 'query buffers when they're killed

### DIFF
--- a/clatter-model.el
+++ b/clatter-model.el
@@ -310,7 +310,8 @@ Installed buffer-locally on `kill-buffer-hook' by `clatter-mode'."
   (remove-hook 'kill-buffer-hook #'clatter--on-kill-buffer t)
   (cond
    ((not (boundp 'clatter--buffer-type)) nil)
-   ((eq 'channel clatter--buffer-type)
+   ((or (eq 'channel clatter--buffer-type)
+        (eq 'query clatter--buffer-type))
     (when (fboundp 'clatter-cmd-close)
       (clatter-cmd-close nil)))
    ((and (eq 'server clatter--buffer-type)


### PR DESCRIPTION
* Do `/msg NickServ help` in a server buffer
* Kill the newly-created NickServ buffer via *C-x k* (kill-buffer)
* Do a second `/msg NickServ help` in the server buffer

→ This will result in an error, because the (non-live) query buffer is still retained in the `clatter--buffer-alist`, and will be returned by `clatter-get-or-create-buffer` / `clatter-get-buffer` when the NickServ replies to us.

This fix adjusts clatter's own kill-buffer-hook to ensure that `clatter-cmd-close` is also run when a query buffer is killed, thus ensuring that the appropriate cleanup is done.