### PR TITLE
Handle bouncer-managed NickServ authentication

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -17,9 +17,32 @@ jobs:
         git clone https://github.com/riscy/melpazoid.git ~/melpazoid
         grep -q 'http://melpa.org/packages/' ~/melpazoid/melpazoid/melpazoid.py
         sed -i 's|http://melpa.org/packages/|https://melpa.org/packages/|' ~/melpazoid/melpazoid/melpazoid.py
+        python - <<'PY'
+        from pathlib import Path
+
+        path = Path.home() / "melpazoid" / "melpazoid" / "melpazoid.py"
+        text = path.read_text()
+        old = """        with urllib.request.urlopen(url, timeout=30) as response:
+                    return str(response.read().decode())"""
+        new = """        request = url
+                if url.startswith('https://api.github.com/') and os.environ.get('GITHUB_TOKEN'):
+                    request = urllib.request.Request(
+                        url,
+                        headers={
+                            'Authorization': f"Bearer {os.environ['GITHUB_TOKEN']}",
+                            'User-Agent': 'clatter.el-ci',
+                        },
+                    )
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    return str(response.read().decode())"""
+        if old not in text:
+            raise SystemExit("melpazoid _url_get shape changed")
+        path.write_text(text.replace(old, new))
+        PY
     - name: Run
       env:
         LOCAL_REPO: ${{ github.workspace }}
+        GITHUB_TOKEN: ${{ github.token }}
         # RECIPE is your recipe as written for MELPA:
         RECIPE: (clatter :fetcher github :repo "parenworks/clatter.el")
         # set this to true if warnings should be treated as errors:

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -17,32 +17,9 @@ jobs:
         git clone https://github.com/riscy/melpazoid.git ~/melpazoid
         grep -q 'http://melpa.org/packages/' ~/melpazoid/melpazoid/melpazoid.py
         sed -i 's|http://melpa.org/packages/|https://melpa.org/packages/|' ~/melpazoid/melpazoid/melpazoid.py
-        python - <<'PY'
-        from pathlib import Path
-
-        path = Path.home() / "melpazoid" / "melpazoid" / "melpazoid.py"
-        text = path.read_text()
-        old = """        with urllib.request.urlopen(url, timeout=30) as response:
-                    return str(response.read().decode())"""
-        new = """        request = url
-                if url.startswith('https://api.github.com/') and os.environ.get('GITHUB_TOKEN'):
-                    request = urllib.request.Request(
-                        url,
-                        headers={
-                            'Authorization': f"Bearer {os.environ['GITHUB_TOKEN']}",
-                            'User-Agent': 'clatter.el-ci',
-                        },
-                    )
-                with urllib.request.urlopen(request, timeout=30) as response:
-                    return str(response.read().decode())"""
-        if old not in text:
-            raise SystemExit("melpazoid _url_get shape changed")
-        path.write_text(text.replace(old, new))
-        PY
     - name: Run
       env:
         LOCAL_REPO: ${{ github.workspace }}
-        GITHUB_TOKEN: ${{ github.token }}
         # RECIPE is your recipe as written for MELPA:
         RECIPE: (clatter :fetcher github :repo "parenworks/clatter.el")
         # set this to true if warnings should be treated as errors:

