### PR TITLE
Ensure secondary selection doesn't enclose new received messages

### DIFF
--- a/clatter-actions.el
+++ b/clatter-actions.el
@@ -44,6 +44,15 @@
   (when-let* ((msgid (get-text-property (point) 'clatter-msgid))
               (begin (previous-single-property-change (point) 'clatter-msgid))
               (end (next-single-property-change (point) 'clatter-msgid)))
+    ;; Ensure the message marker is outside the boundaries of the region,
+    ;; so that newly-added messages are not included in the selection.
+    (when (and (= begin clatter--messages-marker)
+               (< begin (point-max)))
+      (setq begin (1+ begin)))
+    (when (and (= end clatter--messages-marker)
+               (> end (point-min)))
+      (setq end (1- end)))
+    ;; Create the region and convert it into a secondary selection.
     (prog1 msgid
       (save-mark-and-excursion
         (goto-char begin)


### PR DESCRIPTION
If the message marker is included within the boundaries of the secondary selection, any newly-received message within the buffer will be enclosed by the secondary selection (if it is still active). This can only happen when selecting the first message, but handling it properly is cleaner.

Nudge the boundaries of the selection by +1/-1 whenever we detect they match the message marker to ensure this does not happen.