### PR TITLE
CI: use HTTPS for Melpazoid MELPA archive

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -15,6 +15,8 @@ jobs:
       run: |
         sudo apt-get install emacs && emacs --version
         git clone https://github.com/riscy/melpazoid.git ~/melpazoid
+        grep -q 'http://melpa.org/packages/' ~/melpazoid/melpazoid/melpazoid.py
+        sed -i 's|http://melpa.org/packages/|https://melpa.org/packages/|' ~/melpazoid/melpazoid/melpazoid.py
     - name: Run
       env:
         LOCAL_REPO: ${{ github.workspace }}


### PR DESCRIPTION
Melpazoid currently generates _requirements.el with the HTTP MELPA archive URL. Recent CI runs fail while building the Melpazoid Docker image at that requirements step, and the archive endpoint now redirects HTTP to HTTPS.

Patch the cloned Melpazoid checker in CI before it writes _requirements.el, with a grep guard so the workflow fails loudly if upstream Melpazoid changes the target line.