### PR TITLE
Suppress repeated message timestamps

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -118,6 +118,15 @@ See `format-time-string' for format specifiers."
   :type 'string
   :group 'clatter)
 
+(defcustom clatter-timestamp-only-if-changed nil
+  "Display a message timestamp only when its formatted value changes.
+
+When non-nil, consecutive messages in the same buffer whose timestamps
+format to the same string share a single displayed timestamp.  The
+comparison is local to each Clatter buffer."
+  :type 'boolean
+  :group 'clatter)
+
 (defcustom clatter-timestamp-side 'right
   "Side of the window where message timestamps are displayed.
 The value `left' uses the left margin, `right' uses the right margin,

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -24,6 +24,9 @@
 
 ;; --- Faces ---
 
+(defvar-local clatter--last-formatted-timestamp nil
+  "Last formatted message timestamp in the current Clatter buffer.")
+
 (defface clatter-timestamp
   '((t :foreground "#7c7c7c"))
   "Face for message timestamps."
@@ -208,11 +211,22 @@ append at the bottom like a traditional IRC client."
             ;; the layout: below a top prompt for `newest-first', or above a
             ;; bottom prompt for `oldest-first'.
             (goto-char (or clatter--messages-marker (point-max)))
-            (let* ((ts-str (unless no-timestamp
-                             (format-time-string clatter-timestamp-format time)))
+            (let* ((formatted-timestamp
+                    (unless no-timestamp
+                      (format-time-string clatter-timestamp-format time)))
+                   (ts-str (and formatted-timestamp
+                                (or (not clatter-timestamp-only-if-changed)
+                                    (not (equal formatted-timestamp
+                                                clatter--last-formatted-timestamp)))
+                                formatted-timestamp))
                    (wrap-col (1+ clatter-nick-column-width))
                    (wrap-prefix (make-string wrap-col ?\s))
                    (start (point)))
+              ;; Remember the formatted value, rather than the raw time, so
+              ;; formats without seconds coalesce correctly and each buffer
+              ;; keeps its own timestamp run.
+              (when formatted-timestamp
+                (setq clatter--last-formatted-timestamp formatted-timestamp))
               (insert text "\n")
               (when (and clatter-fill-column
                          (> clatter-fill-column wrap-col))

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -9,6 +9,48 @@
 
 ;; --- Timestamp margins ---
 
+(defun clatter-test--timestamp-overlay-count ()
+  "Return the number of message timestamp overlays in the current buffer."
+  (cl-count-if (lambda (overlay) (overlay-get overlay 'clatter-timestamp))
+               (overlays-in (point-min) (point-max))))
+
+(ert-deftest clatter-test-timestamps-only-if-changed-coalesces-formatted-values ()
+  "Repeated formatted timestamps use one margin timestamp when enabled."
+  (let ((clatter-timestamp-only-if-changed t)
+        (clatter-timestamp-format "%H:%M")
+        (clatter-timestamp-side 'right)
+        (first (encode-time 30 12 10 1 1 2026))
+        (same-minute (encode-time 59 12 10 1 1 2026))
+        (next-minute (encode-time 0 13 10 1 1 2026)))
+    (with-temp-buffer
+      (clatter--insert-message (current-buffer) "first" nil nil first)
+      (clatter--insert-message (current-buffer) "same minute" nil nil same-minute)
+      (clatter--insert-message (current-buffer) "next minute" nil nil next-minute)
+      (should (= (clatter-test--timestamp-overlay-count) 2)))))
+
+(ert-deftest clatter-test-timestamps-only-if-changed-is-buffer-local ()
+  "Timestamp suppression does not carry over to another buffer."
+  (let ((clatter-timestamp-only-if-changed t)
+        (clatter-timestamp-format "%H:%M")
+        (time (encode-time 30 12 10 1 1 2026)))
+    (with-temp-buffer
+      (clatter--insert-message (current-buffer) "first" nil nil time)
+      (clatter--insert-message (current-buffer) "same buffer" nil nil time)
+      (should (= (clatter-test--timestamp-overlay-count) 1)))
+    (with-temp-buffer
+      (clatter--insert-message (current-buffer) "other buffer" nil nil time)
+      (should (= (clatter-test--timestamp-overlay-count) 1)))))
+
+(ert-deftest clatter-test-timestamps-only-if-changed-default-keeps-every-timestamp ()
+  "The default preserves the current per-message timestamp behavior."
+  (let ((clatter-timestamp-only-if-changed nil)
+        (clatter-timestamp-format "%H:%M")
+        (time (encode-time 30 12 10 1 1 2026)))
+    (with-temp-buffer
+      (clatter--insert-message (current-buffer) "first" nil nil time)
+      (clatter--insert-message (current-buffer) "second" nil nil time)
+      (should (= (clatter-test--timestamp-overlay-count) 2)))))
+
 (ert-deftest clatter-test-timestamp-side-left-margin ()
   "Left timestamp side configures the left margin."
   (let ((clatter-timestamp-side 'left)


### PR DESCRIPTION
Adds opt-in per-buffer timestamp coalescing when consecutive messages share the same formatted timestamp. Focused UI tests passed and the branch was manually tested.