### PR TITLE
Output 401/403/404 numerics + improve signalling own AWAY status

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -1150,11 +1150,19 @@ COMMAND is the numeric reply code, PARAMS its parameters on CONN."
   (pcase command
     ;; --- Informational numerics ---
     ((or "001" "002" "003" "004" "242" "251" "252" "253" "254" "255"
-         "265" "266" "305" "306")
+         "265" "266")
      (let* ((network (clatter-connection-network-id conn))
             (buf (clatter-get-server-buffer network)))
        (when buf
          (clatter-insert-system buf (string-join (cdr params) " ")))))
+    ((or "305" "306") ;  RPL_UNAWAY, RPL_NOWAWAY
+     (let* ((network (clatter-connection-network-id conn))
+            (buf (clatter-get-server-buffer network))
+            (msg (string-join (cdr params) " ")))
+       (when buf
+         (clatter-insert-system buf msg))
+       (dolist (buf (clatter-channel-buffers network))
+         (clatter-insert-system buf msg))))
     ;; --- MODE numerics ---
     ("221"   ; RPL_UMODEIS
      (let* ((network (clatter-connection-network-id conn))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -1148,14 +1148,14 @@ COMMAND is the CTCP type (VERSION, PING, etc.), REPLY-TEXT is the response."
   "Handle informational and MODE-related numerics for UI.
 COMMAND is the numeric reply code, PARAMS its parameters on CONN."
   (pcase command
-    ;; -- Informational numerics ---
+    ;; --- Informational numerics ---
     ((or "001" "002" "003" "004" "242" "251" "252" "253" "254" "255"
          "265" "266" "305" "306")
      (let* ((network (clatter-connection-network-id conn))
             (buf (clatter-get-server-buffer network)))
        (when buf
          (clatter-insert-system buf (string-join (cdr params) " ")))))
-    ;; -- MODE numerics ---
+    ;; --- MODE numerics ---
     ("221"   ; RPL_UMODEIS
      (let* ((network (clatter-connection-network-id conn))
             (buf (clatter-get-server-buffer network))
@@ -1178,7 +1178,11 @@ COMMAND is the numeric reply code, PARAMS its parameters on CONN."
        (when buf
          (clatter-insert-system
           buf (format "%s was created at %s"
-                      channel (format-time-string "%F %T" ctime))))))))
+                      channel (format-time-string "%F %T" ctime))))))
+    ((or "401" "403"  ; ERR_NOSUCHNICK, ERR_NOSUCHCHANNEL
+         "404")       ; ERR_CANNOTSENDTOCHAN
+     (let ((buf (current-buffer)))
+       (clatter-insert-system buf (string-join (reverse (cdr params)) " "))))))
 
 ;; --- Channel preview on hover (eldoc) ---
 


### PR DESCRIPTION
- ERR_NOSUCHNICK (401), ERR_NOSUCHCHANNEL (403), and ERR_CANNOTSENDTOCHAN (404) are useful errors to display in case we typo a nick while WHOIS'ing, or if we attempt to use some some formatting codes or other characters that are rejected by network/channel rules

- Make RPL_UNAWAY (305) and RPL_NOWAWAY (306) mirror the behavior of AWAY (-on-away) - i.e. echo our own AWAY status to all buffers we're joined into + the server buffer, so we get immediate UI feedback for our `/away …`