### PR TITLE
Anchor URL previews to source messages

### DIFF
--- a/clatter-url-preview.el
+++ b/clatter-url-preview.el
@@ -260,10 +260,13 @@ behind by buffer truncation."
   (when clatter-url-preview-enable
     (let* ((network (clatter-connection-network-id conn))
            (my-nick (clatter-connection-nick conn))
+           (isupport (clatter-connection-isupport conn))
+           (case-mapping (and isupport (gethash "CASEMAPPING" isupport)))
            (sender-nick (clatter-prefix-nick sender))
            (buf-target (if (clatter-channel-name-p target)
                            target
-                         (if (string-equal target my-nick) sender-nick target)))
+                         (if (clatter-nick-equal-p target my-nick case-mapping)
+                             sender-nick target)))
            (buf (clatter-get-buffer network buf-target))
            (pos 0)
            requests)

--- a/clatter-url-preview.el
+++ b/clatter-url-preview.el
@@ -55,6 +55,16 @@
 (defvar clatter-url-preview--pending (make-hash-table :test 'equal)
   "URLs currently being fetched (to avoid duplicate requests).")
 
+(cl-defstruct (clatter-url-preview--anchor
+               (:constructor clatter-url-preview--make-anchor-record))
+  "Insertion state shared by every preview belonging to one message.
+
+START and END delimit the original rendered message.  TAIL is advanced after
+each preview, so synchronous cache hits retain URL order and later previews
+are not inserted before earlier ones.  REMAINING owns the markers: the last
+cache hit or asynchronous request detaches them."
+  buffer start end tail text remaining)
+
 (defun clatter-url-preview--should-fetch-p (url)
   "Return non-nil if URL should be fetched for title preview."
   (and clatter-url-preview-enable
@@ -81,46 +91,169 @@
             (concat (substring raw 0 clatter-url-preview-max-length) "...")
           raw)))))
 
