### PR TITLE
Apply formatting to more user-defined messages

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -855,7 +855,7 @@ Emacs requires `set-window-margins' on the window, not just
       (clatter-nick-remove buf kicked)
       (clatter-insert-system buf
                              (format "%s was kicked by %s%s" kicked sender-nick
-                                     (if reason (format " (%s)" reason) ""))
+                                     (if reason (format " (%s)" (clatter-format-parse reason)) ""))
                              (append (if is-muted '(kick muted) '(kick))
                                      (and (not is-muted)
                                           (not (string-equal-ignore-case my-nick sender-nick))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -789,7 +789,7 @@ Emacs requires `set-window-margins' on the window, not just
         (clatter-nick-remove buf sender-nick)
         (clatter-insert-system buf
                                (format "%s has quit%s" sender-nick
-                                       (if message (format " (%s)" message) ""))
+                                       (if message (format " (%s)" (clatter-format-parse message)) ""))
                                (append (if is-muted '(quit muted) '(quit))
                                        (and (not is-muted)
                                             (not (string-equal-ignore-case my-nick sender-nick))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -918,7 +918,8 @@ Emacs requires `set-window-margins' on the window, not just
                      (buffer-local-value 'clatter--nick-list buf))
         (clatter-insert-system buf
                                (if away-msg
-                                   (format "%s is away: %s" sender-nick away-msg)
+                                   (format "%s is away: %s"
+                                           sender-nick (clatter-format-parse away-msg))
                                  (format "%s is back" sender-nick))
                                (append (if is-muted '(away muted) '(away))
                                        (and (not is-muted)

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -768,7 +768,7 @@ Emacs requires `set-window-margins' on the window, not just
       (clatter-nick-remove buf sender-nick)
       (clatter-insert-system buf
                              (format "%s has left %s%s" sender-nick channel
-                                     (if message (format " (%s)" message) ""))
+                                     (if message (format " (%s)" (clatter-format-parse message)) ""))
                              (append (if is-muted '(part muted) '(part))
                                      (and (not is-muted)
                                           (not (string-equal-ignore-case my-nick sender-nick))


### PR DESCRIPTION
Interpret formatting codes in AWAY, PART, QUIT and KICK.

These may contain formatting codes as may be seen occasionally on Libera.Chat, and perhaps more frequently on other networks. 