### PR TITLE
Do not move point on new messages when clatter-message-order is set to 'oldest-first

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -249,9 +249,11 @@ append at the bottom like a traditional IRC client."
           (when oldest-first
             (dolist (win (get-buffer-window-list buffer nil t))
               (with-selected-window win
-                (save-excursion
-                  (goto-char (point-max))
-                  (recenter -1))))))
+                (when (and clatter--input-marker
+                           (>= (point) clatter--input-marker))
+                  (save-excursion
+                    (goto-char (point-max))
+                    (recenter -1)))))))
         ;; Messages inserted above the input (bottom/oldest-first prompt)
         ;; push the input down.  Without this, the user's pending undo
         ;; entries would still point at the old positions and an undo

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -249,8 +249,9 @@ append at the bottom like a traditional IRC client."
           (when oldest-first
             (dolist (win (get-buffer-window-list buffer nil t))
               (with-selected-window win
-                (goto-char (point-max))
-                (recenter -1)))))
+                (save-excursion
+                  (goto-char (point-max))
+                  (recenter -1))))))
         ;; Messages inserted above the input (bottom/oldest-first prompt)
         ;; push the input down.  Without this, the user's pending undo
         ;; entries would still point at the old positions and an undo


### PR DESCRIPTION
Fixes https://github.com/parenworks/clatter.el/issues/68

Reported by @krisbalintona.