### PR TITLE
Fix -cmd-mode behavior on nil clatter--target

### DIFF
--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -166,7 +166,7 @@ INPUT is the full string including the leading /."
     (when conn
       (let* ((my-nick (clatter-connection-nick conn))
              (target clatter--target)
-             (no-target (string-empty-p target))
+             (no-target (seq-empty-p target))
              (other-target (not no-target))
              (server-target (and other-target (string= target "*server*"))))
         (cond


### PR DESCRIPTION
https://github.com/parenworks/clatter.el/pull/47 had a small thinko in the check for `clatter--target`. 

`seq-empty-p`  returns `t` for both `""` and `nil` cases, so it is generally safer.