### PR TITLE
Parse formatting codes in channel topics within the channel list

### DIFF
--- a/clatter-list.el
+++ b/clatter-list.el
@@ -14,6 +14,7 @@
 
 (require 'cl-lib)
 (require 'clatter-model)
+(require 'clatter-format)
 
 ;; --- State ---
 
@@ -32,7 +33,11 @@ Each entry is (CHANNEL USERS TOPIC).")
 (defun clatter-list--on-entry (conn channel users topic)
   "Accumulate a LIST entry: CHANNEL with USERS and TOPIC on CONN."
   (when (eq conn clatter-list--conn)
-    (push (list channel (string-to-number users) topic)
+    (push (list channel
+                (string-to-number users)
+                (condition-case nil
+                    (clatter-format-parse topic)
+                  (error topic)))
           clatter-list--entries)))
 
 (defun clatter-list--on-end (conn)


### PR DESCRIPTION
We already format the topics in the channel buffers. No reason why we shouldn't format them in the list view as well.

The `condition-case` is added in the event something goes wrong, in which case we fall back to displaying the string as-is.

Preview (on OFTC):

<img width="2398" height="1720" alt="List with formatting codes interpolated" src="https://github.com/user-attachments/assets/1ba12d04-ad93-4cae-83f7-213c717e81c3" />
