### PR TITLE
Clean dead server buffers when killed

### DIFF
--- a/clatter-model.el
+++ b/clatter-model.el
@@ -317,7 +317,10 @@ Installed buffer-locally on `kill-buffer-hook' by `clatter-mode'."
          (boundp 'clatter--network)
          clatter--network
          (fboundp 'clatter-disconnect))
-    (clatter-disconnect clatter--network))))
+    (clatter-disconnect clatter--network)
+    (when (and (fboundp 'clatter-remove-buffer)
+               (boundp 'clatter--target))
+     (clatter-remove-buffer clatter--network clatter--target)))))
 
 (define-derived-mode clatter-mode fundamental-mode "CLatter"
   "Major mode for clatter.el IRC buffers."

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -1065,8 +1065,9 @@ the buffer margin-width variables."
 (defun clatter-ui--on-disconnect (network-id event)
   "Handle disconnect EVENT for UI: show message in all NETWORK-ID buffers."
   (dolist (buf (clatter-all-buffers network-id))
-    (clatter-insert-error buf
-                           (format "Disconnected: %s" (string-trim event)))))
+    (when (buffer-live-p buf)
+      (clatter-insert-error buf
+                            (format "Disconnected: %s" (string-trim event))))))
 
 (defun clatter-ui--on-reconnect (network-id delay attempt)
   "Handle reconnect scheduling (DELAY, ATTEMPT) for UI in NETWORK-ID buffers."


### PR DESCRIPTION
If we kill a `*server*` buffer with *C-x k*, the dead buffer will be retained in `clatter--buffer-alist`, since the hook only disconnects the server connection.

This changeset adds a `(clatter-remove-bufffer …)` call to the server buffer cleanup, ensuring that buffer is definitely deleted from `clatter--buffer-alist`.

Note that the server buffer may be revived via `clatter-ui--on-disconnect` due to the disconnect message being echoed, but this is a different (minor) issue.