### PR TITLE
Add optimistic self-echo mode

### DIFF
--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -108,12 +108,9 @@ INPUT is the full string including the leading /."
         (if space-pos
             (let ((target (substring args 0 space-pos))
                   (text (string-trim-left (substring args (1+ space-pos)))))
-              (clatter-send conn (clatter-irc-privmsg target text))
-              ;; Open query buffer and show the message (skip if echo-message handles it)
               (let ((buf (clatter-get-or-create-buffer clatter--network target)))
                 (clatter-ui-setup-buffer-if-needed buf)
-                (unless (member "echo-message" (clatter-connection-cap-enabled conn))
-                  (clatter-insert-privmsg buf (clatter-connection-nick conn) text conn))))
+                (clatter-ui--send-privmsg conn target text 'privmsg buf)))
           (clatter-insert-error (current-buffer) "Usage: /msg target message"))))))
 
 (defun clatter-cmd-me (args)
@@ -122,11 +119,7 @@ INPUT is the full string including the leading /."
     (when conn
       (when (and clatter--target (not (string= clatter--target "*server*")))
         (let ((ctcp-msg (format "\C-aACTION %s\C-a" args)))
-          (clatter-send conn (clatter-irc-privmsg clatter--target ctcp-msg))
-          (unless (member "echo-message" (clatter-connection-cap-enabled conn))
-            (clatter-insert-action (current-buffer)
-                                   (clatter-connection-nick conn)
-                                   args conn)))))))
+          (clatter-ui--send-privmsg conn clatter--target args 'action (current-buffer) ctcp-msg))))))
 
 (defun clatter-cmd-nick (args)
   "Change nick to the NEWNICK given in ARGS."
@@ -684,15 +677,12 @@ Uses +draft/reply tag to thread the response."
      ((null conn)
       (message "Not connected"))
      (t
-      (clatter-send conn (format "@+draft/reply=%s PRIVMSG %s :%s"
-                                 msgid target text))
+      (clatter-ui--send-privmsg conn target text 'privmsg (current-buffer)
+                                 (format "@+draft/reply=%s PRIVMSG %s :%s"
+                                         msgid target text))
       ; Clear secondary selection
       (save-mark-and-excursion (secondary-selection-to-region))
-      ;; Echo if echo-message not enabled
-      (unless (member "echo-message" (clatter-connection-cap-enabled conn))
-        (clatter-insert-privmsg (current-buffer)
-                                (clatter-connection-nick conn)
-                                text conn))))))
+      ))))
 
 (clatter-defcommand "reply" #'clatter-cmd-reply "r")
 

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -127,6 +127,28 @@ and nil disables margin timestamps."
                  (const :tag "Disabled" nil))
   :group 'clatter)
 
