### PR TITLE
Use package version in CTCP VERSION replies

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -13,6 +13,14 @@
 
 (require 'auth-source)
 
+;; --- Version ---
+
+(defvar clatter-version
+  (or (package-get-version) "devel")
+  "clatter.el version.")
+
+;; --- Customization ---
+
 (defgroup clatter nil
   "An IRCv3-compliant IRC client for Emacs."
   :group 'communication

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -15,7 +15,7 @@
 
 ;; --- Version ---
 
-(defvar clatter-version
+(defconst clatter-version
   (or (package-get-version) "devel")
   "clatter.el version.")
 

--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -767,7 +767,8 @@ MSGID, SERVER-TIME, IS-BOT, REPLY-TO, and IS-REPLY-TO-ME."
       ((guard self-p) nil)
       ("VERSION"
        (clatter-send conn (clatter-irc-ctcp-reply
-                           sender-nick "VERSION" "clatter.el 0.1.0"))
+                           sender-nick "VERSION"
+                           (format "clatter.el %s" clatter-version)))
        (run-hook-with-args 'clatter-system-hook conn
                            (format "CTCP VERSION from %s" sender-nick)))
       ("PING"

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -1181,7 +1181,8 @@ Renders a visual separator before and after history playback."
   "Display CTCP reply from SENDER on CONN in the current clatter buffer.
 COMMAND is the CTCP type (VERSION, PING, etc.), REPLY-TEXT is the response."
   (let* ((network (clatter-connection-network-id conn))
-         (buf (or (clatter-get-buffer network sender)
+         (sender-nick (clatter-prefix-nick sender))
+         (buf (or (clatter-get-buffer network sender-nick)
                   (when-let* ((win (selected-window)))
                     (with-current-buffer (window-buffer win)
                       (when (derived-mode-p 'clatter-mode)
@@ -1189,7 +1190,7 @@ COMMAND is the CTCP type (VERSION, PING, etc.), REPLY-TEXT is the response."
                   (clatter-get-server-buffer network))))
     (when (and buf (buffer-live-p buf))
       (clatter-insert-system
-       buf (format "CTCP %s reply from %s: %s" command sender reply-text)))))
+       buf (format "CTCP %s reply from %s: %s" command sender-nick reply-text)))))
 
 ;; --- Handlers for other numerics ---
 


### PR DESCRIPTION
As per `morganw`'s recommendation on IRC, this uses `package-get-version` to get the version from the package headers. `"devel"` is used as a fallback in case the package is installed from git or elsewhere.

Include a fix for `-on-ctcp-reply` too, where `sender` was assumed to be a nick instead of a prefix.