### PR TITLE
Improve customizability of the mode keymap

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -602,16 +602,6 @@ If the input contains multiple lines and exceeds
                             clatter-track-in-buffer-mode-line)
                    (list 'clatter-track-mode-line-item))
                  (list " " 'mode-line-end-spaces)))
-    ;; Key bindings for input
-    (let ((map (make-sparse-keymap)))
-      (set-keymap-parent map clatter-mode-map)
-      (define-key map (kbd "RET") #'clatter-send-input)
-      (define-key map (kbd "TAB") #'completion-at-point)
-      (define-key map (kbd "M-p") #'clatter-set-prev-input)
-      (define-key map (kbd "M-n") #'clatter-set-next-input)
-      (define-key map (kbd "C-a") #'clatter-bol)
-      (define-key map [home] #'clatter-bol)
-      (use-local-map map))
     ;; Ensure window margins are synced for timestamp display
     (add-hook 'window-configuration-change-hook
               #'clatter--sync-window-margins nil t)
@@ -1384,7 +1374,14 @@ Requires the server to support the message-tags capability."
   (add-hook 'clatter-ctcp-reply-hook #'clatter-ui--on-ctcp-reply)
   (add-hook 'clatter-numeric-hook #'clatter-ui--on-numeric)
   (add-hook 'clatter-typing-hook #'clatter-ui--on-typing)
-  (add-hook 'clatter-mode-hook #'clatter-ui--setup-eldoc))
+  (add-hook 'clatter-mode-hook #'clatter-ui--setup-eldoc)
+  ;; Key bindings for input
+  (define-key clatter-mode-map (kbd "RET") #'clatter-send-input)
+  (define-key clatter-mode-map (kbd "TAB") #'completion-at-point)
+  (define-key clatter-mode-map (kbd "M-p") #'clatter-set-prev-input)
+  (define-key clatter-mode-map (kbd "M-n") #'clatter-set-next-input)
+  (define-key clatter-mode-map (kbd "C-a") #'clatter-bol)
+  (define-key clatter-mode-map [home] #'clatter-bol))
 
 ;; Auto-init when loaded
 (clatter-ui-init)


### PR DESCRIPTION
Using a local keymap in *clatter-ui-setup-buffer* has a significant disadvantage: It makes it impossible for a user to override/remap clatter's keybinds.

A simple use case: I want to remap *RET* to something else (e.g. in a similar way to the Erc [sample config](https://www.gnu.org/software/emacs/manual/html_node/erc/Sample-Configuration.html)), because *RET* is too easy to fat-finger by accident. The local keymap here precludes that, since it's private to the `clatter-ui-setup-buffer` procedure and can't be accessed from the outside.

I propose simply registering the keybinds on the mode keymap during module setup, the way the *-actions* module does. This way the end-user can perform adjustments to the predefined keybinds after the -ui module loads -- e.g. with *use-package*:

```elisp
(use-package clatter
  …
  :bind (:map clatter-mode-map
              ("RET"     . nil)                       ;; This can be changed with this PR
              ("M-RET"   . clatter-send-input)        ;; Now it's harder to send a line by accident
              ("C-c ."   . clatter-track-switch)
              ("C-c C-." . clatter-track-switch)
              ("C-c :"   . clatter-track-list)
              ("C-c n"   . clatter-nicklist-toggle)
              ("C-c C-n" . clatter-nicklist-toggle))
  :config …)
```