+(defcustom clatter-self-echo-mode 'server
+  "How messages sent by this client are displayed.
+
+The default `server' waits for the server's echo-message response when that
+capability is available (and preserves the existing immediate fallback when
+it is not).  `optimistic' inserts a tentative local message immediately, then
+reconciles the matching server echo so that server time and msgid metadata are
+retained without displaying a duplicate."
+  :type '(choice (const :tag "Wait for server echo" server)
+                 (const :tag "Show immediately" optimistic))
+  :group 'clatter)
+
+(defcustom clatter-self-echo-timeout 30
+  "Seconds an optimistic self echo may wait for its server echo.
+
+After this interval Clatter keeps the locally displayed message, but no
+longer reconciles a matching incoming message.  This prevents delayed
+playback from a later connection from being mistaken for an echo of an old
+outgoing message."
+  :type 'number
+  :group 'clatter)
+
 (defcustom clatter-fill-column 80
   "Column at which to wrap messages in channel buffers."
   :type 'integer

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -129,6 +129,12 @@
 (defvar-local clatter--messages-marker nil
   "Marker for the start of the message area (below the input line).")
 
+(defvar-local clatter--pending-self-echoes nil
+  "Tentative outgoing messages awaiting their server echoes.")
+
+(defvar clatter--self-echo-nonce 0
+  "Monotonically increasing identifier for tentative self echoes.")
+
 (defun clatter--fool-invisibility-p (invisible)
   "Return non-nil if INVISIBLE includes the fool visibility category."
   (or (eq invisible 'clatter-fool)
@@ -331,6 +337,7 @@ SERVER-TIME overrides the current time for the timestamp."
                               (clatter-mention-p (downcase my-nick) (downcase text)))))
          (reply-to (get-text-property 0 'clatter-reply-to text))
          (msgid (get-text-property 0 'clatter-msgid text))
+         (self-echo-nonce (get-text-property 0 'clatter-self-echo-nonce text))
          (reply-context (when reply-to
                           (clatter--find-message-by-msgid buffer reply-to)))
          (hl-text (clatter-hl-format-text text buffer conn))
@@ -394,9 +401,12 @@ SERVER-TIME overrides the current time for the timestamp."
             (concat (or reply-line "") nick-col " " msg-text))))
          (props (list 'clatter-msg-type msg-type
                       'clatter-sender sender
-                      'clatter-text text)))
+                      'clatter-text text
+                      'clatter-server-time server-time)))
     (when msgid
       (setq props (plist-put props 'clatter-msgid msgid)))
+    (when self-echo-nonce
+      (setq props (plist-put props 'clatter-self-echo-nonce self-echo-nonce)))
     (clatter--insert-message buffer formatted nil props server-time invisible)
     (when (and (not clatter--suppress-image-scan)
                (fboundp 'clatter-image--scan-message))
@@ -419,6 +429,128 @@ SERVER-TIME overrides the current time for the timestamp."
 (defun clatter-insert-notice (buffer sender text conn &optional server-time invisible)
   "Insert a NOTICE from SENDER with TEXT into BUFFER."
   (clatter-insert-generic 'notice buffer sender text conn server-time invisible))
+
+(defun clatter-ui--self-echo-p (conn)
+  "Return non-nil when CONN should display a local echo immediately."
+  (or (eq clatter-self-echo-mode 'optimistic)
+      (not (member "echo-message" (clatter-connection-cap-enabled conn)))) )
+
+(defun clatter-ui--record-pending-self-echo (buffer target sender text msg-type nonce)
+  "Record tentative outgoing message metadata for later reconciliation."
+  (with-current-buffer buffer
+    (when-let* ((_start (text-property-any (point-min) (point-max)
+                                           'clatter-self-echo-nonce nonce)))
+      (push (list :nonce nonce :target target :sender sender :text text
+                  :msg-type msg-type :created-at (float-time))
+            clatter--pending-self-echoes))))
+
+(defun clatter-ui--expire-pending-self-echoes (&optional buffer)
+  "Discard expired optimistic self echoes from BUFFER.
+
+Their local lines remain visible, but are no longer candidates for server-echo
+reconciliation.  BUFFER defaults to the current buffer."
+  (with-current-buffer (or buffer (current-buffer))
+    (let ((cutoff (- (float-time) clatter-self-echo-timeout)))
+      (dolist (item clatter--pending-self-echoes)
+        (when (<= (plist-get item :created-at) cutoff)
+          (when-let* ((start (text-property-any
+                              (point-min) (point-max) 'clatter-self-echo-nonce
+                              (plist-get item :nonce))))
+            (let ((end (next-single-property-change
+                        start 'clatter-self-echo-nonce nil (point-max))))
+              (with-silent-modifications
+                (remove-text-properties start end '(clatter-self-echo-nonce nil)))))))
+      (setq clatter--pending-self-echoes
+            (cl-remove-if (lambda (item)
+                            (<= (plist-get item :created-at) cutoff))
+                          clatter--pending-self-echoes)))))
+
+(defun clatter-ui--clear-pending-self-echoes (network-id)
+  "Discard optimistic self echoes in all buffers for NETWORK-ID."
+  (dolist (buffer (clatter-all-buffers network-id))
+    (when (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (dolist (item clatter--pending-self-echoes)
+          (when-let* ((start (text-property-any
+                              (point-min) (point-max) 'clatter-self-echo-nonce
+                              (plist-get item :nonce))))
+            (let ((end (next-single-property-change
+                        start 'clatter-self-echo-nonce nil (point-max))))
+              (with-silent-modifications
+                (remove-text-properties start end '(clatter-self-echo-nonce nil))))))
+        (setq clatter--pending-self-echoes nil)))))
+
+(defun clatter-ui--send-privmsg (conn target text &optional msg-type buffer line)
+  "Send TEXT to TARGET and render it according to `clatter-self-echo-mode'.
+MSG-TYPE is `privmsg' or `action'; BUFFER receives the local echo.  LINE, when
+non-nil, is the already formatted IRC command to send."
+  (let* ((msg-type (or msg-type 'privmsg))
+         (buffer (or buffer (current-buffer)))
+         (sender (clatter-connection-nick conn)))
+    (clatter-send conn (or line (clatter-irc-privmsg target text)))
+    (when (clatter-ui--self-echo-p conn)
+      (let* ((nonce (cl-incf clatter--self-echo-nonce))
+             (tentative (propertize (copy-sequence text) 'clatter-self-echo-nonce nonce)))
+        (pcase msg-type
+          ('action (clatter-insert-action buffer sender tentative conn))
+          (_ (clatter-insert-privmsg buffer sender tentative conn)))
+        ;; Only optimistic messages with echo-message negotiated expect a
+        ;; server echo to replace the local line.  Without that capability,
+        ;; retain the established local fallback without a record that could
+        ;; swallow an unrelated later self message.
+        (when (and (eq clatter-self-echo-mode 'optimistic)
+                   (member "echo-message" (clatter-connection-cap-enabled conn)))
+          (clatter-ui--record-pending-self-echo buffer target sender text msg-type nonce))))))
+
+(defun clatter-ui--reconcile-self-echo (buffer sender target text msg-type server-time)
+  "Reconcile a server echo with its tentative local message in BUFFER.
+Matching includes target, sender, message type, and a FIFO pending record, so
+identical messages sent close together each reconcile only one local line."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (clatter-ui--expire-pending-self-echoes)
+      (let ((pending (cl-find-if
+                      (lambda (item)
+                        (and (string-equal-ignore-case sender (plist-get item :sender))
+                             (string-equal-ignore-case target (plist-get item :target))
+                             (eq msg-type (plist-get item :msg-type))
+                             (string= text (plist-get item :text))))
+                      (reverse clatter--pending-self-echoes))))
+        (when pending
+          (let ((start (text-property-any (point-min) (point-max)
+                                          'clatter-self-echo-nonce
+                                          (plist-get pending :nonce))))
+            (when start
+              (let* ((inhibit-read-only t)
+                     (end (next-single-property-change
+                           start 'clatter-self-echo-nonce nil (point-max)))
+                     (msgid (get-text-property 0 'clatter-msgid text)))
+                (remove-text-properties start end '(clatter-self-echo-nonce nil))
+                (add-text-properties start end
+                                     (list 'clatter-server-time server-time
+                                           ;; `clatter-text' is consumed by replies and
+                                           ;; message lookup, so update the stored text as
+                                           ;; well as the visible tentative line.
+                                           'clatter-text text))
+                (when msgid
+                  (put-text-property start end 'clatter-msgid msgid))
+                (when server-time
+                  (dolist (overlay (overlays-at start))
+                    (when (overlay-get overlay 'clatter-timestamp)
+                      (overlay-put overlay 'before-string
+                                   (propertize " " 'display
+                                               `((margin ,(if (eq clatter-timestamp-side 'left)
+                                                              'left-margin
+                                                            'right-margin))
+                                                 ,(propertize
+                                                   (format-time-string clatter-timestamp-format server-time)
+                                                   'face '(clatter-timestamp default))))))))
+                ;; Do not consume a pending record unless its tentative line
+                ;; still exists.  Buffer truncation may have removed it, in
+                ;; which case the caller must insert the server echo normally.
+                (setq clatter--pending-self-echoes
+                      (delq pending clatter--pending-self-echoes))
+                t))))))))
 
 (defun clatter-insert-system (buffer text &optional invisible)
   "Insert a system message TEXT into BUFFER."
@@ -577,12 +709,7 @@ If the input contains multiple lines and exceeds
     (when (and conn target (not (string= target "*server*")))
       (let ((parts (clatter-split-long-message target text)))
         (dolist (part parts)
-          (clatter-send conn (clatter-irc-privmsg target part))
-          ;; Echo our own message if echo-message not enabled
-          (unless (member "echo-message" (clatter-connection-cap-enabled conn))
-            (clatter-insert-privmsg (current-buffer)
-                                    (clatter-connection-nick conn)
-                                    part conn)))))))
+          (clatter-ui--send-privmsg conn target part 'privmsg (current-buffer)))))))
 
 (defun clatter--handle-command (input)
   "Parse and execute INPUT as a /command."
@@ -712,7 +839,9 @@ the buffer margin-width variables."
          (is-muted (clatter-muted-p sender network))
          (invisible (clatter-sender-invisibility sender network)))
     (clatter-ui-setup-buffer-if-needed buf)
-    (clatter-insert-privmsg buf sender-nick text conn server-time invisible)
+    (unless (and (string-equal-ignore-case my-nick sender-nick)
+                 (clatter-ui--reconcile-self-echo buf sender-nick buf-target text 'privmsg server-time))
+      (clatter-insert-privmsg buf sender-nick text conn server-time invisible))
     (when (and (not is-muted)
                (eq 'channel (buffer-local-value 'clatter--buffer-type buf))
                (not (string-equal-ignore-case my-nick sender-nick))
@@ -732,7 +861,9 @@ the buffer margin-width variables."
          (is-muted (clatter-muted-p sender network))
          (invisible (clatter-sender-invisibility sender network)))
     (clatter-ui-setup-buffer-if-needed buf)
-    (clatter-insert-action buf sender-nick text conn server-time invisible)
+    (unless (and (string-equal-ignore-case my-nick sender-nick)
+                 (clatter-ui--reconcile-self-echo buf sender-nick buf-target text 'action server-time))
+      (clatter-insert-action buf sender-nick text conn server-time invisible))
     (when (and (not is-muted)
                (eq 'channel (buffer-local-value 'clatter--buffer-type buf))
                (not (string-equal-ignore-case my-nick sender-nick))
@@ -1066,6 +1197,7 @@ the buffer margin-width variables."
 
 (defun clatter-ui--on-disconnect (network-id event)
   "Handle disconnect EVENT for UI: show message in all NETWORK-ID buffers."
+  (clatter-ui--clear-pending-self-echoes network-id)
   (dolist (buf (clatter-all-buffers network-id))
     (when (buffer-live-p buf)
       (clatter-insert-error buf

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -7,6 +7,145 @@
 (require 'clatter-commands)
 (require 'clatter-nicklist)
 
+;; --- Self echo ---
+
+(ert-deftest clatter-test-optimistic-self-echo-reconciles-server-metadata ()
+  "An optimistic local line is replaced by its server echo metadata."
+  (let ((clatter-self-echo-mode 'optimistic)
+        (clatter-timestamp-side nil))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (let* ((conn (clatter-test-make-connection "echo-one"))
+                 (buf (clatter-get-or-create-buffer "echo-one" "#test")))
+            (clatter-ui-setup-buffer-if-needed buf)
+            (with-current-buffer buf
+              (clatter-ui--send-privmsg conn "#test" "hello"))
+            (should (= 1 (length (with-current-buffer buf clatter--pending-self-echoes))))
+            (let ((server-text (propertize "hello" 'clatter-msgid "server-id"))
+                  (server-time (encode-time 0 2 3 4 5 2026)))
+              (clatter-ui--on-privmsg
+               conn (clatter-parse-prefix "testnick!u@h") "#test" server-text server-time)
+              (with-current-buffer buf
+                (should-not clatter--pending-self-echoes)
+                (let ((pos (clatter--find-message-position-by-msgid
+                            buf "server-id")))
+                  (should pos)
+                  (should (equal (get-text-property pos 'clatter-server-time)
+                                 server-time))
+                  (should (equal (get-text-property pos 'clatter-text)
+                                 server-text)))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-optimistic-self-echo-queues-identical-messages ()
+  "Identical optimistic sends consume one pending entry per server echo."
+  (let ((clatter-self-echo-mode 'optimistic)
+        (clatter-timestamp-side nil))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (let* ((conn (clatter-test-make-connection "echo-two"))
+                 (buf (clatter-get-or-create-buffer "echo-two" "#test"))
+                 (sender (clatter-parse-prefix "testnick!u@h")))
+            (clatter-ui-setup-buffer-if-needed buf)
+            (with-current-buffer buf
+              (clatter-ui--send-privmsg conn "#test" "same")
+              (clatter-ui--send-privmsg conn "#test" "same"))
+            (let ((before-first-echo (with-current-buffer buf (buffer-string))))
+            (clatter-ui--on-privmsg conn sender "#test"
+                                    (propertize "same" 'clatter-msgid "one") nil)
+            (with-current-buffer buf
+              (should (= 1 (length clatter--pending-self-echoes)))
+              ;; Reconciliation updates the tentative line in place; a
+              ;; duplicate server echo would change the buffer contents.
+              (should (equal before-first-echo (buffer-string))))
+            (clatter-ui--on-privmsg conn sender "#test"
+                                    (propertize "same" 'clatter-msgid "two") nil)
+            (with-current-buffer buf
+              (should-not clatter--pending-self-echoes)
+              (should (equal before-first-echo (buffer-string)))
+              (should (clatter--find-message-position-by-msgid buf "one"))
+              (should (clatter--find-message-position-by-msgid buf "two"))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-server-self-echo-waits-for-echo-message ()
+  "The default mode retains the existing server-echo behavior."
+  (let ((clatter-self-echo-mode 'server)
+        (clatter-timestamp-side nil))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (let* ((conn (clatter-test-make-connection "echo-three"))
+                 (buf (clatter-get-or-create-buffer "echo-three" "#test")))
+            (clatter-ui-setup-buffer-if-needed buf)
+            (with-current-buffer buf
+              (clatter-ui--send-privmsg conn "#test" "delayed")
+              (should-not clatter--pending-self-echoes)
+              (should-not (string-match-p "delayed" (buffer-string))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-optimistic-self-echo-without-echo-message-does-not-reconcile ()
+  "Optimistic fallback does not retain state that swallows a later self message."
+  (let ((clatter-self-echo-mode 'optimistic)
+        (clatter-timestamp-side nil))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (let* ((conn (clatter-test-make-connection-with-caps
+                        '("server-time" "message-tags") "echo-no-cap"))
+                 (buf (clatter-get-or-create-buffer "echo-no-cap" "#test"))
+                 (sender (clatter-parse-prefix "testnick!u@h")))
+            (clatter-ui-setup-buffer-if-needed buf)
+            (with-current-buffer buf
+              (clatter-ui--send-privmsg conn "#test" "fallback")
+              (should-not clatter--pending-self-echoes))
+            (clatter-ui--on-privmsg conn sender "#test"
+                                    (propertize "fallback" 'clatter-msgid "late-server") nil)
+            (with-current-buffer buf
+              (should-not clatter--pending-self-echoes)
+              (should (clatter--find-message-position-by-msgid buf "late-server"))
+              (should (= 2 (how-many "fallback" (point-min) (point-max)))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-expired-optimistic-self-echo-does-not-reconcile ()
+  "A delayed self message is not reconciled with an expired local echo."
+  (let ((clatter-self-echo-mode 'optimistic)
+        (clatter-self-echo-timeout 1)
+        (clatter-timestamp-side nil))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (let* ((conn (clatter-test-make-connection "echo-expired"))
+                 (buf (clatter-get-or-create-buffer "echo-expired" "#test"))
+                 (sender (clatter-parse-prefix "testnick!u@h")))
+            (clatter-ui-setup-buffer-if-needed buf)
+            (with-current-buffer buf
+              (clatter-ui--send-privmsg conn "#test" "delayed")
+              (setf (plist-get (car clatter--pending-self-echoes) :created-at) 0))
+            (clatter-ui--on-privmsg conn sender "#test"
+                                    (propertize "delayed" 'clatter-msgid "playback") nil)
+            (with-current-buffer buf
+              (should-not clatter--pending-self-echoes)
+              (should (clatter--find-message-position-by-msgid buf "playback"))
+              (should (= 2 (how-many "delayed" (point-min) (point-max)))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-disconnect-clears-optimistic-self-echoes ()
+  "Disconnecting clears pending local echoes before any later replay."
+  (let ((clatter-self-echo-mode 'optimistic)
+        (clatter-timestamp-side nil))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (let* ((conn (clatter-test-make-connection "echo-disconnect"))
+                 (buf (clatter-get-or-create-buffer "echo-disconnect" "#test"))
+                 nonce)
+            (clatter-ui-setup-buffer-if-needed buf)
+            (with-current-buffer buf
+              (clatter-ui--send-privmsg conn "#test" "before-disconnect")
+              (setq nonce (plist-get (car clatter--pending-self-echoes) :nonce))
+              (should clatter--pending-self-echoes))
+            (clatter-ui--on-disconnect "echo-disconnect" "closed")
+            (with-current-buffer buf
+              (should-not clatter--pending-self-echoes)
+              (should-not (text-property-any
+                           (point-min) (point-max) 'clatter-self-echo-nonce nonce)))))
+      (clatter-test-cleanup))))
+
 ;; --- Timestamp margins ---
 
 (ert-deftest clatter-test-timestamp-side-left-margin ()


### PR DESCRIPTION
Adds opt-in immediate local echoes with timeout and server reconciliation, preserving server metadata and avoiding duplicate messages across PRIVMSG, ACTION, and reply sends. Focused UI tests passed and the branch was manually tested.