### PR TITLE
Make /mode useful in *server* buffers

### DIFF
--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -164,10 +164,29 @@ INPUT is the full string including the leading /."
   "Handle /mode [MODE] [ARGS]."
   (let ((conn (clatter--require-conn)))
     (when conn
-      (let ((target (or clatter--target "")))
-        (if (> (length args) 0)
-            (clatter-send conn (format "MODE %s %s" target args))
-          (clatter-send conn (clatter-irc-mode target)))))))
+      (let* ((my-nick (clatter-connection-nick conn))
+             (target clatter--target)
+             (no-target (string-empty-p target))
+             (other-target (not no-target))
+             (server-target (and other-target (string= target "*server*"))))
+        (cond
+         (server-target
+          ;; If we're in a server buffer, assume TARGET is MY-NICK if no arguments
+          ;; are given.
+          ;; If arguments are given, assume TARGET is the first argument, with
+          ;; the MODE arguments being the remaining trailing arguments.
+          (let (mode-args)
+            (if (string-empty-p args)
+                (setq target my-nick)
+              (let* ((parts (split-string args " " t))
+                     (head (car parts))
+                     (rest (cdr parts)))
+                (setq target head)
+                (setq mode-args rest)))
+            (clatter-send conn (apply #'clatter-irc-mode target mode-args))))
+         (other-target
+          ;; If we're in a channel buffer, assume TARGET is the channel.
+          (clatter-send conn (apply #'clatter-irc-mode target (string-split args " " t)))))))))
 
 (defun clatter-cmd-whois (args)
   "Request WHOIS for the NICK in ARGS."


### PR DESCRIPTION
Currently, using `/mode` in the server buffer binds the target to `*server*`, resulting in `MODE *server* …`, which isn't very useful.

This reworks -cmd-mode, giving it the following (more useful) behavior:

- Bare (no arguments) `/mode` in the *server buffer* is equivalent to `/mode my-nick` i.e. this becomes a shorthand for querying one's usermodes
- `/mode <target> [args...]` in the *server buffer* is the "free form" variant i.e. allows the user to set arbitrary modes on *target*.

`/mode` in channel buffers always binds the target to the current channel (this behavior is retained).