### PR TITLE
Fix prefix handling in url-preview hook

### DIFF
--- a/clatter-url-preview.el
+++ b/clatter-url-preview.el
@@ -127,9 +127,10 @@ Uses curl subprocess to avoid blocking Emacs on DNS/TLS."
   (when clatter-url-preview-enable
     (let* ((network (clatter-connection-network-id conn))
            (my-nick (clatter-connection-nick conn))
+           (sender-nick (clatter-prefix-nick sender))
            (buf-target (if (clatter-channel-name-p target)
                            target
-                         (if (string-equal target my-nick) sender target)))
+                         (if (string-equal target my-nick) sender-nick target)))
            (buf (clatter-get-buffer network buf-target))
            (pos 0))
       (when buf


### PR DESCRIPTION
Fixes https://github.com/parenworks/clatter.el/issues/85

Extract nick from prefix instead assmuing we get passed the nick.