### PR TITLE
Consolidate CTCP ACTION / PRIVMSG / NOTICE handling

### DIFF
--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -341,6 +341,7 @@ Return the trimmed character."
       ;; --- PRIVMSG ---
       ("PRIVMSG"
        (let* ((parsed-tags (clatter-parse-tags tags))
+              (server-time (clatter-get-parsed-server-time parsed-tags))
               (msgid (cdr (assoc "msgid" parsed-tags)))
               (target (nth 0 params))
               (raw-text (nth 1 params))
@@ -359,9 +360,8 @@ Return the trimmed character."
          (if (and (> (length raw-text) 1)
                   (= (aref raw-text 0) 1)
                   (= (aref raw-text (1- (length raw-text))) 1))
-             (clatter--handle-ctcp conn parsed-prefix target raw-text)
+             (clatter--handle-ctcp conn parsed-prefix target raw-text server-time)
            (let* ((text (clatter--prepend-status-prefix status-prefix raw-text))
-                  (server-time (clatter-get-server-time tags))
                   (batch-id (cdr (assoc "batch" parsed-tags)))
                   (is-bot (assoc "bot" parsed-tags))
                   (reply-to (or (cdr (assoc "+draft/reply" parsed-tags))
@@ -702,7 +702,7 @@ Return the trimmed character."
 
 ;; --- CTCP Handling ---
 
-(defun clatter--handle-ctcp (conn sender target raw-text)
+(defun clatter--handle-ctcp (conn sender target raw-text server-time)
   "Handle CTCP request on CONN from SENDER to TARGET with RAW-TEXT."
   (let* ((ctcp-content (substring raw-text 1 (1- (length raw-text))))
          (space-pos (cl-position ?\s ctcp-content))
@@ -718,8 +718,7 @@ Return the trimmed character."
       ("ACTION"
        (run-hook-with-args 'clatter-action-hook
                            conn sender target ctcp-args
-                           (clatter-get-server-time (clatter-message-tags
-                                                     (clatter-parse-line "")))))
+                           server-time))
       ;; Don't respond to our own CTCP requests
       ((guard self-p) nil)
       ("VERSION"

--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -28,7 +28,7 @@ Called with (CONN SENDER TARGET TEXT SERVER-TIME).")
 
 (defvar clatter-notice-hook nil
   "Hook for NOTICE events.
-Called with (CONN SENDER TARGET TEXT).")
+Called with (CONN SENDER TARGET TEXT SERVER-TIME).")
 
 (defvar clatter-join-hook nil
   "Hook for JOIN events.
@@ -395,15 +395,8 @@ Return the trimmed character."
 
       ;; --- NOTICE ---
       ("NOTICE"
-       (let* ((target (nth 0 params))
-              (raw-text (nth 1 params))
-              (parsed-prefix (clatter-parse-prefix prefix))
-              ;; STATUSMSG: detect prefix like @#channel or +#channel and strip
-              ;; it from target
-              (statusmsg-chars (let ((isup (clatter-connection-isupport conn)))
-                                 (when isup (gethash "STATUSMSG" isup))))
-              (status-prefix (clatter--set-unprefixed target statusmsg-chars))
-              (text (clatter--prepend-status-prefix status-prefix raw-text)))
+       (let ((raw-text (nth 1 params))
+             (parsed-prefix (clatter-parse-prefix prefix)))
          ;; Check for CTCP reply in NOTICE (don't respond)
          (if (and (> (length raw-text) 1)
                   (= (aref raw-text 0) 1)
@@ -414,8 +407,39 @@ Return the trimmed character."
                     (ctcp-args (if space-pos (substring ctcp-content (1+ space-pos)) "")))
                (run-hook-with-args 'clatter-ctcp-reply-hook
                                    conn parsed-prefix ctcp-cmd ctcp-args))
-           (run-hook-with-args 'clatter-notice-hook
-                               conn parsed-prefix target text))))
+           (let* ((sender-nick (clatter-prefix-nick parsed-prefix))
+                  (parsed-tags (clatter-parse-tags tags))
+                  ;; --- >> EXTRACT MESSAGE TAGS ---
+                  (server-time (clatter-get-parsed-server-time parsed-tags))
+                  (msgid (clatter-get-parsed-tag parsed-tags "msgid"))
+                  (is-bot (assoc "bot" parsed-tags))
+                  (reply-to (or (clatter-get-parsed-tag parsed-tags "+draft/reply")
+                                (clatter-get-parsed-tag parsed-tags "+reply")
+                                (clatter-get-parsed-tag parsed-tags "draft/reply")))
+                  ;; --- << EXTRACT MESSAGE TAGS ---
+                  (is-reply-to-me (and reply-to
+                                       (clatter-sent-p
+                                        (clatter-connection-network-id conn) reply-to)))
+                  (target (nth 0 params))
+                  ;; STATUSMSG: detect prefix like @#channel or +#channel and strip
+                  ;; it from target
+                  (statusmsg-chars (let ((isup (clatter-connection-isupport conn)))
+                                     (when isup (gethash "STATUSMSG" isup))))
+                  (status-prefix (clatter--set-unprefixed target statusmsg-chars))
+                  (text (clatter--prepend-status-prefix status-prefix raw-text)))
+             ;; Mark sender as bot if draft/bot tag present
+             (when is-bot
+               (setq sender-nick (propertize sender-nick 'clatter-bot t))
+               (setf (car parsed-prefix) sender-nick))
+             ;; Attach msgid and reply-to as text properties
+             (when msgid
+               (setq text (propertize text 'clatter-msgid msgid)))
+             (when reply-to
+               (setq text (propertize text 'clatter-reply-to reply-to)))
+             (when is-reply-to-me
+               (setq text (propertize text 'clatter-reply-to-me t)))
+             (run-hook-with-args 'clatter-notice-hook
+                                 conn parsed-prefix target text server-time)))))
 
       ;; --- INVITE ---
       ("INVITE"

--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -340,11 +340,20 @@ Return the trimmed character."
 
       ;; --- PRIVMSG ---
       ("PRIVMSG"
-       (let* ((parsed-tags (clatter-parse-tags tags))
-              (server-time (clatter-get-parsed-server-time parsed-tags))
-              (msgid (cdr (assoc "msgid" parsed-tags)))
-              (target (nth 0 params))
+       (let* ((target (nth 0 params))
               (raw-text (nth 1 params))
+              (parsed-tags (clatter-parse-tags tags))
+              ;; --- >> EXTRACT MESSAGE TAGS ---
+              (server-time (clatter-get-parsed-server-time parsed-tags))
+              (msgid (clatter-get-parsed-tag parsed-tags "msgid"))
+              (is-bot (assoc "bot" parsed-tags))
+              (reply-to (or (clatter-get-parsed-tag parsed-tags "+draft/reply")
+                            (clatter-get-parsed-tag parsed-tags "+reply")
+                            (clatter-get-parsed-tag parsed-tags "draft/reply")))
+              ;; --- << EXTRACT MESSAGE TAGS ---
+              (is-reply-to-me (and reply-to
+                                   (clatter-sent-p
+                                    (clatter-connection-network-id conn) reply-to)))
               (parsed-prefix (clatter-parse-prefix prefix))
               (sender-nick (clatter-prefix-nick parsed-prefix))
               ;; STATUSMSG: detect prefix like @#channel or +#channel and strip
@@ -360,16 +369,10 @@ Return the trimmed character."
          (if (and (> (length raw-text) 1)
                   (= (aref raw-text 0) 1)
                   (= (aref raw-text (1- (length raw-text))) 1))
-             (clatter--handle-ctcp conn parsed-prefix target raw-text server-time)
+             (clatter--handle-ctcp conn parsed-prefix target raw-text status-prefix
+                                   msgid server-time is-bot reply-to is-reply-to-me)
            (let* ((text (clatter--prepend-status-prefix status-prefix raw-text))
-                  (batch-id (cdr (assoc "batch" parsed-tags)))
-                  (is-bot (assoc "bot" parsed-tags))
-                  (reply-to (or (cdr (assoc "+draft/reply" parsed-tags))
-                                (cdr (assoc "+reply" parsed-tags))
-                                (cdr (assoc "draft/reply" parsed-tags))))
-                  (is-reply-to-me (and reply-to
-                                       (clatter-sent-p
-                                        (clatter-connection-network-id conn) reply-to))))
+                  (batch-id (clatter-get-parsed-tag parsed-tags "batch-id")))
              ;; Mark sender as bot if draft/bot tag present
              (when is-bot
                (setq sender-nick (propertize sender-nick 'clatter-bot t))
@@ -702,8 +705,13 @@ Return the trimmed character."
 
 ;; --- CTCP Handling ---
 
-(defun clatter--handle-ctcp (conn sender target raw-text server-time)
-  "Handle CTCP request on CONN from SENDER to TARGET with RAW-TEXT."
+(defun clatter--handle-ctcp (conn
+                             sender target raw-text
+                             &optional
+                             status-prefix
+                             msgid server-time is-bot reply-to is-reply-to-me)
+  "Handle CTCP request on CONN from SENDER to TARGET with RAW-TEXT, STATUS-PREFIX,
+MSGID, SERVER-TIME, IS-BOT, REPLY-TO, and IS-REPLY-TO-ME."
   (let* ((ctcp-content (substring raw-text 1 (1- (length raw-text))))
          (space-pos (cl-position ?\s ctcp-content))
          (ctcp-cmd (upcase (if space-pos
@@ -716,9 +724,21 @@ Return the trimmed character."
          (self-p (string-equal sender-nick (clatter-connection-nick conn))))
     (pcase ctcp-cmd
       ("ACTION"
-       (run-hook-with-args 'clatter-action-hook
-                           conn sender target ctcp-args
-                           server-time))
+       (let ((text (clatter--prepend-status-prefix status-prefix ctcp-args)))
+         ;; Mark sender as bot if draft/bot tag present
+         (when is-bot
+           (setq sender-nick (propertize sender-nick 'clatter-bot t))
+           (setf (car sender) sender-nick))
+         ;; Attach msgid and reply-to as text properties
+         (when msgid
+           (setq text (propertize text 'clatter-msgid msgid)))
+         (when reply-to
+           (setq text (propertize text 'clatter-reply-to reply-to)))
+         (when is-reply-to-me
+           (setq text (propertize text 'clatter-reply-to-me t)))
+         (run-hook-with-args 'clatter-action-hook
+                             conn sender target text
+                             server-time)))
       ;; Don't respond to our own CTCP requests
       ((guard self-p) nil)
       ("VERSION"

--- a/clatter-log.el
+++ b/clatter-log.el
@@ -180,7 +180,7 @@ FILE is stored for flushing."
                          (format "<%s> %s" sender-nick text)
                          server-time)))
 
-(defun clatter-log--on-action (conn sender target text _server-time)
+(defun clatter-log--on-action (conn sender target text server-time)
   "Log ACTION from SENDER to TARGET with TEXT on CONN."
   (let* ((network (clatter-connection-network-id conn))
          (my-nick (clatter-connection-nick conn))
@@ -189,7 +189,8 @@ FILE is stored for flushing."
                          target
                        (if (string-equal target my-nick) sender-nick target))))
     (clatter-log--write network log-target
-                         (format "* %s %s" sender-nick text))))
+                        (format "* %s %s" sender-nick text)
+                        server-time)))
 
 (defun clatter-log--on-notice (conn sender target text)
   "Log NOTICE from SENDER to TARGET on CONN."

--- a/clatter-log.el
+++ b/clatter-log.el
@@ -192,7 +192,7 @@ FILE is stored for flushing."
                         (format "* %s %s" sender-nick text)
                         server-time)))
 
-(defun clatter-log--on-notice (conn sender target text)
+(defun clatter-log--on-notice (conn sender target text server-time)
   "Log NOTICE from SENDER to TARGET on CONN."
   (let* ((network (clatter-connection-network-id conn))
          (sender-nick (or (clatter-prefix-nick sender) "*"))
@@ -202,7 +202,8 @@ FILE is stored for flushing."
                        target)))
     (when log-target
       (clatter-log--write network log-target
-                           (format "-%s- %s" sender-nick text)))))
+                          (format "-%s- %s" sender-nick text)
+                          server-time))))
 
 (defun clatter-log--on-join (conn sender channel _account realname)
   "Log JOIN of SENDER to CHANNEL on CONN."

--- a/clatter-protocol.el
+++ b/clatter-protocol.el
@@ -239,16 +239,25 @@ Tags format: key1=value1;key2=value2;key3"
                   (cons tag nil))))
             (split-string tags-string ";"))))
 
+(defun clatter-get-parsed-tag (tags-alist key)
+  "Get the value of KEY from TAGS-ALIST"
+  (cdr (assoc key tags-alist #'string=)))
+
 (defun clatter-get-tag (tags-string key)
   "Get the value of KEY from TAGS-STRING."
-  (cdr (assoc key (clatter-parse-tags tags-string) #'string=)))
+  (clatter-get-parsed-tag (clatter-parse-tags tags-string) key))
+
+(defun clatter-get-parsed-server-time (tags-alist)
+  "Extract server-time from IRCv3 TAGS-ALIST.
+Returns an Emacs time value or nil."
+  (let ((time-str (clatter-get-parsed-tag tags-alist "time")))
+    (when time-str
+      (clatter-parse-iso8601 time-str))))
 
 (defun clatter-get-server-time (tags-string)
   "Extract server-time from IRCv3 TAGS-STRING.
 Returns an Emacs time value or nil."
-  (let ((time-str (clatter-get-tag tags-string "time")))
-    (when time-str
-      (clatter-parse-iso8601 time-str))))
+  (clatter-get-parsed-server-time (clatter-parse-tags tags-string)))
 
 (defun clatter-parse-iso8601 (time-string)
   "Parse ISO8601 TIME-STRING to Emacs time value.

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -354,15 +354,18 @@ SERVER-TIME overrides the current time for the timestamp."
 (defun clatter-insert-action (buffer sender text conn &optional server-time invisible)
   "Insert a /me ACTION from SENDER with TEXT into BUFFER."
   (let* ((hl-text (clatter-hl-format-text text buffer conn))
+         (msgid (get-text-property 0 'clatter-msgid text))
          (prefix (clatter--format-nick-column "*" 'clatter-action sender)))
     (add-face-text-property 0 (length hl-text) 'clatter-action nil hl-text)
-    (let ((formatted (concat prefix " "
+    (let ((props (list 'clatter-msg-type 'action
+                       'clatter-sender sender
+                       'clatter-text text))
+          (formatted (concat prefix " "
                              (propertize (concat sender " ") 'face 'clatter-action)
                              hl-text)))
-      (clatter--insert-message buffer formatted nil
-                               (list 'clatter-msg-type 'action
-                                     'clatter-sender sender
-                                     'clatter-text text)
+      (when msgid
+        (setq props (plist-put props 'clatter-msgid msgid)))
+      (clatter--insert-message buffer formatted nil props
                                server-time
                                invisible)
       (unless (eq buffer (current-buffer))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -270,11 +270,12 @@ Removes oldest messages from the appropriate end of the buffer."
 
 (defun clatter--find-message-by-msgid (buffer msgid)
   "Find message text and sender in BUFFER by MSGID.
-Returns (sender . text) or nil."
+Returns ((sender . text) . msg-type) or nil."
   (let ((found (clatter--find-message-position-by-msgid buffer msgid)))
     (when found
-      (cons (get-text-property found 'clatter-sender)
-            (get-text-property found 'clatter-text)))))
+      (cons (cons (get-text-property found 'clatter-sender)
+                  (get-text-property found 'clatter-text))
+            (get-text-property found 'clatter-msg-type)))))
 
 (defun clatter-jump-to-msgid (buffer msgid)
   "Jump to BUFFER message identified by MSGID."
@@ -329,13 +330,18 @@ SERVER-TIME overrides the current time for the timestamp."
                        (add-face-text-property 0 (length hl-text) 'clatter-mention nil hl-text))))
          ;; Prepend reply context if available
          (reply-line (when reply-context
-                       (let* ((ref-sender (car reply-context))
-                              (ref-text (cdr reply-context))
+                       (let* ((ref-sender-text (car reply-context))
+                              (ref-sender (car ref-sender-text))
+                              (ref-text (cdr ref-sender-text))
+                              (ref-msg-type (cdr reply-context))
                               (ref-text-formatted (clatter-format-parse ref-text))
                               (preview (if (> (length ref-text-formatted) 60)
                                            (concat (substring ref-text-formatted 0 57) "...")
                                          ref-text-formatted))
-                              (front (propertize (format "↳ %s: " ref-sender) 'face 'shadow)))
+                              (front-nick (if (eq 'action ref-msg-type)
+                                              (format "* %s" ref-sender)
+                                            (format "%s:" ref-sender)))
+                              (front (propertize (format "↳ %s " front-nick) 'face 'shadow)))
                          (add-face-text-property 0 (length preview) 'shadow nil preview)
                          (let ((context (concat front preview "\n"))
                                (map (make-sparse-keymap))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -310,13 +310,18 @@ SERVER-TIME overrides the current time for the timestamp."
          (nick-col (cond
                     ((eq 'action msg-type)
                      (clatter--format-nick-column "*" 'clatter-action sender))
+                    ((eq 'notice msg-type)
+                     (clatter--format-nick-column
+                      (format "-%s-" sender) 'clatter-notice))
                     (t
                      (clatter--format-nick-column
                       (concat (format "<%s>" sender) bot-tag) nick-face sender))))
          (msg-text (prog1 hl-text
                      (cond
                       ((eq 'action msg-type)
-                       (add-face-text-property 0 (length hl-text) 'clatter-action nil hl-text)))
+                       (add-face-text-property 0 (length hl-text) 'clatter-action nil hl-text))
+                      ((eq 'notice msg-type)
+                       (add-face-text-property 0 (length hl-text) 'clatter-notice nil hl-text)))
                      (when is-mention
                        (add-face-text-property 0 (length hl-text) 'clatter-mention nil hl-text))))
          ;; Prepend reply context if available
@@ -347,7 +352,7 @@ SERVER-TIME overrides the current time for the timestamp."
            ((eq 'action msg-type)
             (concat (or reply-line "") nick-col " "
                     (propertize (concat sender " ") 'face 'clatter-action)
-                    hl-text))
+                    msg-text))
            (t
             (concat (or reply-line "") nick-col " " msg-text))))
          (props (list 'clatter-msg-type msg-type
@@ -374,14 +379,9 @@ SERVER-TIME overrides the current time for the timestamp."
   "Insert a /me ACTION from SENDER with TEXT into BUFFER."
   (clatter-insert-generic 'action buffer sender text conn server-time invisible))
 
-(defun clatter-insert-notice (buffer sender text conn &optional invisible)
+(defun clatter-insert-notice (buffer sender text conn &optional server-time invisible)
   "Insert a NOTICE from SENDER with TEXT into BUFFER."
-  (let ((hl-text (clatter-hl-format-text text buffer conn))
-        (prefix (clatter--format-nick-column
-                 (format "-%s-" sender) 'clatter-notice)))
-    (add-face-text-property 0 (length hl-text) 'clatter-notice nil hl-text)
-    (let ((formatted (concat prefix (propertize " " 'face 'clatter-notice) hl-text)))
-      (clatter--insert-message buffer formatted nil nil nil invisible))))
+  (clatter-insert-generic 'notice buffer sender text conn server-time invisible))
 
 (defun clatter-insert-system (buffer text &optional invisible)
   "Insert a system message TEXT into BUFFER."
@@ -705,7 +705,7 @@ Emacs requires `set-window-margins' on the window, not just
                (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf)))
       (clatter-smart-put buf sender-nick 'privmsg))))
 
-(defun clatter-ui--on-notice (conn sender target text)
+(defun clatter-ui--on-notice (conn sender target text server-time)
   "Display SENDER's NOTICE TEXT to TARGET on CONN."
   (let* ((network (clatter-connection-network-id conn))
          (my-nick (clatter-connection-nick conn))
@@ -715,7 +715,7 @@ Emacs requires `set-window-margins' on the window, not just
                   (clatter-get-or-create-buffer network "*server*" 'server)))
          (is-muted (clatter-muted-p sender network)))
     (clatter-ui-setup-buffer-if-needed buf)
-    (clatter-insert-notice buf sender-nick text conn (and is-muted 'muted))
+    (clatter-insert-notice buf sender-nick text conn server-time (and is-muted 'muted))
     (when (and (not is-muted)
                (not (string-equal-ignore-case my-nick sender-nick))
                (eq 'channel (buffer-local-value 'clatter--buffer-type buf))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -309,9 +309,9 @@ SERVER-TIME overrides the current time for the timestamp."
                      (propertize "[bot]" 'face 'clatter-notice) ""))
          (nick-col (clatter--format-nick-column
                     (concat (format "<%s>" sender) bot-tag) nick-face sender))
-         (msg-text (if is-mention
-                       (propertize hl-text 'face 'clatter-mention)
-                     hl-text))
+         (msg-text (prog1 hl-text
+                     (when is-mention
+                       (add-face-text-property 0 (length hl-text) 'clatter-mention nil hl-text))))
          ;; Prepend reply context if available
          (reply-line (when reply-context
                        (let* ((ref-sender (car reply-context))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -306,16 +306,19 @@ SERVER-TIME overrides the current time for the timestamp."
                           (clatter--find-message-by-msgid buffer reply-to)))
          (hl-text (clatter-hl-format-text text buffer conn))
          (bot-tag (if (get-text-property 0 'clatter-bot sender)
-                     (propertize "[bot]" 'face 'clatter-notice) ""))
+                      (propertize "[bot]" 'face 'clatter-notice) ""))
+         (bot-tag-delim (if (string-empty-p bot-tag) "" " "))
          (nick-col (cond
                     ((eq 'action msg-type)
                      (clatter--format-nick-column "*" 'clatter-action sender))
                     ((eq 'notice msg-type)
                      (clatter--format-nick-column
-                      (format "-%s-" sender) 'clatter-notice))
+                      (concat (format "-%s-" sender) bot-tag-delim bot-tag)
+                      'clatter-notice))
                     (t
                      (clatter--format-nick-column
-                      (concat (format "<%s>" sender) bot-tag) nick-face sender))))
+                      (concat (format "<%s>" sender) bot-tag-delim bot-tag)
+                      nick-face sender))))
          (msg-text (prog1 hl-text
                      (cond
                       ((eq 'action msg-type)
@@ -351,7 +354,8 @@ SERVER-TIME overrides the current time for the timestamp."
           (cond
            ((eq 'action msg-type)
             (concat (or reply-line "") nick-col " "
-                    (propertize (concat sender " ") 'face 'clatter-action)
+                    (propertize (concat sender " " bot-tag bot-tag-delim)
+                                'face 'clatter-action)
                     msg-text))
            (t
             (concat (or reply-line "") nick-col " " msg-text))))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -351,7 +351,7 @@ SERVER-TIME overrides the current time for the timestamp."
     (unless (eq buffer (current-buffer))
       (clatter-mark-activity buffer is-mention))))
 
-(defun clatter-insert-action (buffer sender text conn &optional invisible)
+(defun clatter-insert-action (buffer sender text conn &optional server-time invisible)
   "Insert a /me ACTION from SENDER with TEXT into BUFFER."
   (let* ((hl-text (clatter-hl-format-text text buffer conn))
          (prefix (clatter--format-nick-column "*" 'clatter-action sender)))
@@ -363,7 +363,7 @@ SERVER-TIME overrides the current time for the timestamp."
                                (list 'clatter-msg-type 'action
                                      'clatter-sender sender
                                      'clatter-text text)
-                               nil
+                               server-time
                                invisible)
       (unless (eq buffer (current-buffer))
         (clatter-mark-activity buffer nil)))))
@@ -680,7 +680,7 @@ Emacs requires `set-window-margins' on the window, not just
                (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf)))
       (clatter-smart-put buf sender-nick 'privmsg))))
 
-(defun clatter-ui--on-action (conn sender target text _server-time)
+(defun clatter-ui--on-action (conn sender target text server-time)
   "Display SENDER's ACTION TEXT to TARGET on CONN."
   (let* ((network (clatter-connection-network-id conn))
          (my-nick (clatter-connection-nick conn))
@@ -691,7 +691,7 @@ Emacs requires `set-window-margins' on the window, not just
          (buf (clatter-get-or-create-buffer network buf-target))
          (is-muted (clatter-muted-p sender network)))
     (clatter-ui-setup-buffer-if-needed buf)
-    (clatter-insert-action buf sender-nick text conn (and is-muted 'muted))
+    (clatter-insert-action buf sender-nick text conn server-time (and is-muted 'muted))
     (when (and (not is-muted)
                (eq 'channel (buffer-local-value 'clatter--buffer-type buf))
                (not (string-equal-ignore-case my-nick sender-nick))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -84,6 +84,10 @@
   "Face for muted reactions."
   :group 'clatted)
 
+(defface clatter-bot-label-face
+  '((t :foreground "#ffcb6b"))
+  "Face used for the bot label."
+  :group 'clatter)
 ;; --- Nick color palette (hash-based consistent colors) ---
 
 (defcustom clatter-nick-colors
@@ -106,6 +110,13 @@
   (if (string-equal nick (clatter-connection-nick conn))
       'clatter-my-nick
     (list :foreground (clatter-nick-color nick) :weight 'bold)))
+
+;; --- Bot label ---
+
+(defcustom clatter-bot-label "[bot]"
+  "Label added to messages to messages sent by bots."
+  :type 'string
+  :group 'clatter)
 
 ;; --- Message insertion ---
 
@@ -307,7 +318,7 @@ SERVER-TIME overrides the current time for the timestamp."
                           (clatter--find-message-by-msgid buffer reply-to)))
          (hl-text (clatter-hl-format-text text buffer conn))
          (bot-tag (if (get-text-property 0 'clatter-bot sender)
-                      (propertize "[bot]" 'face 'clatter-notice) ""))
+                      (propertize clatter-bot-label 'face 'clatter-bot-label-face) ""))
          (bot-tag-delim (if (string-empty-p bot-tag) "" " "))
          (nick-col (cond
                     ((eq 'action msg-type)
@@ -359,10 +370,9 @@ SERVER-TIME overrides the current time for the timestamp."
          (formatted
           (cond
            ((eq 'action msg-type)
-            (concat (or reply-line "") nick-col " "
-                    (propertize (concat sender " " bot-tag bot-tag-delim)
-                                'face 'clatter-action)
-                    msg-text))
+            (let ((formatted-sender (concat sender " " bot-tag bot-tag-delim)))
+              (add-face-text-property 0 (length formatted-sender) 'clatter-action nil formatted-sender)
+              (concat (or reply-line "") nick-col " " formatted-sender msg-text)))
            (t
             (concat (or reply-line "") nick-col " " msg-text))))
          (props (list 'clatter-msg-type msg-type

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -287,8 +287,8 @@ Returns (sender . text) or nil."
 Bound around history/batch playback so a reconnect backlog does not scan
 and fetch images for hundreds of old messages at once.")
 
-(defun clatter-insert-privmsg (buffer sender text conn &optional server-time invisible)
-  "Insert a PRIVMSG from SENDER with TEXT into BUFFER using CONN context.
+(defun clatter-insert-generic (msg-type buffer sender text conn &optional server-time invisible)
+  "Insert a MSG-TYPE from SENDER with TEXT into BUFFER using CONN context.
 SERVER-TIME overrides the current time for the timestamp."
   (let* ((nick-face (clatter-hl-nick-face sender conn))
          (my-nick (clatter-connection-nick conn))
@@ -307,9 +307,16 @@ SERVER-TIME overrides the current time for the timestamp."
          (hl-text (clatter-hl-format-text text buffer conn))
          (bot-tag (if (get-text-property 0 'clatter-bot sender)
                      (propertize "[bot]" 'face 'clatter-notice) ""))
-         (nick-col (clatter--format-nick-column
-                    (concat (format "<%s>" sender) bot-tag) nick-face sender))
+         (nick-col (cond
+                    ((eq 'action msg-type)
+                     (clatter--format-nick-column "*" 'clatter-action sender))
+                    (t
+                     (clatter--format-nick-column
+                      (concat (format "<%s>" sender) bot-tag) nick-face sender))))
          (msg-text (prog1 hl-text
+                     (cond
+                      ((eq 'action msg-type)
+                       (add-face-text-property 0 (length hl-text) 'clatter-action nil hl-text)))
                      (when is-mention
                        (add-face-text-property 0 (length hl-text) 'clatter-mention nil hl-text))))
          ;; Prepend reply context if available
@@ -335,8 +342,15 @@ SERVER-TIME overrides the current time for the timestamp."
                                                       'help-echo "Click or press RET to jump to reply context")
                                                 context)
                            context))))
-         (formatted (concat (or reply-line "") nick-col " " msg-text))
-         (props (list 'clatter-msg-type 'privmsg
+         (formatted
+          (cond
+           ((eq 'action msg-type)
+            (concat (or reply-line "") nick-col " "
+                    (propertize (concat sender " ") 'face 'clatter-action)
+                    hl-text))
+           (t
+            (concat (or reply-line "") nick-col " " msg-text))))
+         (props (list 'clatter-msg-type msg-type
                       'clatter-sender sender
                       'clatter-text text)))
     (when msgid
@@ -351,25 +365,14 @@ SERVER-TIME overrides the current time for the timestamp."
     (unless (eq buffer (current-buffer))
       (clatter-mark-activity buffer is-mention))))
 
+(defun clatter-insert-privmsg (buffer sender text conn &optional server-time invisible)
+  "Insert a PRIVMSG from SENDER with TEXT into BUFFER using CONN context.
+SERVER-TIME overrides the current time for the timestamp."
+  (clatter-insert-generic 'privmsg buffer sender text conn server-time invisible))
+
 (defun clatter-insert-action (buffer sender text conn &optional server-time invisible)
   "Insert a /me ACTION from SENDER with TEXT into BUFFER."
-  (let* ((hl-text (clatter-hl-format-text text buffer conn))
-         (msgid (get-text-property 0 'clatter-msgid text))
-         (prefix (clatter--format-nick-column "*" 'clatter-action sender)))
-    (add-face-text-property 0 (length hl-text) 'clatter-action nil hl-text)
-    (let ((props (list 'clatter-msg-type 'action
-                       'clatter-sender sender
-                       'clatter-text text))
-          (formatted (concat prefix " "
-                             (propertize (concat sender " ") 'face 'clatter-action)
-                             hl-text)))
-      (when msgid
-        (setq props (plist-put props 'clatter-msgid msgid)))
-      (clatter--insert-message buffer formatted nil props
-                               server-time
-                               invisible)
-      (unless (eq buffer (current-buffer))
-        (clatter-mark-activity buffer nil)))))
+  (clatter-insert-generic 'action buffer sender text conn server-time invisible))
 
 (defun clatter-insert-notice (buffer sender text conn &optional invisible)
   "Insert a NOTICE from SENDER with TEXT into BUFFER."

--- a/tests/test-handlers.el
+++ b/tests/test-handlers.el
@@ -21,6 +21,21 @@
             (should (equal (nth 3 args) "hello everyone"))))
       (clatter-test-cleanup))))
 
+(ert-deftest clatter-test-dispatch-privmsg-ctcp-action ()
+  "PRIVMSG CTCP ACTION dispatches to clatter-action-hook."
+  (let ((conn (clatter-test-make-connection)))
+    (unwind-protect
+        (let ((calls (clatter-test-capture-hook clatter-action-hook
+                       (clatter-dispatch-message
+                        conn (clatter-test-parse
+                              ":alice!~a@host PRIVMSG #emacs :ACTION greets everyone")))))
+          (should (= (length calls) 1))
+          (let ((args (car calls)))
+            (should (equal (nth 1 args) '("alice" "~a" "host")))
+            (should (equal (nth 2 args) "#emacs"))
+            (should (equal (nth 3 args) "greets everyone"))))
+      (clatter-test-cleanup))))
+
 (ert-deftest clatter-test-dispatch-privmsg-dm ()
   "PRIVMSG to our nick dispatches with our nick as target."
   (let ((conn (clatter-test-make-connection "testnet" "testnick")))
@@ -29,6 +44,20 @@
                        (clatter-dispatch-message
                         conn (clatter-test-parse
                               ":bob!~b@host PRIVMSG testnick :hey there")))))
+          (should (= (length calls) 1))
+          (let ((args (car calls)))
+            (should (equal (nth 1 args) '("bob" "~b" "host")))
+            (should (equal (nth 2 args) "testnick"))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-dispatch-privmsg-dm-ctcp-action ()
+  "PRIVMSG CTCP ACTION to our nick dispatches with our nick as target."
+  (let ((conn (clatter-test-make-connection "testnet" "testnick")))
+    (unwind-protect
+        (let ((calls (clatter-test-capture-hook clatter-action-hook
+                       (clatter-dispatch-message
+                        conn (clatter-test-parse
+                              ":bob!~b@host PRIVMSG testnick :ACTION waves")))))
           (should (= (length calls) 1))
           (let ((args (car calls)))
             (should (equal (nth 1 args) '("bob" "~b" "host")))
@@ -219,6 +248,20 @@
             (should (get-text-property 0 'clatter-bot sender))))
       (clatter-test-cleanup))))
 
+(ert-deftest clatter-test-dispatch-bot-tag-ctcp-action ()
+  "PRIVMSG CTCP ACTION with bot tag marks sender."
+  (let ((conn (clatter-test-make-connection)))
+    (unwind-protect
+        (let ((calls (clatter-test-capture-hook clatter-action-hook
+                       (clatter-dispatch-message
+                        conn (clatter-test-parse
+                              "@bot :botuser!~b@host PRIVMSG #emacs :ACTION automated msg")))))
+          (should (= (length calls) 1))
+          (let* ((args (car calls))
+                 (sender (clatter-prefix-nick (nth 1 args))))
+            (should (get-text-property 0 'clatter-bot sender))))
+      (clatter-test-cleanup))))
+
 ;; --- Reply/Thread tags ---
 
 (ert-deftest clatter-test-dispatch-reply-tag ()
@@ -229,6 +272,21 @@
                        (clatter-dispatch-message
                         conn (clatter-test-parse
                               "@+draft/reply=msg999;msgid=msg1000 :alice!~a@host PRIVMSG #emacs :replying")))))
+          (should (= (length calls) 1))
+          (let* ((args (car calls))
+                 (text (nth 3 args)))
+            (should (equal (get-text-property 0 'clatter-reply-to text) "msg999"))
+            (should (equal (get-text-property 0 'clatter-msgid text) "msg1000"))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-dispatch-reply-tag-ctcp-action ()
+  "PRIVMSG CTCP ACTION with draft/reply tag attaches reply-to property."
+  (let ((conn (clatter-test-make-connection)))
+    (unwind-protect
+        (let ((calls (clatter-test-capture-hook clatter-action-hook
+                       (clatter-dispatch-message
+                        conn (clatter-test-parse
+                              "@+draft/reply=msg999;msgid=msg1000 :alice!~a@host PRIVMSG #emacs :ACTION replying")))))
           (should (= (length calls) 1))
           (let* ((args (car calls))
                  (text (nth 3 args)))
@@ -278,6 +336,28 @@
                        (clatter-dispatch-message
                         conn (clatter-test-parse
                               ":alice!~a@host PRIVMSG @#emacs :ops only message")))))
+          (should (= (length calls) 1))
+          (let* ((args (car calls))
+                 (target (nth 2 args))
+                 (text (nth 3 args)))
+            ;; Target should be #emacs (prefix stripped)
+            (should (equal target "#emacs"))
+            ;; Text should contain [ops] prefix
+            (should (string-match-p "\\[ops\\]" text))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-dispatch-statusmsg-ctcp-action ()
+  "PRIVMSG CTCP ACTION to @#channel strips prefix and adds label."
+  (let ((conn (clatter-test-make-connection)))
+    ;; Set up ISUPPORT with STATUSMSG
+    (let ((isup (make-hash-table :test 'equal)))
+      (puthash "STATUSMSG" "@+" isup)
+      (setf (clatter-connection-isupport conn) isup))
+    (unwind-protect
+        (let ((calls (clatter-test-capture-hook clatter-action-hook
+                       (clatter-dispatch-message
+                        conn (clatter-test-parse
+                              ":alice!~a@host PRIVMSG @#emacs :ACTION ops only action")))))
           (should (= (length calls) 1))
           (let* ((args (car calls))
                  (target (nth 2 args))

--- a/tests/test-handlers.el
+++ b/tests/test-handlers.el
@@ -21,6 +21,25 @@
             (should (equal (nth 3 args) "hello everyone"))))
       (clatter-test-cleanup))))
 
+(ert-deftest clatter-test-dispatch-privmsg-time-tag ()
+  "PRIVMSG with @time tag dispatches to clatter-privmsg-hook."
+  (let ((conn (clatter-test-make-connection)))
+    (unwind-protect
+        (let* ((time "2011-10-19T16:40:51.620Z")
+               (time-tag (concat "@time=" time))
+               (calls (clatter-test-capture-hook
+                       clatter-privmsg-hook
+                       (clatter-dispatch-message
+                        conn (clatter-test-parse
+                              (concat time-tag " :alice!~a@host PRIVMSG #emacs :hello everyone"))))))
+          (should (= (length calls) 1))
+          (let ((args (car calls)))
+            (should (equal (nth 1 args) '("alice" "~a" "host")))
+            (should (equal (nth 2 args) "#emacs"))
+            (should (equal (nth 3 args) "hello everyone"))
+            (should (equal (nth 4 args) (clatter-parse-iso8601 time)))))
+      (clatter-test-cleanup))))
+
 (ert-deftest clatter-test-dispatch-privmsg-ctcp-action ()
   "PRIVMSG CTCP ACTION dispatches to clatter-action-hook."
   (let ((conn (clatter-test-make-connection)))
@@ -34,6 +53,25 @@
             (should (equal (nth 1 args) '("alice" "~a" "host")))
             (should (equal (nth 2 args) "#emacs"))
             (should (equal (nth 3 args) "greets everyone"))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-dispatch-privmsg-ctcp-action-time-tag ()
+  "PRIVMSG CTCP ACTION with @time tag dispatches to clatter-action-hook."
+  (let ((conn (clatter-test-make-connection)))
+    (unwind-protect
+        (let* ((time "2011-10-19T16:40:51.620Z")
+               (time-tag (concat "@time=" time))
+               (calls (clatter-test-capture-hook
+                       clatter-action-hook
+                       (clatter-dispatch-message
+                        conn (clatter-test-parse
+                              (concat time-tag " :alice!~a@host PRIVMSG #emacs :ACTION greets everyone"))))))
+          (should (= (length calls) 1))
+          (let ((args (car calls)))
+            (should (equal (nth 1 args) '("alice" "~a" "host")))
+            (should (equal (nth 2 args) "#emacs"))
+            (should (equal (nth 3 args) "greets everyone"))
+            (should (equal (nth 4 args) (clatter-parse-iso8601 time)))))
       (clatter-test-cleanup))))
 
 (ert-deftest clatter-test-dispatch-privmsg-dm ()


### PR DESCRIPTION
CTCP ACTIONs and NOTICEs should be treated in a similar way to regular PRIVMSG:

- The _server-time_ tag `time` can be parsed and passed on to the hooks if available (the machinery for this already partially exists)
- The `msgid` can be affixed to the ACTION/NOTICE message, if available
- The bot tag/property may be affixed, in case the sender is a bot
- Reply tags may be also affixed
- Replies and reactions (if available) may be added 
- All formatting should be additive, by the priority order: `mention > action | notice > IRC text formatting`