### PR TITLE
Navigate URL buttons with TAB

### DIFF
--- a/clatter-hl-nicks.el
+++ b/clatter-hl-nicks.el
@@ -13,6 +13,8 @@
 
 ;;; Code:
 
+(require 'button)
+
 (require 'cl-lib)
 (require 'clatter-config)
 (require 'clatter-model)
@@ -244,7 +246,7 @@ Returns `clatter-my-nick' for our own nick, otherwise a named
   "Regexp matching URLs in IRC messages.")
 
 (defun clatter-hl-urls-in-string (text)
-  "Highlight URLs in TEXT with clickable properties."
+  "Highlight URLs in TEXT as standard Emacs buttons."
   (let ((pos 0)
         (result ""))
     (while (string-match clatter-url-regexp text pos)
@@ -252,13 +254,17 @@ Returns `clatter-my-nick' for our own nick, otherwise a named
             (end (match-end 0))
             (url (match-string 0 text)))
         (setq result (concat result (substring text pos start)))
-        (setq result (concat result
-                             (propertize url
-                                         'face '(:foreground "#89ddff" :underline t)
-                                         'mouse-face 'highlight
-                                         'clatter-url url
-                                         'help-echo url
-                                         'keymap clatter-hl-url-keymap)))
+        (let ((button-text
+               (propertize url
+                           'button '(t)
+                           'category 'default-button
+                           'follow-link t
+                           'clatter-url url
+                           'face '(:foreground "#89ddff" :underline t)
+                           'help-echo url
+                           'action (lambda (button)
+                                     (browse-url (button-get button 'clatter-url))))))
+          (setq result (concat result button-text)))
         (setq pos end)))
     (concat result (substring text pos))))
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -596,6 +596,20 @@ If the input contains multiple lines and exceeds
        (equal (point-marker) clatter--prompt-marker)
        (goto-char clatter--input-marker)))
 
+(defun clatter-tab ()
+  "Complete at the prompt, or move to the next button in message history."
+  (interactive)
+  (if (and clatter--input-marker (>= (point) (marker-position clatter--input-marker)))
+      (completion-at-point)
+    (forward-button 1)))
+
+(defun clatter-backtab ()
+  "Complete at the prompt, or move to the previous button in message history."
+  (interactive)
+  (if (and clatter--input-marker (>= (point) (marker-position clatter--input-marker)))
+      (completion-at-point)
+    (backward-button 1)))
+
 ;; Forward declaration
 (declare-function clatter-execute-command "clatter-commands")
 
@@ -1453,7 +1467,8 @@ Requires the server to support the message-tags capability."
   (add-hook 'clatter-mode-hook #'clatter-ui--setup-eldoc)
   ;; Key bindings for input
   (define-key clatter-mode-map (kbd "RET") #'clatter-send-input)
-  (define-key clatter-mode-map (kbd "TAB") #'completion-at-point)
+  (define-key clatter-mode-map (kbd "TAB") #'clatter-tab)
+  (define-key clatter-mode-map (kbd "<backtab>") #'clatter-backtab)
   (define-key clatter-mode-map (kbd "M-p") #'clatter-set-prev-input)
   (define-key clatter-mode-map (kbd "M-n") #'clatter-set-next-input)
   (define-key clatter-mode-map (kbd "C-a") #'clatter-bol)

--- a/tests/test-hl-nicks.el
+++ b/tests/test-hl-nicks.el
@@ -11,6 +11,14 @@
 (require 'ert)
 (require 'clatter-hl-nicks)
 
+(ert-deftest clatter-hl-urls-are-standard-buttons ()
+  "URL highlighting produces a standard Emacs button."
+  (let* ((text (clatter-hl-urls-in-string "see https://example.com/a"))
+         (button (get-text-property (string-match "https" text) 'button text)))
+    (should button)
+    (should (equal (get-text-property (string-match "https" text) 'clatter-url text)
+                   "https://example.com/a"))))
+
 (ert-deftest clatter-hl-nick-index-deterministic-and-in-range ()
   "The palette index is stable and within bounds."
   (let ((n (length clatter-hl-nick-colors)))

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -7,6 +7,15 @@
 (require 'clatter-commands)
 (require 'clatter-nicklist)
 
+(ert-deftest clatter-tab-navigates-buttons-outside-input ()
+  "TAB moves to a message button when outside the input area."
+  (with-temp-buffer
+    (clatter-mode)
+    (insert "x" (clatter-hl-urls-in-string "https://example.com/a"))
+    (goto-char (point-min))
+    (clatter-tab)
+    (should (button-at (point)))))
+
 ;; --- Timestamp margins ---
 
 (ert-deftest clatter-test-timestamp-side-left-margin ()


### PR DESCRIPTION
Turns URLs into standard Emacs buttons and adds context-aware TAB/backtab navigation while preserving prompt completion. Focused button and UI tests passed and the branch was manually tested.