### PR TITLE
Fill inserted messages

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -195,6 +195,12 @@ append at the bottom like a traditional IRC client."
                    (wrap-prefix (make-string wrap-col ?\s))
                    (start (point)))
               (insert text "\n")
+              (when (and clatter-fill-column
+                         (> clatter-fill-column wrap-col))
+                (let ((fill-column clatter-fill-column)
+                      (fill-prefix wrap-prefix)
+                      (adaptive-fill-mode nil))
+                  (fill-region start (1- (point)))))
               (when ts-str
                 (let ((ov (make-overlay start (1+ start) nil t)))
                   (overlay-put ov 'before-string

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -6,6 +6,21 @@
 (require 'clatter-ui)
 (require 'clatter-nicklist)
 
+;; --- Message filling ---
+
+(ert-deftest clatter-test-insert-message-fills-at-fill-column ()
+  "Inserted messages are hard-wrapped at `clatter-fill-column'."
+  (let ((clatter-fill-column 40)
+        (clatter-nick-column-width 7))
+    (with-temp-buffer
+      (clatter--insert-message
+       (current-buffer)
+       "<alice> this is a long message that should wrap around the configured fill column"
+       t)
+      (should
+       (equal (buffer-string)
+              "<alice> this is a long message that\n        should wrap around the\n        configured fill column\n")))))
+
 ;; --- Channel-at-point detection ---
 
 (ert-deftest clatter-test-channel-at-point-hash ()


### PR DESCRIPTION
## Summary
- hard-fill inserted messages at clatter-fill-column
- keep continuation lines aligned to the message text column

## Tests
- emacs -Q --batch --eval "(setq load-prefer-newer t)" -L /home/trev/Workspace/clatter.el -L /home/trev/Workspace/clatter.el/tests -l ert -l test-helper -l test-ui --eval "(ert-run-tests-batch-and-exit \"clatter-test-insert-message-fills\")"