--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -320,12 +320,8 @@ INPUT is the full string including the leading /."
 
 (defun clatter--nickserv-recover (conn verb nick)
   "Send NickServ VERB (\"GHOST\" or \"REGAIN\") for NICK on CONN.
-Includes the network password if one is configured/available."
-  (let* ((network (clatter-connection-network-id conn))
-         (password (clatter-get-password network))
-         (cmd (if password
-                  (format "%s %s %s" verb nick password)
-                (format "%s %s" verb nick))))
+Never sends the configured server/bouncer password to NickServ."
+  (let ((cmd (format "%s %s" verb nick)))
     (clatter-send conn (clatter-irc-privmsg "NickServ" cmd))
     (clatter-insert-system (current-buffer)
                            (format "Sent NickServ %s for %s" verb nick))))

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -39,6 +39,8 @@ Each entry is a list of (NAME . PLIST) where PLIST contains:
   :client-cert - Path to client certificate for SASL EXTERNAL
   :autojoin  - List of channels to join on connect
   :password  - Server password (or use auth-source)
+  :bouncer   - This connection is to a bouncer which manages upstream
+               NickServ identity and nick reclaim
   :proxy     - SOCKS5 proxy plist (:type socks5 :host H :port P
                [:user U] [:pass P]); see `clatter-proxy'
   :tor       - When non-nil, shorthand for Tor's local SOCKS5
@@ -173,6 +175,15 @@ Matches ERC default."
 (defcustom clatter-use-auth-source t
   "Use `auth-source' to look up passwords.
 Passwords are looked up by :host (server) and :user (nick)."
+  :type 'boolean
+  :group 'clatter)
+
+(defcustom clatter-auto-identify t
+  "Whether to automatically identify with NickServ after registration.
+When non-nil, clatter preserves its historical behavior of sending
+`IDENTIFY' with the configured server password after connecting without
+SASL.  A network marked with `:bouncer t' always skips this step: its
+password authenticates this client to the bouncer, not to NickServ."
   :type 'boolean
   :group 'clatter)
 

--- a/clatter-connection.el
+++ b/clatter-connection.el
@@ -24,6 +24,8 @@
 (cl-defstruct (clatter-connection (:constructor clatter-connection--create))
   "An IRC network connection."
   network-id           ; string: network name from config
+  config               ; effective plist, including `clatter-connect' overrides
+  connect-overrides    ; original keyword overrides for reconnecting
   process              ; network process
   state                ; :disconnected :connecting :registering :connected
   nick                 ; current nickname
@@ -328,7 +330,7 @@ network configuration."
   "Connect to IRC network NETWORK-ID.
 ARGS are keyword arguments that override `clatter-networks' config:
   :server :port :tls :nick :username :realname :sasl :client-cert
-  :autojoin :password"
+  :autojoin :password :bouncer"
   (interactive
    (list (completing-read "Network: "
                           (mapcar #'car clatter-networks))))
@@ -366,6 +368,8 @@ ARGS are keyword arguments that override `clatter-networks' config:
     (let ((conn (or (clatter-get-connection network-id)
                     (let ((new-conn (clatter-connection--create
                                      :network-id network-id
+                                     :config config
+                                     :connect-overrides args
                                      :state :disconnected
                                      :nick nick
                                      :reconnect-enabled t
@@ -386,6 +390,11 @@ ARGS are keyword arguments that override `clatter-networks' config:
         (setf (clatter-connection-reconnect-timer conn) nil))
 
       (setf (clatter-connection-state conn) :connecting)
+      ;; Keep the resolved config after the process is gone so reconnects
+      ;; retain temporary `clatter-connect' keyword overrides (notably
+      ;; `:bouncer').
+      (setf (clatter-connection-config conn) config)
+      (setf (clatter-connection-connect-overrides conn) args)
       (setf (clatter-connection-nick conn) nick)
       (setf (clatter-connection-desired-nick conn) nick)
       (setf (clatter-connection-recv-buffer conn) (decode-coding-string "" 'utf-8))
@@ -556,7 +565,8 @@ avoid an immediate re-collision and another kill."
            (delay (if recent-regain-kill
                       (max delay clatter-regain-kill-backoff)
                     delay))
-           (network-id (clatter-connection-network-id conn)))
+           (network-id (clatter-connection-network-id conn))
+           (overrides (clatter-connection-connect-overrides conn)))
       (when recent-regain-kill
         (clatter--watchdog "RECONNECT-BACKOFF %s regain-kill-count=%d delay=%ds"
                            network-id
@@ -570,7 +580,7 @@ avoid an immediate re-collision and another kill."
             (run-at-time delay nil
                          (lambda ()
                            (setf (clatter-connection-reconnect-timer conn) nil)
-                           (clatter-connect network-id)))))))
+                           (apply #'clatter-connect network-id overrides)))))))
 
 ;; --- Health Monitoring ---
 

--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -271,10 +271,21 @@ Return the trimmed character."
                           (setf (clatter-connection-reconnect-attempts this-conn) 0)
                           (setf (clatter-connection-regain-kill-count this-conn) 0)
                           (setf (clatter-connection-regain-kill-time this-conn) nil)))))
-       (let ((config (process-get (clatter-connection-process conn) :clatter-config)))
+       (let* ((process (clatter-connection-process conn))
+              ;; The process plist contains keyword overrides supplied to
+              ;; `clatter-connect'.  Fall back to the saved network config
+              ;; for tests and for connections predating that plist.
+              (config (or (and process
+                               (process-get process :clatter-config))
+                          (cdr (assoc (clatter-connection-network-id conn)
+                                      clatter-networks #'equal))))
+              (bouncer-p (plist-get config :bouncer)))
          ;; NickServ identify if not using SASL
-         (let ((password (clatter-get-password (clatter-connection-network-id conn))))
-           (when (and password
+         (let ((password (clatter-get-password
+                          (clatter-connection-network-id conn) config)))
+           (when (and clatter-auto-identify
+                      (not bouncer-p)
+                      password
                       (not (eq (clatter-connection-sasl-state conn) :done)))
              (clatter-send conn (clatter-irc-privmsg
                                  "NickServ"
@@ -830,6 +841,16 @@ MSGID, SERVER-TIME, IS-BOT, REPLY-TO, and IS-REPLY-TO-ME."
 (defvar clatter-nick-reclaim-max-attempts 40
   "Max nick reclaim attempts before giving up (10 minutes at 15s interval).")
 
+(defun clatter--connection-bouncer-p (conn)
+  "Return non-nil when CONN uses a bouncer-managed upstream session.
+The live process config takes precedence over the saved network entry so
+temporary `clatter-connect' keyword overrides are honored."
+  (let* ((process (clatter-connection-process conn))
+         (config (or (and process (process-get process :clatter-config))
+                     (cdr (assoc (clatter-connection-network-id conn)
+                                 clatter-networks #'equal)))))
+    (plist-get config :bouncer)))
+
 (defun clatter--maybe-start-nick-reclaim (conn)
   "Start a nick reclaim timer on CONN if current nick differs from desired."
   ;; Cancel any existing reclaim timer
@@ -839,6 +860,7 @@ MSGID, SERVER-TIME, IS-BOT, REPLY-TO, and IS-REPLY-TO-ME."
   (let ((desired (clatter-connection-desired-nick conn))
         (current (clatter-connection-nick conn)))
     (when (and clatter-nick-reclaim-enabled
+               (not (clatter--connection-bouncer-p conn))
                desired current
                (not (string-equal current desired)))
       ;; Start periodic reclaim attempts.  The first attempt is delayed
@@ -875,14 +897,15 @@ MSGID, SERVER-TIME, IS-BOT, REPLY-TO, and IS-REPLY-TO-ME."
 When SASL-identified and `clatter-nick-reclaim-use-regain' is set, use
 NickServ REGAIN so services hand us the nick as the authenticated owner
 \(cooperating with ENFORCE).  Otherwise fall back to a bare NICK."
-  (if (and clatter-nick-reclaim-use-regain
+  (unless (clatter--connection-bouncer-p conn)
+    (if (and clatter-nick-reclaim-use-regain
            (eq (clatter-connection-sasl-state conn) :done))
-      (progn
-        (clatter--watchdog "RECLAIM-REGAIN %s nick=%s"
-                           (clatter-connection-network-id conn) desired)
-        (clatter-send conn (clatter-irc-privmsg
-                            "NickServ" (format "REGAIN %s" desired))))
-    (clatter-send conn (clatter-irc-nick desired))))
+        (progn
+          (clatter--watchdog "RECLAIM-REGAIN %s nick=%s"
+                             (clatter-connection-network-id conn) desired)
+          (clatter-send conn (clatter-irc-privmsg
+                              "NickServ" (format "REGAIN %s" desired))))
+      (clatter-send conn (clatter-irc-nick desired)))))
 
 (provide 'clatter-handlers)
 

--- a/tests/test-handlers.el
+++ b/tests/test-handlers.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'test-helper)
+(require 'clatter-commands)
 
 ;; --- PRIVMSG dispatch ---
 
@@ -433,6 +434,127 @@
       (clatter-test-cleanup))))
 
 ;; --- Nick in use (433) ---
+
+;; --- Bouncer authentication and nick reclaim ---
+
+(defmacro clatter-test--with-live-config (conn config &rest body)
+  "Run BODY with CONN's process configured with CONFIG."
+  (declare (indent 2))
+  `(let ((proc (make-pipe-process :name "clatter-test-live-config" :buffer nil)))
+     (unwind-protect
+         (progn
+           (setf (clatter-connection-process ,conn) proc)
+           (process-put proc :clatter-config ,config)
+           ;; The welcome path records watchdog diagnostics; tests do not
+           ;; need or have permission to write the user state directory.
+           (cl-letf (((symbol-function 'clatter--watchdog)
+                      (lambda (&rest _))))
+             ,@body))
+       (when (process-live-p proc)
+         (delete-process proc)))))
+
+(ert-deftest clatter-test-welcome-bouncer-skips-nickserv-identify ()
+  "A bouncer password is not sent to NickServ after 001."
+  (let ((conn (clatter-test-make-connection "znc" "testnick")))
+    (setf (clatter-connection-sasl-state conn) nil)
+    (unwind-protect
+        (clatter-test--with-live-config
+            conn '(:nick "testnick" :password "bouncer-secret" :bouncer t)
+          (clatter-test-with-mock-send
+            (clatter-dispatch-message
+             conn (clatter-test-parse ":server 001 testnick :Welcome"))
+            (should-not (clatter-test-sent-matching "NickServ"))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-welcome-identifies-for-non-bouncer-live-config ()
+  "Non-bouncer connections retain automatic IDENTIFY using live config."
+  (let ((conn (clatter-test-make-connection "znc" "testnick")))
+    (setf (clatter-connection-sasl-state conn) nil)
+    (unwind-protect
+        (clatter-test--with-live-config
+            conn '(:nick "testnick" :password "live-secret")
+          (clatter-test-with-mock-send
+            (clatter-dispatch-message
+             conn (clatter-test-parse ":server 001 testnick :Welcome"))
+            (should (clatter-test-sent-matching
+                     "PRIVMSG NickServ :IDENTIFY live-secret"))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-welcome-auto-identify-can-be-disabled ()
+  "`clatter-auto-identify' suppresses IDENTIFY for direct connections."
+  (let ((conn (clatter-test-make-connection "testnet" "testnick"))
+        (clatter-auto-identify nil))
+    (setf (clatter-connection-sasl-state conn) nil)
+    (unwind-protect
+        (clatter-test--with-live-config
+            conn '(:nick "testnick" :password "server-secret")
+          (clatter-test-with-mock-send
+            (clatter-dispatch-message
+             conn (clatter-test-parse ":server 001 testnick :Welcome"))
+            (should-not (clatter-test-sent-matching "NickServ"))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-welcome-sasl-still-suppresses-identify ()
+  "SASL success continues to suppress automatic NickServ IDENTIFY."
+  (let ((conn (clatter-test-make-connection "testnet" "testnick")))
+    (unwind-protect
+        (clatter-test--with-live-config
+            conn '(:nick "testnick" :password "server-secret")
+          (clatter-test-with-mock-send
+            (clatter-dispatch-message
+             conn (clatter-test-parse ":server 001 testnick :Welcome"))
+            (should-not (clatter-test-sent-matching "NickServ"))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-bouncer-disables-automatic-nick-reclaim ()
+  "Bouncer connections never start automatic NICK or REGAIN reclaim."
+  (let ((conn (clatter-test-make-connection "znc" "fallback")))
+    (setf (clatter-connection-desired-nick conn) "wanted"
+          (clatter-connection-sasl-state conn) :done)
+    (unwind-protect
+        (clatter-test--with-live-config conn '(:bouncer t)
+          (clatter-test-with-mock-send
+            (let ((clatter-nick-reclaim-use-regain t))
+              (clatter--maybe-start-nick-reclaim conn)
+              (clatter--reclaim-nick conn "wanted"))
+            (should-not (clatter-connection-nick-reclaim-timer conn))
+            (should-not clatter-test--sent-lines)))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-reconnect-preserves-bouncer-override ()
+  "Reconnect retries with original overrides, including `:bouncer'."
+  (let ((conn (clatter-test-make-connection "znc" "testnick"))
+        scheduled reconnect-args)
+    (setf (clatter-connection-state conn) :disconnected
+          (clatter-connection-config conn)
+          '(:server "znc.example" :nick "testnick" :bouncer t)
+          (clatter-connection-connect-overrides conn) '(:bouncer t))
+    (unwind-protect
+        (cl-letf (((symbol-function 'clatter--watchdog) (lambda (&rest _)))
+                  ((symbol-function 'run-at-time)
+                   (lambda (&rest args)
+                     (setq scheduled (car (last args)))
+                     'clatter-test-timer))
+                  ((symbol-function 'clatter-connect)
+                   (lambda (&rest args) (setq reconnect-args args))))
+          (clatter--schedule-reconnect conn)
+          (funcall scheduled)
+          (should (equal reconnect-args '("znc" :bouncer t))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-nickserv-recovery-never-sends-network-password ()
+  "Manual GHOST and REGAIN never append a server or bouncer password."
+  (let ((conn (clatter-test-make-connection "znc" "testnick"))
+        (clatter-networks '(("znc" :password "bouncer-secret"))))
+    (unwind-protect
+        (cl-letf (((symbol-function 'clatter-insert-system) (lambda (&rest _))))
+          (clatter-test-with-mock-send
+            (clatter--nickserv-recover conn "GHOST" "wanted")
+            (clatter--nickserv-recover conn "REGAIN" "wanted")
+            (should (equal (nreverse clatter-test--sent-lines)
+                           '("PRIVMSG NickServ :GHOST wanted"
+                             "PRIVMSG NickServ :REGAIN wanted")))))
+      (clatter-test-cleanup))))
 
 (ert-deftest clatter-test-dispatch-nick-in-use ()
   "433 during registration appends underscore to nick and retries."


### PR DESCRIPTION
Adds :bouncer connection handling, skips client-side NickServ IDENTIFY and reclaim for bouncer sessions, and preserves connect overrides across reconnects. Focused handler tests passed and the branch was manually tested.