### PR TITLE
Do not recenter to avoid jarring scrolling/point movement behavior in 'oldest-first mode

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -200,8 +200,7 @@ append at the bottom like a traditional IRC client."
       (let ((pre-input (and clatter--input-marker
                             (marker-position clatter--input-marker))))
         (let ((inhibit-read-only t)
-              (buffer-undo-list t)
-              (oldest-first (eq clatter-message-order 'oldest-first)))
+              (buffer-undo-list t))
           (save-excursion
             ;; Messages always insert at the messages marker.  Its position
             ;; and insertion type (set in `clatter--setup-prompt') determine

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -244,13 +244,7 @@ append at the bottom like a traditional IRC client."
               (when (clatter--fool-invisibility-p invisible)
                 (add-face-text-property start (point) 'clatter-fool))
               (put-text-property start (point) 'invisible invisible)))
-          (clatter--maybe-truncate buffer)
-          ;; Auto-scroll in oldest-first mode
-          (when oldest-first
-            (dolist (win (get-buffer-window-list buffer nil t))
-              (with-selected-window win
-                (goto-char (point-max))
-                (recenter -1)))))
+          (clatter--maybe-truncate buffer))
         ;; Messages inserted above the input (bottom/oldest-first prompt)
         ;; push the input down.  Without this, the user's pending undo
         ;; entries would still point at the old positions and an undo


### PR DESCRIPTION
Fixes https://github.com/parenworks/clatter.el/issues/82
Fixes https://github.com/parenworks/clatter.el/issues/68