### PR TITLE
Exclude targets from activity tracking

### DIFF
--- a/README.org
+++ b/README.org
@@ -119,7 +119,10 @@ Example:
 - Unread counts and mention detection per channel
 - Priority sorting: mentions > DMs > regular activity
 - Clickable mode-line entries (switch to buffer on click)
-- Channel mute/unmute support
+- Muted targets remain visible but dimmed; for example,
+  =(setq clatter-track-muted-channels '(\"*server*\" \"#bots\"))=
+- Excluded targets are omitted from every tracker surface; for example,
+  =(setq clatter-track-exclude-targets '(\"*server*\"))=
 - Consult integration (narrow with =i= in =consult-buffer=)
 - =M-x clatter-track-switch= to jump to most urgent activity
 - =M-x clatter-track-list= to list all activity

--- a/clatter-track.el
+++ b/clatter-track.el
@@ -33,8 +33,31 @@ Valid values: before-modes, after-modes, end."
   :group 'clatter)
 
 (defcustom clatter-track-muted-channels nil
-  "List of channel names to exclude from activity tracking.
-Example: (\"#spam\" \"#bots\")"
+  "List of targets to dim, but keep, in the activity tracker.
+Muted targets still appear in the mode-line indicator, activity list,
+activity switch command, and Consult activity source.  They use the
+`clatter-track-muted' face instead of their normal activity face.
+
+Despite the historical variable name, this list may contain any target,
+including the server target \"*server*\".  Use
+`clatter-track-exclude-targets' when a target should not appear in any
+tracker surface.
+
+Example: (\"*server*\" \"#spam\" \"#bots\")"
+  :type '(repeat string)
+  :group 'clatter)
+
+(defcustom clatter-track-exclude-targets nil
+  "List of targets to hide completely from the activity tracker.
+Excluded targets do not appear in the mode-line indicator, activity list,
+activity switch command, or Consult activity source.  Exclusion only affects
+the tracker: messages still appear in the target buffer and retain their
+normal unread state.
+
+This differs from `clatter-track-muted-channels', which keeps targets in the
+tracker and merely dims them.  Target names use the same spelling as
+`clatter--target'.  For example, use (\"*server*\") to omit server activity,
+or (\"#spam\" \"#bots\") to omit selected channels."
   :type '(repeat string)
   :group 'clatter)
 
@@ -112,6 +135,7 @@ Plist keys: :buffer :name :unread :mention :muted :dm"
     (with-current-buffer buf
       (when (and (derived-mode-p 'clatter-mode)
                  clatter--target
+                 (not (member clatter--target clatter-track-exclude-targets))
                  (> clatter--unread-count 0))
         (let* ((target clatter--target)
                (is-channel (and target (string-match-p "^[#&!+]" target)))

--- a/tests/test-track.el
+++ b/tests/test-track.el
@@ -1,0 +1,40 @@
+;;; test-track.el --- Tests for clatter activity tracking -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'test-helper)
+(require 'clatter-track)
+(require 'clatter-ui)
+
+(defmacro clatter-track-test--with-buffer (target &rest body)
+  "Run BODY in a temporary clatter buffer for TARGET."
+  (declare (indent 1))
+  `(clatter-test-with-buffer
+     (setq-local clatter--target ,target)
+     (setq-local clatter--buffer-type
+                 (if (string= ,target "*server*") 'server 'channel))
+     ,@body))
+
+(ert-deftest clatter-track-exclude-targets-omits-buffer-info ()
+  "Excluded targets are absent from the tracker collection."
+  (let ((clatter-track-exclude-targets '("#quiet")))
+    (clatter-track-test--with-buffer "#quiet"
+      (setq-local clatter--unread-count 2)
+      (should-not (clatter-track--buffer-info (current-buffer)))
+      (should-not (clatter-track--collect)))))
+
+(ert-deftest clatter-track-muted-channels-remain-visible ()
+  "Muted targets remain visible and use the muted tracker face."
+  (let ((clatter-track-muted-channels '("#bots")))
+    (clatter-track-test--with-buffer "#bots"
+      (setq-local clatter--unread-count 1)
+      (let* ((info (clatter-track--buffer-info (current-buffer)))
+             (entry (clatter-track--format-entry info)))
+        (should info)
+        (should (plist-get info :muted))
+        (should (eq (get-text-property 0 'face entry)
+                    'clatter-track-muted))))))
+
+(provide 'test-track)
+
+;;; test-track.el ends here


### PR DESCRIPTION
Adds explicit target exclusions for activity collection while keeping the default empty, so the server tab and all other targets remain tracked unless the user opts out. Muted targets remain visible with muted styling. Focused tracker tests passed and the branch was manually tested.