-(defun clatter-url-preview--fetch (url buffer)
-  "Asynchronously fetch URL and display its title in BUFFER.
+(defun clatter-url-preview--anchor-live-p (anchor)
+  "Return non-nil when ANCHOR still refers to its source message."
+  (and (clatter-url-preview--anchor-p anchor)
+       (let ((buffer (clatter-url-preview--anchor-buffer anchor))
+             (start (clatter-url-preview--anchor-start anchor))
+             (end (clatter-url-preview--anchor-end anchor)))
+         (and (buffer-live-p buffer)
+              (markerp start) (markerp end)
+              (eq (marker-buffer start) buffer)
+              (eq (marker-buffer end) buffer)
+              (with-current-buffer buffer
+                (let ((start-pos (marker-position start))
+                      (end-pos (marker-position end)))
+                  (and (<= (point-min) start-pos)
+                       (< start-pos (point-max))
+                       (<= end-pos (point-max))
+                       (< start-pos end-pos)
+                       ;; Actual UI messages carry this property.  The
+                       ;; fallback keeps the helper usable in minimal tests.
+                       (or (null (clatter-url-preview--anchor-text anchor))
+                           (equal (get-text-property start-pos 'clatter-text)
+                                  (clatter-url-preview--anchor-text anchor))))))))))
+
+(defun clatter-url-preview--dispose-anchor (anchor)
+  "Detach every marker owned by ANCHOR."
+  (when (clatter-url-preview--anchor-p anchor)
+    (dolist (marker (list (clatter-url-preview--anchor-start anchor)
+                          (clatter-url-preview--anchor-end anchor)
+                          (clatter-url-preview--anchor-tail anchor)))
+      (when (markerp marker) (set-marker marker nil)))))
+
+(defun clatter-url-preview--release-anchor (anchor)
+  "Release one URL request's ownership of ANCHOR."
+  (when (clatter-url-preview--anchor-p anchor)
+    (setf (clatter-url-preview--anchor-remaining anchor)
+          (1- (clatter-url-preview--anchor-remaining anchor)))
+    (when (<= (clatter-url-preview--anchor-remaining anchor) 0)
+      (clatter-url-preview--dispose-anchor anchor))))
+
+(defun clatter-url-preview--insert (title buffer anchor)
+  "Insert TITLE below ANCHOR's original message.
+
+ANCHOR's tail marker is advanced after insertion, retaining cached URL order.
+No text is inserted if truncation or deletion has removed the source message."
+  (cond
+   ((clatter-url-preview--anchor-p anchor)
+    (when (and (eq buffer (clatter-url-preview--anchor-buffer anchor))
+               (clatter-url-preview--anchor-live-p anchor))
+      (with-current-buffer buffer
+        (let ((inhibit-read-only t)
+              (prefix (make-string (1+ clatter-nick-column-width) ?\s)))
+          (save-excursion
+            (goto-char (clatter-url-preview--anchor-tail anchor))
+            (insert (propertize (format "↳ %s\n" title)
+                                'face '(:foreground "#89ddff" :slant italic)
+                                'read-only t
+                                'front-sticky t
+                                'line-prefix prefix
+                                'wrap-prefix prefix))
+            ;; A nil-insertion-type marker stays before unrelated messages,
+            ;; but must move past this preview to form a stable local tail.
+            (set-marker (clatter-url-preview--anchor-tail anchor) (point)))))))
+   ;; Compatibility for callers of the former low-level marker API.
+   ((and (buffer-live-p buffer) (markerp anchor) (marker-buffer anchor))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t)
+            (prefix (make-string (1+ clatter-nick-column-width) ?\s)))
+        (save-excursion
+          (goto-char anchor)
+          (insert (propertize (format "↳ %s\n" title)
+                              'face '(:foreground "#89ddff" :slant italic)
+                              'read-only t
+                              'front-sticky t
+                              'line-prefix prefix
+                              'wrap-prefix prefix))))))))
+
+(defun clatter-url-preview--fetch (url buffer anchor)
+  "Asynchronously fetch URL and display its title in BUFFER at ANCHOR.
 Uses curl subprocess to avoid blocking Emacs on DNS/TLS."
-  (let ((clean-url (substring-no-properties url)))
+  (let ((clean-url (substring-no-properties url))
+        (fetch-buffer (generate-new-buffer " *clatter-url-fetch*")))
     (puthash clean-url t clatter-url-preview--pending)
     (condition-case nil
-        (let* ((proc-buf (generate-new-buffer " *clatter-url-fetch*"))
-               (proc (start-process
-                      "clatter-url-preview" proc-buf
+        (let ((process (start-process
+                      "clatter-url-preview" fetch-buffer
                       "curl" "-sL" "-m" (number-to-string clatter-url-preview-timeout)
                       "-o" "-" "-r" "0-16384"
                       "-H" "User-Agent: Mozilla/5.0 (compatible; clatter.el)"
                       "-H" "Accept: text/html"
                       clean-url)))
           (set-process-sentinel
-           proc
+           process
            (lambda (process _event)
              (when (memq (process-status process) '(exit signal))
-               (let ((proc-buffer (process-buffer process)))
+               (let ((output-buffer (process-buffer process)))
                  (remhash clean-url clatter-url-preview--pending)
-                 (when (and (eq (process-exit-status process) 0)
-                            (buffer-live-p proc-buffer))
-                   (let ((body (with-current-buffer proc-buffer
-                                 (buffer-string))))
-                     (let ((title (clatter-url-preview--extract-title body)))
-                       (when (and title (buffer-live-p buffer))
-                         (when (> (hash-table-count clatter-url-preview--cache)
-                                  clatter-url-preview--cache-max)
-                           (clrhash clatter-url-preview--cache))
-                         (puthash clean-url title clatter-url-preview--cache)
-                         (with-current-buffer buffer
-                           (clatter-insert-system
-                            buffer (propertize (format "\u21b3 %s" title)
-                                              'face '(:foreground "#89ddff" :slant italic))))))))
-                 (when (buffer-live-p proc-buffer)
-                   (kill-buffer proc-buffer)))))))
+                 (unwind-protect
+                     (when (and (eq (process-exit-status process) 0)
+                                (buffer-live-p output-buffer))
+                       (let ((body (with-current-buffer output-buffer
+                                     (buffer-string))))
+                         (let ((title (clatter-url-preview--extract-title body)))
+                           (when (and title (buffer-live-p buffer))
+                             (when (> (hash-table-count clatter-url-preview--cache)
+                                      clatter-url-preview--cache-max)
+                               (clrhash clatter-url-preview--cache))
+                             (puthash clean-url title clatter-url-preview--cache)
+                             (clatter-url-preview--insert title buffer anchor))))
+                   (when (buffer-live-p output-buffer)
+                     (kill-buffer output-buffer))
+                   (clatter-url-preview--release-anchor anchor))))))))
       (error
-       (remhash clean-url clatter-url-preview--pending)))))
+       (remhash clean-url clatter-url-preview--pending)
+       (when (buffer-live-p fetch-buffer)
+         (kill-buffer fetch-buffer))
+       (clatter-url-preview--release-anchor anchor)))))
 
 ;; --- Hook Handler ---
+
+(defun clatter-url-preview--message-end-marker (buffer text)
+  "Return a fixed marker immediately after TEXT's rendered message in BUFFER.
+
+For `newest-first', the messages marker is immediately before the newly
+inserted message; for `oldest-first', it is immediately after it.  The UI
+stores the unformatted message text as `clatter-text', which lets this work
+for either order and for wrapped messages."
+  (with-current-buffer buffer
+    (let* ((messages-marker (or clatter--messages-marker (point-max)))
+           (position (marker-position messages-marker))
+           (before (and (> position (point-min)) (1- position)))
+           (end (cond
+                 ((equal (get-text-property position 'clatter-text) text)
+                  (next-single-property-change position 'clatter-text nil (point-max)))
+                 ((and before
+                       (equal (get-text-property before 'clatter-text) text))
+                  position)
+                 (t position))))
+      (copy-marker end))))
+
+(defun clatter-url-preview--message-anchor (buffer text request-count)
+  "Return a shared anchor for REQUEST-COUNT previews of TEXT in BUFFER.
+
+The rendered message's `clatter-text' property is retained as an identity
+check, preventing a delayed curl sentinel from inserting at a marker left
+behind by buffer truncation."
+  (with-current-buffer buffer
+    (let* ((end (clatter-url-preview--message-end-marker buffer text))
+           (end-pos (marker-position end))
+           (start (or (previous-single-property-change
+                       end-pos 'clatter-text nil (point-min))
+                      (point-min)))
+           ;; `previous-single-property-change' returns the beginning when
+           ;; END is just after a property run; use the property's value at
+           ;; the first character to distinguish real UI messages from a
+           ;; minimal buffer used by a low-level caller.
+           (source-text (and (< start end-pos)
+                             (get-text-property start 'clatter-text)))
+           (tail (copy-marker end-pos)))
+      (set-marker-insertion-type end nil)
+      (set-marker-insertion-type tail nil)
+      (clatter-url-preview--make-anchor-record
+       :buffer buffer :start (copy-marker start) :end end :tail tail
+       :text source-text :remaining request-count))))
 
 (defun clatter-url-preview--on-privmsg (conn sender target text _server-time)
   "Check TEXT from SENDER for URLs and fetch titles for TARGET buffer on CONN."
@@ -131,25 +264,37 @@ Uses curl subprocess to avoid blocking Emacs on DNS/TLS."
                            target
                          (if (string-equal target my-nick) sender target)))
            (buf (clatter-get-buffer network buf-target))
-           (pos 0))
+           (pos 0)
+           requests)
       (when buf
         (while (string-match "https?://[^ \t\n\r<>\"']+" text pos)
           (let ((url (match-string 0 text)))
             (setq pos (match-end 0))
             (when (clatter-url-preview--should-fetch-p url)
-              ;; Check cache first
+              (push url requests))))
+        ;; Build exactly one tail per source message.  In particular, do not
+        ;; make a fresh marker for each cache hit: nil-insertion markers at
+        ;; the same position otherwise reverse source URL order.
+        (when requests
+          (setq requests (nreverse requests))
+          (let ((anchor (clatter-url-preview--message-anchor
+                         buf text (length requests))))
+            (dolist (url requests)
               (let ((cached (gethash url clatter-url-preview--cache)))
                 (if cached
-                    (clatter-insert-system
-                     buf (propertize (format "↳ %s" cached)
-                                    'face '(:foreground "#89ddff" :slant italic)))
-                  (clatter-url-preview--fetch url buf))))))))))
+                    (unwind-protect
+                        (clatter-url-preview--insert cached buf anchor)
+                      (clatter-url-preview--release-anchor anchor))
+                  (clatter-url-preview--fetch url buf anchor))))))))))
 
 ;; --- Init/Teardown ---
 
 (defun clatter-url-preview-init ()
   "Register URL preview hooks."
-  (add-hook 'clatter-privmsg-hook #'clatter-url-preview--on-privmsg))
+  ;; The UI hook must render the source message first.  The preview anchor is
+  ;; located relative to that rendered message, and a default-depth hook would
+  ;; run before the UI because `add-hook' prepends same-depth functions.
+  (add-hook 'clatter-privmsg-hook #'clatter-url-preview--on-privmsg 90))
 
 (defun clatter-url-preview-teardown ()
   "Remove URL preview hooks."

--- a/tests/test-url-preview.el
+++ b/tests/test-url-preview.el
@@ -1,0 +1,214 @@
+;;; test-url-preview.el --- Tests for URL title preview placement -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'test-helper)
+(require 'clatter-ui)
+(require 'clatter-url-preview)
+
+(ert-deftest clatter-url-preview-insert-stays-at-message-anchor ()
+  "An async title is inserted below its URL, not at the current buffer end."
+  (with-temp-buffer
+    (insert "<alice> https://example.com/one\n")
+    (let ((anchor (copy-marker (point))))
+      ;; Simulate messages arriving while curl fetches the title.  A nil
+      ;; insertion-type anchor remains before this later text.
+      (insert "<bob> later message\n")
+      (clatter-url-preview--insert "Example title" (current-buffer) anchor)
+      (should (equal (buffer-string)
+                     "<alice> https://example.com/one\n↳ Example title\n<bob> later message\n")))))
+
+(ert-deftest clatter-url-preview-hook-passes-message-anchor-to-fetch ()
+  "The hook gives the fetcher an anchor after the just-inserted message."
+  (let ((clatter-url-preview-enable t)
+        (clatter-url-preview--cache (make-hash-table :test 'equal))
+        (clatter-url-preview--pending (make-hash-table :test 'equal)))
+    (with-temp-buffer
+      (insert "<alice> https://example.com/one\n")
+      (let ((clatter--messages-marker (copy-marker (point) t))
+            (conn (clatter-test-make-connection "preview-test" "me"))
+            captured-marker)
+        (cl-letf (((symbol-function 'clatter-get-buffer)
+                   (lambda (&rest _) (current-buffer)))
+                  ((symbol-function 'clatter-url-preview--fetch)
+                   (lambda (_url _buffer marker) (setq captured-marker marker))))
+          (clatter-url-preview--on-privmsg
+           conn "alice" "#chat" "https://example.com/one" nil))
+        (should (clatter-url-preview--anchor-p captured-marker))
+        (should (eq (clatter-url-preview--anchor-buffer captured-marker)
+                    (current-buffer)))
+        (should (= (marker-position
+                    (clatter-url-preview--anchor-tail captured-marker))
+                   (point-max)))
+        (should-not (marker-insertion-type
+                     (clatter-url-preview--anchor-tail captured-marker)))))))
+
+(ert-deftest clatter-url-preview-hook-renders-after-message-in-both-orders ()
+  "URL previews follow their source message for either message order."
+  (dolist (order '(newest-first oldest-first))
+    (let ((clatter-message-order order)
+          (clatter-url-preview-enable t)
+          (clatter-url-preview--cache (make-hash-table :test 'equal))
+          (clatter-url-preview--pending (make-hash-table :test 'equal))
+          (clatter-privmsg-hook (list #'clatter-ui--on-privmsg)))
+      (puthash "https://example.com/one" "Example title"
+               clatter-url-preview--cache)
+      (clatter-url-preview-init)
+      (should (eq (car clatter-privmsg-hook) #'clatter-ui--on-privmsg))
+      (should (eq (cadr clatter-privmsg-hook)
+                  #'clatter-url-preview--on-privmsg))
+      (with-temp-buffer
+        (clatter-mode)
+        (setq-local clatter--network "preview-order")
+        (setq-local clatter--target "#chat")
+        (let ((conn (clatter-test-make-connection "preview-order" "me")))
+          (cl-letf (((symbol-function 'clatter-get-or-create-buffer)
+                     (lambda (&rest _) (current-buffer)))
+                    ((symbol-function 'clatter-get-buffer)
+                     (lambda (&rest _) (current-buffer))))
+            (run-hook-with-args 'clatter-privmsg-hook
+                                conn '("alice" nil nil) "#chat"
+                                "https://example.com/one" nil)))
+        (let* ((contents (buffer-substring-no-properties (point-min) (point-max)))
+               (message-pos (string-match "https://example.com/one" contents))
+               (preview-pos (string-match "↳ Example title" contents))
+               (prompt-pos (string-match "#chat>" contents)))
+          (should message-pos)
+          (should preview-pos)
+          (should prompt-pos)
+          (should (< message-pos preview-pos))
+          (if (eq order 'oldest-first)
+              (should (< preview-pos prompt-pos))
+            (should (< prompt-pos message-pos))))))))
+
+(ert-deftest clatter-url-preview-message-anchor-finds-newest-message-end ()
+  "A newest-first messages marker is before the message, not after it."
+  (with-temp-buffer
+    (insert "<alice> https://example.com/one\n<older> previous\n")
+    (add-text-properties (point-min) (+ (point-min) 32)
+                         '(clatter-text "https://example.com/one"))
+    (let ((clatter--messages-marker (copy-marker (point-min))))
+      (should (= (marker-position
+                  (clatter-url-preview--message-end-marker
+                   (current-buffer) "https://example.com/one"))
+                 (+ (point-min) 32))))))
+
+(ert-deftest clatter-url-preview-cached-title-uses-message-anchor ()
+  "Cached previews use the same anchor as asynchronous previews."
+  (let ((clatter-url-preview-enable t)
+        (clatter-url-preview--cache (make-hash-table :test 'equal))
+        (clatter-url-preview--pending (make-hash-table :test 'equal)))
+    (puthash "https://example.com/one" "Cached title" clatter-url-preview--cache)
+    (with-temp-buffer
+      (insert "<alice> https://example.com/one\n")
+      (let ((clatter--messages-marker (copy-marker (point) t))
+            (conn (clatter-test-make-connection "preview-cache" "me")))
+        (cl-letf (((symbol-function 'clatter-get-buffer)
+                   (lambda (&rest _) (current-buffer))))
+          (clatter-url-preview--on-privmsg
+           conn "alice" "#chat" "https://example.com/one" nil))
+        (should (equal (buffer-string)
+                       "<alice> https://example.com/one\n↳ Cached title\n"))))))
+
+(ert-deftest clatter-url-preview-fetch-start-failure-cleans-up ()
+  "A failed curl start clears pending state without signaling repeatedly."
+  (let ((clatter-url-preview--pending (make-hash-table :test 'equal))
+        (clatter-url-preview--cache (make-hash-table :test 'equal)))
+    (with-temp-buffer
+      (let ((start (copy-marker (point-min)))
+            (end (copy-marker (point-max)))
+            (tail (copy-marker (point-max))))
+        (let ((anchor
+               (clatter-url-preview--make-anchor-record
+                :buffer (current-buffer)
+                :start start
+                :end end
+                :tail tail
+                :text nil
+                :remaining 1)))
+          (cl-letf (((symbol-function 'start-process)
+                     (lambda (&rest _)
+                       (signal 'file-missing '("curl")))))
+            (clatter-url-preview--fetch
+             "https://example.com/failure" (current-buffer) anchor))
+          (should-not (gethash "https://example.com/failure"
+                               clatter-url-preview--pending))
+          (should-not (marker-buffer start))
+          (should-not (marker-buffer end))
+          (should-not (marker-buffer tail)))))))
+
+(ert-deftest clatter-url-preview-fetch-sentinel-cleans-up ()
+  "A completed curl sentinel inserts the title and releases its resources."
+  (let ((clatter-url-preview--pending (make-hash-table :test 'equal))
+        (clatter-url-preview--cache (make-hash-table :test 'equal))
+        sentinel process output-buffer)
+    (with-temp-buffer
+      (insert "https://example.com/one\n")
+      (add-text-properties (point-min) (1- (point-max))
+                           '(clatter-text "https://example.com/one"))
+      (let ((start (copy-marker (point-min)))
+            (end (copy-marker (point-max)))
+            (tail (copy-marker (point-max))))
+        (let ((anchor
+               (clatter-url-preview--make-anchor-record
+                :buffer (current-buffer)
+                :start start
+                :end end
+                :tail tail
+                :text "https://example.com/one"
+                :remaining 1)))
+          (setq process 'fake-process)
+          (cl-letf (((symbol-function 'start-process)
+                     (lambda (_name buffer &rest _args)
+                       (setq output-buffer buffer)
+                       process))
+                    ((symbol-function 'set-process-sentinel)
+                     (lambda (_process function)
+                       (setq sentinel function)))
+                    ((symbol-function 'process-status)
+                     (lambda (_process) 'exit))
+                    ((symbol-function 'process-exit-status)
+                     (lambda (_process) 0))
+                    ((symbol-function 'process-buffer)
+                     (lambda (_process) output-buffer))
+                    ((symbol-function 'process-live-p)
+                     (lambda (_process) nil))
+                    ((symbol-function 'delete-process)
+                     (lambda (_process) nil)))
+            (clatter-url-preview--fetch
+             "https://example.com/one" (current-buffer) anchor)
+            (with-current-buffer output-buffer
+              (insert "<html><title>Example title</title></html>"))
+            (funcall sentinel process "finished"))
+          (should (equal (buffer-string)
+                         "https://example.com/one\n↳ Example title\n"))
+          (should (equal (gethash "https://example.com/one"
+                                  clatter-url-preview--cache)
+                         "Example title"))
+          (should-not (gethash "https://example.com/one"
+                               clatter-url-preview--pending))
+          (should-not (buffer-live-p output-buffer))
+          (should-not (marker-buffer start))
+          (should-not (marker-buffer end))
+          (should-not (marker-buffer tail)))))))
+
+(ert-deftest clatter-url-preview-stale-anchor-is-safe-at-buffer-end ()
+  "A truncated anchor is rejected without reading past point-max."
+  (with-temp-buffer
+    (insert "message")
+    (let ((start (copy-marker (point-max)))
+          (end (copy-marker (point-max)))
+          (tail (copy-marker (point-max))))
+      (let ((anchor
+             (clatter-url-preview--make-anchor-record
+              :buffer (current-buffer)
+              :start start
+              :end end
+              :tail tail
+              :text "message"
+              :remaining 1)))
+        (should-not (clatter-url-preview--anchor-live-p anchor))))))
+
+(provide 'test-url-preview)
+
+;;; test-url-preview.el ends here

--- a/tests/test-url-preview.el
+++ b/tests/test-url-preview.el
@@ -33,7 +33,7 @@
                   ((symbol-function 'clatter-url-preview--fetch)
                    (lambda (_url _buffer marker) (setq captured-marker marker))))
           (clatter-url-preview--on-privmsg
-           conn "alice" "#chat" "https://example.com/one" nil))
+           conn '("alice" nil nil) "#chat" "https://example.com/one" nil))
         (should (clatter-url-preview--anchor-p captured-marker))
         (should (eq (clatter-url-preview--anchor-buffer captured-marker)
                     (current-buffer)))
@@ -106,7 +106,7 @@
         (cl-letf (((symbol-function 'clatter-get-buffer)
                    (lambda (&rest _) (current-buffer))))
           (clatter-url-preview--on-privmsg
-           conn "alice" "#chat" "https://example.com/one" nil))
+           conn '("alice" nil nil) "#chat" "https://example.com/one" nil))
         (should (equal (buffer-string)
                        "<alice> https://example.com/one\n↳ Cached title\n"))))))
 


### PR DESCRIPTION
Anchors cached and asynchronous URL previews to their source messages, preserves preview order, guards stale markers, and cleans up failed fetches and sentinels. Focused URL-preview tests passed and the branch was manually tested.