### PR TITLE
Enable smart noise filtering

### DIFF
--- a/clatter-smart.el
+++ b/clatter-smart.el
@@ -25,6 +25,15 @@
                          (const :tag "AWAY" away)))
   :group 'clatter)
 
+(defcustom clatter-smart-enabled t
+  "When non-nil, hide smart-filtered noise in newly created buffers.
+
+This adds the `noise' invisibility category to new clatter buffers when
+`clatter-smart-noise' is non-nil.  Explicit `clatter-suppress-messages'
+settings continue to be honored independently."
+  :type 'boolean
+  :group 'clatter)
+
 (defcustom clatter-smart-threshold 0.5
   "SNR threshold under which noisy message types are hidden."
   :type 'number

--- a/clatter-smart.el
+++ b/clatter-smart.el
@@ -35,12 +35,14 @@ settings continue to be honored independently."
   :group 'clatter)
 
 (defcustom clatter-smart-threshold 0.5
-  "SNR threshold under which noisy message types are hidden."
+  "SNR threshold under which inactive nicks' noisy message types are hidden."
   :type 'number
   :group 'clatter)
 
 (defvar clatter-smart-data nil
-  "Count of noisy and non-noisy messages, keyed by nick.")
+  "Smart filter state keyed by nick.
+
+Each value is a list (SIGNAL-COUNT NOISE-COUNT ACTIVE-P).")
 
 (defun clatter-smart-on (buf)
   "Get smart filter data for BUF."
@@ -48,6 +50,23 @@ settings continue to be honored independently."
     (or clatter-smart-data
         (setq-local clatter-smart-data
                     (make-hash-table :test 'equal)))))
+
+(defun clatter-smart--entry-signal-count (entry)
+  "Return signal count from smart state ENTRY."
+  (if (consp entry) (or (car entry) 0) 0))
+
+(defun clatter-smart--entry-noise-count (entry)
+  "Return noise count from smart state ENTRY."
+  (cond
+   ((and (consp entry) (consp (cdr entry))) (or (cadr entry) 0))
+   ((consp entry) (or (cdr entry) 0))
+   (t 0)))
+
+(defun clatter-smart--entry-active-p (entry)
+  "Return non-nil when smart state ENTRY has observed signal."
+  (and (consp entry)
+       (consp (cdr entry))
+       (nth 2 entry)))
 
 (defun clatter-smart-put (buf nick elt)
   "Record ELT for NICK in BUF and return the SNR value."
@@ -60,22 +79,30 @@ settings continue to be honored independently."
                               (stringp elt)))
          (data (clatter-smart-on buf))
          (signal-noise (gethash nick data))
-         (signal-count (or (car signal-noise) 1))
-         (noise-count (or (cdr signal-noise) 1))
+         (signal-count (clatter-smart--entry-signal-count signal-noise))
+         (noise-count (clatter-smart--entry-noise-count signal-noise))
+         (active-p (clatter-smart--entry-active-p signal-noise))
          (is-noise (memq (if is-nick-change 'nick elt) clatter-smart-noise)))
     (when is-nick-change
       (remhash nick data)
       (setq nick elt))
     (setq signal-count (+ signal-count (if is-noise 0 1)))
     (setq noise-count (+ noise-count (if is-noise 1 0)))
-    (puthash nick (cons signal-count noise-count) data)
+    (setq active-p (or active-p (not is-noise)))
+    (puthash nick (list signal-count noise-count active-p) data)
     ;; Float division: integer division would collapse the ratio to 0 or 1
     ;; and make `clatter-smart-threshold' meaningless.
-    (/ (float signal-count) noise-count)))
+    (if (zerop noise-count)
+        most-positive-fixnum
+      (/ (float signal-count) noise-count))))
 
 (defun clatter-smart-eval (buf nick elt)
   "Record ELT for NICK in BUF and return whether NICK is noisy."
-  (< (clatter-smart-put buf nick elt) clatter-smart-threshold))
+  (let* ((ratio (clatter-smart-put buf nick elt))
+         (key (downcase (if (stringp elt) elt nick)))
+         (entry (gethash key (clatter-smart-on buf))))
+    (and (not (clatter-smart--entry-active-p entry))
+         (< ratio clatter-smart-threshold))))
 
 (provide 'clatter-smart)
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -632,6 +632,11 @@ If the input contains multiple lines and exceeds
     ;; Use a fresh copy so per-buffer /suppress and /unsuppress edits
     ;; never mutate the shared clatter-suppress-messages list.
     (setq buffer-invisibility-spec (copy-sequence clatter-suppress-messages))
+    ;; Smart filtering uses the `noise' category.  Seed it automatically
+    ;; only when smart filtering is enabled and has message types to filter;
+    ;; an explicitly configured `noise' suppression remains untouched.
+    (when (and clatter-smart-enabled clatter-smart-noise)
+      (add-to-invisibility-spec 'noise))
     (unless clatter-fools-visible
       (add-to-invisibility-spec 'clatter-fool))
     (clatter--setup-prompt buffer)

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -63,6 +63,70 @@
 
 ;; --- Fool visibility ---
 
+;; --- Smart noise visibility ---
+
+(ert-deftest clatter-test-smart-noise-seeds-new-buffer-by-default ()
+  "New clatter buffers hide smart-filtered noise by default."
+  (let ((clatter-smart-enabled t)
+        (clatter-smart-noise '(join)))
+    (with-temp-buffer
+      (clatter-mode)
+      (clatter-ui-setup-buffer (current-buffer))
+      (should (memq 'noise buffer-invisibility-spec)))))
+
+(ert-deftest clatter-test-smart-noise-disabled-does-not-seed-new-buffer ()
+  "Disabling smart noise leaves the automatic category out of new buffers."
+  (let ((clatter-smart-enabled nil)
+        (clatter-smart-noise '(join))
+        (clatter-suppress-messages '(muted)))
+    (with-temp-buffer
+      (clatter-mode)
+      (clatter-ui-setup-buffer (current-buffer))
+      (should-not (memq 'noise buffer-invisibility-spec)))))
+
+(ert-deftest clatter-test-empty-smart-noise-does-not-seed-new-buffer ()
+  "No automatic category is added when no message types are smart-filtered."
+  (let ((clatter-smart-enabled t)
+        (clatter-smart-noise nil)
+        (clatter-suppress-messages '(muted)))
+    (with-temp-buffer
+      (clatter-mode)
+      (clatter-ui-setup-buffer (current-buffer))
+      (should-not (memq 'noise buffer-invisibility-spec)))))
+
+(ert-deftest clatter-test-explicit-noise-suppression-is-preserved ()
+  "Global noise suppression remains effective when smart noise is disabled."
+  (let ((clatter-smart-enabled nil)
+        (clatter-smart-noise nil)
+        (clatter-suppress-messages '(muted noise)))
+    (with-temp-buffer
+      (clatter-mode)
+      (clatter-ui-setup-buffer (current-buffer))
+      (should (memq 'noise buffer-invisibility-spec)))))
+
+(ert-deftest clatter-test-smart-noise-tags-noisy-events-in-new-buffer ()
+  "A smart-filtered event in a new buffer carries the hidden noise category."
+  (let ((clatter-smart-enabled t)
+        (clatter-smart-noise '(join))
+        (clatter--buffer-alist nil)
+        (conn (clatter-test-make-connection)))
+    (unwind-protect
+          (cl-letf (((symbol-function 'clatter-smart-eval)
+                   (lambda (&rest _args) t)))
+          (clatter-ui--on-join conn '("noisy" nil nil) "#test" nil nil)
+          (let ((buffer (clatter-get-buffer "testnet" "#test")))
+            (should buffer)
+            (with-current-buffer buffer
+              (should (memq 'noise buffer-invisibility-spec))
+              (goto-char (point-min))
+              (search-forward "noisy has joined")
+              (should (memq 'noise
+                            (ensure-list (get-text-property (match-beginning 0) 'invisible)))))))
+      (dolist (buffer (clatter-all-buffers))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer)))
+      (clatter-test-cleanup))))
+
 (ert-deftest clatter-test-fool-message-gets-dim-face ()
   "Messages with the fool invisibility category get `clatter-fool'."
   (with-temp-buffer

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -127,6 +127,87 @@
           (kill-buffer buffer)))
       (clatter-test-cleanup))))
 
+(ert-deftest clatter-test-smart-noise-hides-first-join-from-non-chatter ()
+  "A nick with no prior channel signal has its first smart-noise event hidden."
+  (let ((clatter-smart-enabled t)
+        (clatter-smart-noise '(join part away))
+        (clatter-suppress-messages '(muted))
+        (clatter--buffer-alist nil)
+        (conn (clatter-test-make-connection)))
+    (unwind-protect
+        (progn
+          (clatter-ui--on-join conn '("lurker" nil nil) "#test" nil nil)
+          (let ((buffer (clatter-get-buffer "testnet" "#test")))
+            (should buffer)
+            (with-current-buffer buffer
+              (goto-char (point-min))
+              (search-forward "lurker has joined")
+              (should (memq 'noise
+                            (ensure-list (get-text-property (match-beginning 0) 'invisible)))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-smart-noise-keeps-part-from-active-nick ()
+  "A nick that chatted in a channel keeps its later PART visible."
+  (let ((clatter-smart-enabled t)
+        (clatter-smart-noise '(join part away))
+        (clatter-suppress-messages '(muted))
+        (clatter--buffer-alist nil)
+        (conn (clatter-test-make-connection)))
+    (unwind-protect
+        (progn
+          (clatter-ui--on-privmsg conn '("alice" nil nil) "#test" "hello" nil)
+          (clatter-ui--on-part conn '("alice" nil nil) "#test" "bye")
+          (let ((buffer (clatter-get-buffer "testnet" "#test")))
+            (should buffer)
+            (with-current-buffer buffer
+              (goto-char (point-min))
+              (search-forward "alice has left #test")
+              (should-not (memq 'noise
+                                (ensure-list (get-text-property (match-beginning 0) 'invisible)))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-smart-noise-keeps-away-from-active-nick ()
+  "A nick that chatted in a channel keeps its later AWAY visible."
+  (let ((clatter-smart-enabled t)
+        (clatter-smart-noise '(join part away))
+        (clatter-suppress-messages '(muted))
+        (clatter--buffer-alist nil)
+        (conn (clatter-test-make-connection)))
+    (unwind-protect
+        (progn
+          (clatter-ui--on-privmsg conn '("alice" nil nil) "#test" "hello" nil)
+          (let ((buffer (clatter-get-buffer "testnet" "#test")))
+            (should buffer)
+            (with-current-buffer buffer
+              (clatter-nick-add buffer "alice")))
+          (clatter-ui--on-away conn '("alice" nil nil) "away")
+          (let ((buffer (clatter-get-buffer "testnet" "#test")))
+            (with-current-buffer buffer
+              (goto-char (point-min))
+              (search-forward "alice is away: away")
+              (should-not (memq 'noise
+                                (ensure-list (get-text-property (match-beginning 0) 'invisible)))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-smart-noise-keeps-repeated-noise-from-active-nick ()
+  "Once a nick has signal, later noise stays visible regardless of volume."
+  (let ((clatter-smart-noise '(join part quit nick away))
+        (clatter-smart-threshold 0.5))
+    (with-temp-buffer
+      (clatter-smart-put (current-buffer) "alice" 'privmsg)
+      (dotimes (_ 8)
+        (should-not (clatter-smart-eval (current-buffer) "alice" 'away))))))
+
+(ert-deftest clatter-test-smart-noise-preserves-active-state-across-nick-change ()
+  "Nick changes carry active state to the new nick."
+  (let ((clatter-smart-noise '(join part quit nick away))
+        (clatter-smart-threshold 0.5))
+    (with-temp-buffer
+      (clatter-smart-put (current-buffer) "alice" 'privmsg)
+      (should-not (clatter-smart-eval (current-buffer) "alice" "alice_"))
+      (dotimes (_ 8)
+        (should-not (clatter-smart-eval (current-buffer) "alice_" 'part))))))
+
 (ert-deftest clatter-test-fool-message-gets-dim-face ()
   "Messages with the fool invisibility category get `clatter-fool'."
   (with-temp-buffer


### PR DESCRIPTION
Adds an opt-out smart-noise switch and seeds the noise invisibility category for new buffers when smart filtering is configured. Focused UI tests passed and the branch was manually tested.