### PR TITLE
Support left-side timestamps

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -110,6 +110,15 @@ See `format-time-string' for format specifiers."
   :type 'string
   :group 'clatter)
 
+(defcustom clatter-timestamp-side 'right
+  "Side of the window where message timestamps are displayed.
+The value `left' uses the left margin, `right' uses the right margin,
+and nil disables margin timestamps."
+  :type '(choice (const :tag "Left margin" left)
+                 (const :tag "Right margin" right)
+                 (const :tag "Disabled" nil))
+  :group 'clatter)
+
 (defcustom clatter-fill-column 80
   "Column at which to wrap messages in channel buffers."
   :type 'integer

--- a/clatter-model.el
+++ b/clatter-model.el
@@ -327,9 +327,10 @@ Installed buffer-locally on `kill-buffer-hook' by `clatter-mode'."
   (setq-local word-wrap t)
   (setq-local truncate-lines nil)
   (setq-local wrap-prefix (make-string (1+ clatter-nick-column-width) ?\s))
-  ;; Right margin for timestamps (always on first visual line)
+  ;; Margin for timestamps (always on first visual line)
   (let ((ts-width (1+ (length (format-time-string clatter-timestamp-format)))))
-    (setq-local right-margin-width ts-width))
+    (setq-local left-margin-width (if (eq clatter-timestamp-side 'left) ts-width 0))
+    (setq-local right-margin-width (if (eq clatter-timestamp-side 'right) ts-width 0)))
   ;; Per-buffer setup (kept here, not on a global hook, so that loading
   ;; clatter has no side effects).
   (add-hook 'kill-buffer-hook #'clatter--on-kill-buffer nil t)

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -197,13 +197,16 @@ append at the bottom like a traditional IRC client."
               (insert text "\n")
               (when ts-str
                 (let ((ov (make-overlay start (1+ start) nil t)))
-                  (overlay-put ov 'before-string
-                               ;; Apply 'default face after 'clatter-timestamp to ensure that no
-                               ;; unwanted face properties are inherited from text which might be
-                               ;; at point.
-                               (propertize " " 'display
-                                           `((margin right-margin)
-                                             ,(propertize ts-str 'face '(clatter-timestamp default)))))
+                  (when clatter-timestamp-side
+                    (overlay-put ov 'before-string
+                                 ;; Apply 'default face after 'clatter-timestamp to ensure that no
+                                 ;; unwanted face properties are inherited from text which might be
+                                 ;; at point.
+                                 (propertize " " 'display
+                                             `((margin ,(if (eq clatter-timestamp-side 'left)
+                                                            'left-margin
+                                                          'right-margin))
+                                               ,(propertize ts-str 'face '(clatter-timestamp default))))))
                   (overlay-put ov 'clatter-timestamp t)
                   (overlay-put ov 'invisible invisible)))
               (add-text-properties start (point)
@@ -621,13 +624,17 @@ If the input contains multiple lines and exceeds
 (defun clatter--sync-window-margins ()
   "Ensure the current window has correct margins for timestamp display.
 Emacs requires `set-window-margins' on the window, not just
-`right-margin-width' on the buffer."
+the buffer margin-width variables."
   (when (and (derived-mode-p 'clatter-mode)
              (eq (current-buffer) (window-buffer)))
     (let ((ts-width (1+ (length (format-time-string clatter-timestamp-format)))))
-      (set-window-margins (selected-window)
-                          (car (window-margins))
-                          ts-width))))
+      (pcase clatter-timestamp-side
+        ('left
+         (set-window-margins (selected-window) ts-width 0))
+        ('right
+         (set-window-margins (selected-window) 0 ts-width))
+        (_
+         (set-window-margins (selected-window) 0 0))))))
 
 ;; --- Nick completion ---
 

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -6,6 +6,45 @@
 (require 'clatter-ui)
 (require 'clatter-nicklist)
 
+;; --- Timestamp margins ---
+
+(ert-deftest clatter-test-timestamp-side-left-margin ()
+  "Left timestamp side configures the left margin."
+  (let ((clatter-timestamp-side 'left)
+        (clatter-timestamp-format "%H:%M"))
+    (with-temp-buffer
+      (clatter-mode)
+      (should (= left-margin-width 6))
+      (should (= right-margin-width 0)))))
+
+(ert-deftest clatter-test-timestamp-side-right-margin ()
+  "Right timestamp side configures the right margin."
+  (let ((clatter-timestamp-side 'right)
+        (clatter-timestamp-format "%H:%M"))
+    (with-temp-buffer
+      (clatter-mode)
+      (should (= left-margin-width 0))
+      (should (= right-margin-width 6)))))
+
+(ert-deftest clatter-test-timestamp-side-sync-clears-stale-window-margin ()
+  "Window margin sync clears the previous timestamp side."
+  (let ((clatter-timestamp-format "%H:%M"))
+    (with-temp-buffer
+      (clatter-mode)
+      (switch-to-buffer (current-buffer))
+      (let ((clatter-timestamp-side 'right))
+        (clatter--sync-window-margins)
+        (should-not (car (window-margins)))
+        (should (= (cdr (window-margins)) 6)))
+      (let ((clatter-timestamp-side 'left))
+        (clatter--sync-window-margins)
+        (should (= (car (window-margins)) 6))
+        (should-not (cdr (window-margins))))
+      (let ((clatter-timestamp-side nil))
+        (clatter--sync-window-margins)
+        (should-not (car (window-margins)))
+        (should-not (cdr (window-margins)))))))
+
 ;; --- Channel-at-point detection ---
 
 (ert-deftest clatter-test-channel-at-point-hash ()


### PR DESCRIPTION
## Summary
- add clatter-timestamp-side to choose left, right, or no margin timestamp display
- update buffer and window margin syncing to follow the configured side
- clear stale window margins when switching sides

## Tests
- emacs -Q --batch --eval "(setq load-prefer-newer t)" -L /home/trev/Workspace/clatter.el -L /home/trev/Workspace/clatter.el/tests -l ert -l test-helper -l test-ui --eval "(ert-run-tests-batch-and-exit \"clatter-test-timestamp-side\")"