### PR TITLE
Fix handling of multi-line CAP LS

### DIFF
--- a/clatter-cap.el
+++ b/clatter-cap.el
@@ -39,14 +39,22 @@ Strips =value suffixes (e.g., \"sasl=PLAIN,EXTERNAL\" -> \"sasl\")."
   "Handle a CAP response on CONN with PARAMS.
 Dispatches based on subcommand (LS, ACK, NAK)."
   (let* ((subcommand (nth 1 params))
-         ;; Handle multi-line CAP LS (second param is *)
-         (is-multiline (string= (nth 1 params) "*"))
+         ;; Handle multi-line CAP LS (third param is *)
+         (is-multiline (string= (nth 2 params) "*"))
          (caps-string (if is-multiline (nth 3 params) (nth 2 params))))
     (cond
      ;; CAP LS - server lists available capabilities
-     ((or (string-equal subcommand "LS")
-          (and is-multiline (string-equal (nth 2 params) "LS")))
-      (clatter-cap--handle-ls conn caps-string))
+     ((string-equal subcommand "LS")
+      ;; Accumulate capabilities
+      (push caps-string (clatter-connection-cap-available conn))
+      ;; If there is no multiline indicator, the capability list is complete, so
+      ;; concatenate the capability lines together and handle the result as if
+      ;; it was a single CAP * LS <CAPS-STRING> line.
+      (unless is-multiline
+        (setq caps-string
+              (string-join (clatter-connection-cap-available conn) " "))
+        (setf (clatter-connection-cap-available conn) nil)
+        (clatter-cap--handle-ls conn caps-string)))
 
      ;; CAP ACK - capabilities accepted
      ((string-equal subcommand "ACK")

--- a/clatter-cap.el
+++ b/clatter-cap.el
@@ -42,19 +42,26 @@ Dispatches based on subcommand (LS, ACK, NAK)."
          ;; Handle multi-line CAP LS (third param is *)
          (is-multiline (string= (nth 2 params) "*"))
          (caps-string (if is-multiline (nth 3 params) (nth 2 params))))
+    (unless (seq-empty-p caps-string)
+      (setq caps-string (string-trim caps-string)))
     (cond
      ;; CAP LS - server lists available capabilities
      ((string-equal subcommand "LS")
       ;; Accumulate capabilities
-      (push caps-string (clatter-connection-cap-available conn))
+      (setf (clatter-connection-cap-string conn)
+            (cond
+             ((and (seq-empty-p (clatter-connection-cap-string conn))
+                   (not (seq-empty-p caps-string)))
+              caps-string)
+             ((and (not (seq-empty-p (clatter-connection-cap-string conn)))
+                   (not (seq-empty-p caps-string)))
+              (concat (clatter-connection-cap-string conn) " " caps-string))
+             (t (clatter-connection-cap-string conn))))
       ;; If there is no multiline indicator, the capability list is complete, so
-      ;; concatenate the capability lines together and handle the result as if
-      ;; it was a single CAP * LS <CAPS-STRING> line.
-      (unless is-multiline
-        (setq caps-string
-              (string-join (clatter-connection-cap-available conn) " "))
-        (setf (clatter-connection-cap-available conn) nil)
-        (clatter-cap--handle-ls conn caps-string)))
+      ;; handle the result as if it was a single CAP * LS <CAPS-STRING> line.
+      (unless (or is-multiline
+                  (seq-empty-p (clatter-connection-cap-string conn)))
+        (clatter-cap--handle-ls conn (clatter-connection-cap-string conn))))
 
      ;; CAP ACK - capabilities accepted
      ((string-equal subcommand "ACK")

--- a/clatter-connection.el
+++ b/clatter-connection.el
@@ -32,6 +32,7 @@
   cap-negotiating      ; t during CAP negotiation
   cap-enabled          ; list of enabled capability strings
   cap-available        ; list of capabilities advertised by the server
+  cap-string           ; capability string sent by the server
   ;; IRCv3 batch/label tracking
   active-batches       ; hash-table: batch-id -> plist
   pending-labels       ; hash-table: label -> callback
@@ -380,6 +381,7 @@ ARGS are keyword arguments that override `clatter-networks' config:
       (setf (clatter-connection-desired-nick conn) nick)
       (setf (clatter-connection-recv-buffer conn) (decode-coding-string "" 'utf-8))
       (setf (clatter-connection-cap-enabled conn) nil)
+      (setf (clatter-connection-cap-string conn) nil)
       (setf (clatter-connection-sasl-state conn) nil)
       (setf (clatter-connection-ping-sent-time conn) nil)
       (clrhash (clatter-connection-active-batches conn))


### PR DESCRIPTION
As per https://ircv3.net/specs/extensions/capability-negotiation.html the multi-line CAP LS has the form (NTH line is purely illustrative):

    CAP  * LS  *
    ____________
    NTH  0  1  2

Hence, the multi-line indicator preceding the capability list would be the third parameter i.e. (nth 2 params).

If such a multi-line indicator is present, accumulate the capability string until we're done (indicated by the absence of the multi-indicator).

Fixes authentication sequence on a number of ergochat IRCv3 networks, incl. milkmedicine IRC.