### PR TITLE
Stricter & more configurable mention matching

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -360,6 +360,39 @@ Supports glob wildcards (* and ?)."
 (defconst clatter-max-irc-line-length 510
   "Maximum IRC line length (512 minus CR LF).")
 
+;; --- Matching functions ---
+
+(defvar clatter-nick-syntax-table
+  (let ((table (copy-syntax-table))
+        (extra-nick-chars '(?\[ ?\] ?{ ?} ?| ?- ?\\ ?` ?^ ?_)))
+    (dolist (char extra-nick-chars)
+      (modify-syntax-entry char "w" table))
+    table)
+  "Syntax table for IRC nicknames.")
+
+(defun clatter-nick-match-p (nick text)
+  "Return t if NICK is in TEXT; nil otherwise."
+  (with-syntax-table clatter-nick-syntax-table
+    (string-match-p (rx bow (literal nick) eow) text)))
+
+(defun clatter-substring-match-p (substring text)
+  "Return t if SUBSTRING is in TEXT; nil otherwise."
+  (string-match-p (regexp-quote substring) text))
+
+(defcustom clatter-mention-p-function #'clatter-nick-match-p
+  "The function used to check for mentions.
+The function must accept two arguments: the needle (nick/substring)
+and the haystack (text), and return non-nil if a match is found."
+  :type '(choice (const :tag "Whole Word/Nick Match" clatter-nick-match-p)
+                 (const :tag "Substring Match" clatter-substring-match-p)
+                 (function :tag "Other Function"))
+  :group 'clatter)
+
+(defun clatter-mention-p (nick text)
+  "Return t if NICK is in TEXT; nil otherwise.
+Uses CLATTER-MENTION-P-FUNCTION."
+  (funcall clatter-mention-p-function nick text))
+
 ;; --- Helper functions ---
 
 (defun clatter-network-get (network key &optional default)

--- a/clatter-hl-nicks.el
+++ b/clatter-hl-nicks.el
@@ -170,14 +170,6 @@ deterministic, hash-based `clatter-nick-color-N' palette face."
 
 ;; --- In-text highlighting ---
 
-(defvar clatter-hl-nicks-syntax-table
-  (let ((table (copy-syntax-table))
-        (extra-nick-chars '(?\[ ?\] ?{ ?} ?| ?- ?\\ ?` ?^)))
-    (dolist (char extra-nick-chars)
-      (modify-syntax-entry char "w" table))
-    table)
-  "Syntax table for IRC nicknames.")
-
 (defun clatter-hl-nicks-in-string (text buffer)
   "Return TEXT with nicks from BUFFER's nick list highlighted.
 Only highlights nicks that are currently in the channel."
@@ -187,9 +179,9 @@ Only highlights nicks that are currently in the channel."
     (with-current-buffer buffer
       (when clatter--nick-list
         (let ((nicks (clatter-hl--collect-nicks buffer)))
-          (with-syntax-table clatter-hl-nicks-syntax-table
+          (with-syntax-table clatter-nick-syntax-table
             (dolist (nick nicks)
-              (let ((re (concat "\\b" (regexp-quote nick) "\\b")))
+              (let ((re (rx bow (literal nick) eow)))
                 (setq text (clatter-hl--propertize-matches
                             text re
                             (list 'face (clatter-hl-nick-face-symbol nick)

--- a/clatter-notify.el
+++ b/clatter-notify.el
@@ -282,8 +282,7 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
               ((and clatter-notify-on-mention
                     (or is-reply-to-me
                         (and my-nick
-                             (string-match-p (regexp-quote (downcase my-nick))
-                                             text-lower))))
+                             (clatter-mention-p (downcase my-nick) text-lower))))
                'mention)
               ;; Keyword
               ((and clatter-notify-on-keyword

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -297,9 +297,7 @@ SERVER-TIME overrides the current time for the timestamp."
                           ;; do not highlight self-mentions
                           (not (string-equal-ignore-case sender my-nick))
                           (or is-reply-to-me
-                              (string-match-p
-                               (regexp-quote (downcase my-nick))
-                               (downcase text)))))
+                              (clatter-mention-p (downcase my-nick) (downcase text)))))
          (reply-to (get-text-property 0 'clatter-reply-to text))
          (msgid (get-text-property 0 'clatter-msgid text))
          (reply-context (when reply-to

--- a/tests/test-pr-integration.el
+++ b/tests/test-pr-integration.el
@@ -184,6 +184,17 @@
         (should-not (clatter-ui--on-numeric conn "221" '("testnick" "+iw")))
       (clatter-test-cleanup))))
 
+;; --- #46: Stricter nick/mention matching ---
+
+(ert-deftest clatter-test-mention-p-functions ()
+  (should (clatter-nick-match-p "alcor" "alcor: hello!"))
+  (should (clatter-nick-match-p "alcor`" "alcor`: hello!"))
+  (should (clatter-nick-match-p "alcor^" "hello alcor^!"))
+  (should (clatter-nick-match-p "alcor" "like <alcor> said"))
+  (should (clatter-nick-match-p "alcor`" "like <alcor`> said"))
+  (should-not (clatter-nick-match-p "alcor" "metalcore music"))
+  (should (clatter-substring-match-p "alcor" "metalcore music")))
+
 (provide 'test-pr-integration)
 
 ;;; test-pr-integration.el ends here


### PR DESCRIPTION
The substring match procedure currently in-use is a bit too permissive - e.g. if my nick is `alcor`, then `metalcore` is considered a mention because word boundaries aren't taken into consideration when using a simple substring match.

This PR makes this concern customizable/configurable; The default is word-boundary-based mention matching, the same used for applying nick faces in hl-nicks.