### PR TITLE
Make input prompts configurable

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -272,6 +272,19 @@ prompt so the character is entered there."
   :type 'boolean
   :group 'clatter)
 
+(defcustom clatter-prompt-format "%t> "
+  "Format used for the input prompt in Clatter buffers.
+
+The value may be a string or a function.  In a string, `%t' expands to
+the buffer target, `%n' to the current nickname, `%N' to the network
+name, and `%%' to a literal percent sign.  A function is called with
+one argument, the Clatter buffer, and must return a string.
+
+The default preserves Clatter's historical `target> ' prompt."
+  :type '(choice (string :tag "Format string")
+                 (function :tag "Function"))
+  :group 'clatter)
+
 (defcustom clatter-buffer-max-lines 10000
   "Maximum number of lines to keep in a clatter buffer.
 When exceeded, oldest messages are removed.

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -437,6 +437,62 @@ SERVER-TIME overrides the current time for the timestamp."
 
 ;; --- Input prompt ---
 
+(defun clatter--prompt-string (&optional buffer)
+  "Return the configured prompt string for BUFFER.
+When BUFFER is nil, use the current buffer."
+  (with-current-buffer (or buffer (current-buffer))
+    (let* ((target (or clatter--target "clatter"))
+           (network (or clatter--network ""))
+           (conn (and clatter--network
+                      (clatter-get-connection clatter--network)))
+           (nick (if conn (or (clatter-connection-nick conn) "") ""))
+           (format-spec `((?t . ,target) (?n . ,nick) (?N . ,network)
+                          (?% . "%"))))
+      (cond
+       ((stringp clatter-prompt-format)
+        (format-spec clatter-prompt-format format-spec))
+       ((functionp clatter-prompt-format)
+        (let ((result (funcall clatter-prompt-format (current-buffer))))
+          (unless (stringp result)
+            (error "`clatter-prompt-format' function must return a string"))
+          result))
+       (t (error "Invalid `clatter-prompt-format': %S" clatter-prompt-format))))))
+
+(defun clatter--prompt-format-needs-nick-p ()
+  "Return non-nil if `clatter-prompt-format' may depend on the current nick."
+  (or (functionp clatter-prompt-format)
+      (and (stringp clatter-prompt-format)
+           (string-match-p "\\(?:^\\|[^%]\\)\\(?:%%\\)*%n"
+                           clatter-prompt-format))))
+
+(defun clatter--propertized-prompt (&optional buffer)
+  "Return the read-only, propertized prompt for BUFFER."
+  (propertize (clatter--prompt-string buffer)
+              'face 'clatter-prompt
+              'read-only t
+              'front-sticky t
+              'rear-nonsticky t))
+
+(defun clatter--refresh-prompt ()
+  "Refresh the current buffer's prompt without losing pending input."
+  (when (and clatter--prompt-marker clatter--input-marker)
+    (let* ((input (clatter--get-input))
+           (point-in-input (and (>= (point) (marker-position clatter--input-marker))
+                                (<= (point) (clatter--input-end))))
+           (input-offset (and point-in-input
+                              (- (point) (marker-position clatter--input-marker))))
+           (inhibit-read-only t))
+      (save-excursion
+        (goto-char clatter--prompt-marker)
+        (delete-region clatter--prompt-marker clatter--input-marker)
+        (insert (clatter--propertized-prompt))
+        (set-marker clatter--input-marker (point)))
+      ;; INPUT remains after the newly inserted prompt.  Restore point in it
+      ;; so a nick change cannot disrupt someone composing a message.
+      (when point-in-input
+        (goto-char (+ (marker-position clatter--input-marker)
+                      (min input-offset (length input))))))))
+
 (defun clatter--setup-prompt (buffer)
   "Set up the input prompt in BUFFER.
 For `newest-first' the prompt sits at the top with messages below it.
@@ -445,11 +501,7 @@ conventional IRC client, with messages accumulating above it."
   (with-current-buffer buffer
     (let ((inhibit-read-only t)
           (buffer-undo-list t)
-          (prompt (propertize (concat (or clatter--target "clatter") "> ")
-                              'face 'clatter-prompt
-                              'read-only t
-                              'front-sticky t
-                              'rear-nonsticky t)))
+          (prompt (clatter--propertized-prompt buffer)))
       (clatter-input-ring-setup)
       (if (eq clatter-message-order 'oldest-first)
           ;; Bottom prompt: [messages...] then prompt+input on the last line.
@@ -864,7 +916,15 @@ the buffer margin-width variables."
                                             (listp (buffer-local-value 'buffer-invisibility-spec buf))
                                             (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
                                             (clatter-smart-eval buf old-nick new-nick)
-                                            '(noise))))))))
+                                            '(noise))))))
+    ;; The handler has already updated CONN's nick.  Refresh every prompt on
+    ;; this network only when this was our own nick change and the configured
+    ;; prompt may depend on the nick.
+    (when (string-equal-ignore-case new-nick my-nick)
+      (dolist (buf (clatter-all-buffers network))
+        (with-current-buffer buf
+          (when (clatter--prompt-format-needs-nick-p)
+            (clatter--refresh-prompt)))))))
 
 (defun clatter-ui--on-topic (conn channel sender topic at)
   "Show TOPIC for CHANNEL set by SENDER at AT on CONN."

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -129,6 +129,9 @@
 (defvar-local clatter--messages-marker nil
   "Marker for the start of the message area (below the input line).")
 
+(defvar-local clatter--prompt-shows-nick nil
+  "Non-nil when the current prompt already displays the connection nick.")
+
 (defun clatter--fool-invisibility-p (invisible)
   "Return non-nil if INVISIBLE includes the fool visibility category."
   (or (eq invisible 'clatter-fool)
@@ -465,13 +468,30 @@ When BUFFER is nil, use the current buffer."
            (string-match-p "\\(?:^\\|[^%]\\)\\(?:%%\\)*%n"
                            clatter-prompt-format))))
 
+(defun clatter--prompt-shows-nick-p (prompt &optional buffer)
+  "Return non-nil if PROMPT displays BUFFER's current connection nick."
+  (with-current-buffer (or buffer (current-buffer))
+    (let* ((conn (and clatter--network
+                      (clatter-get-connection clatter--network)))
+           (nick (and conn (clatter-connection-nick conn))))
+      (and (stringp nick)
+           (not (string-empty-p nick))
+           (if (stringp clatter-prompt-format)
+               (string-match-p "\\(?:^\\|[^%]\\)\\(?:%%\\)*%n"
+                               clatter-prompt-format)
+             (string-match-p (regexp-quote nick) prompt))))))
+
 (defun clatter--propertized-prompt (&optional buffer)
   "Return the read-only, propertized prompt for BUFFER."
-  (propertize (clatter--prompt-string buffer)
-              'face 'clatter-prompt
-              'read-only t
-              'front-sticky t
-              'rear-nonsticky t))
+  (let ((prompt (clatter--prompt-string buffer)))
+    (with-current-buffer (or buffer (current-buffer))
+      (setq-local clatter--prompt-shows-nick
+                  (clatter--prompt-shows-nick-p prompt)))
+    (propertize prompt
+                'face 'clatter-prompt
+                'read-only t
+                'front-sticky t
+                'rear-nonsticky t)))
 
 (defun clatter--refresh-prompt ()
   "Refresh the current buffer's prompt without losing pending input."
@@ -662,14 +682,16 @@ If the input contains multiple lines and exceeds
   (when clatter--network
     (let* ((conn (clatter-get-connection clatter--network))
            (nick (if conn (clatter-connection-nick conn) "?"))
+           (nick-str (unless clatter--prompt-shows-nick
+                       (format " %s" nick)))
            (nicks (clatter-nick-count (current-buffer)))
            (topic-str (if clatter--topic
                           (truncate-string-to-width clatter--topic 40 nil nil "...")
                         "")))
-      (format " [%s/%s] %s%s%s"
+      (format " [%s/%s]%s%s%s"
               clatter--network
               (or clatter--target "")
-              nick
+              (or nick-str "")
               (if (> nicks 0) (format " (%d)" nicks) "")
               (if (> (length topic-str) 0)
                   (format " - %s" topic-str)

--- a/tests/test-input.el
+++ b/tests/test-input.el
@@ -77,6 +77,36 @@
   (let ((clatter-prompt-format (lambda (_buffer) "prompt> ")))
     (should (clatter--prompt-format-needs-nick-p))))
 
+(ert-deftest clatter-prompt-nick-hides-mode-line-nick ()
+  "Prompts that display the current nick do not repeat it in the mode-line."
+  (let ((clatter-prompt-format "%n> "))
+    (with-temp-buffer
+      (clatter-mode)
+      (setq-local clatter--network "testnet")
+      (setq-local clatter--target "#test")
+      (let ((conn (clatter-test-make-connection "testnet" "alice")))
+        (unwind-protect
+            (progn
+              (clatter--setup-prompt (current-buffer))
+              (should (string-prefix-p "alice> " (buffer-string)))
+              (should-not (string-match-p "alice" (clatter--mode-line-string))))
+          (remhash (clatter-connection-network-id conn) clatter-connections))))))
+
+(ert-deftest clatter-prompt-target-keeps-mode-line-nick ()
+  "Prompts without the current nick keep the nick in the mode-line."
+  (let ((clatter-prompt-format "%t> "))
+    (with-temp-buffer
+      (clatter-mode)
+      (setq-local clatter--network "testnet")
+      (setq-local clatter--target "#test")
+      (let ((conn (clatter-test-make-connection "testnet" "alice")))
+        (unwind-protect
+            (progn
+              (clatter--setup-prompt (current-buffer))
+              (should (string-prefix-p "#test> " (buffer-string)))
+              (should (string-match-p "alice" (clatter--mode-line-string))))
+          (remhash (clatter-connection-network-id conn) clatter-connections))))))
+
 (ert-deftest clatter-prompt-refresh-preserves-pending-input ()
   "Refreshing a nick-based prompt retains typed input and input point."
   (let ((clatter-prompt-format "%n> "))

--- a/tests/test-input.el
+++ b/tests/test-input.el
@@ -8,6 +8,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'test-helper)
 (require 'clatter-ui)
 
 (defmacro clatter-input-test--with (order &rest body)
@@ -31,6 +32,106 @@
   (save-excursion
     (goto-char (point-min))
     (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+
+(ert-deftest clatter-prompt-format-expands-placeholders ()
+  "String prompt formats expand target, nick, network, and percent."
+  (let ((clatter-prompt-format "%N/%n:%t %% "))
+    (with-temp-buffer
+      (clatter-mode)
+      (setq-local clatter--network "testnet")
+      (setq-local clatter--target "#test")
+      (let ((conn (clatter-test-make-connection "testnet" "alice")))
+        (unwind-protect
+            (progn
+              (clatter--setup-prompt (current-buffer))
+              (should (string-prefix-p "testnet/alice:#test % " (buffer-string))))
+          (remhash (clatter-connection-network-id conn) clatter-connections))))))
+
+(ert-deftest clatter-prompt-format-function-receives-context ()
+  "Function prompt formats receive the Clatter buffer."
+  (let ((clatter-prompt-format
+         (lambda (buffer)
+           (with-current-buffer buffer
+             (let ((conn (clatter-get-connection clatter--network)))
+               (format "%s@%s/%s>"
+                       (clatter-connection-nick conn)
+                       clatter--network
+                       clatter--target))))))
+    (with-temp-buffer
+      (clatter-mode)
+      (setq-local clatter--network "testnet")
+      (setq-local clatter--target "#test")
+      (let ((conn (clatter-test-make-connection "testnet" "alice")))
+        (unwind-protect
+            (progn
+              (clatter--setup-prompt (current-buffer))
+              (should (string-prefix-p "alice@testnet/#test>" (buffer-string))))
+          (remhash (clatter-connection-network-id conn) clatter-connections))))))
+
+(ert-deftest clatter-prompt-format-needs-nick-detects-unescaped-specifier ()
+  "Nick prompt detection ignores literal percent escapes."
+  (let ((clatter-prompt-format "%n> "))
+    (should (clatter--prompt-format-needs-nick-p)))
+  (let ((clatter-prompt-format "%t %%n> "))
+    (should-not (clatter--prompt-format-needs-nick-p)))
+  (let ((clatter-prompt-format (lambda (_buffer) "prompt> ")))
+    (should (clatter--prompt-format-needs-nick-p))))
+
+(ert-deftest clatter-prompt-refresh-preserves-pending-input ()
+  "Refreshing a nick-based prompt retains typed input and input point."
+  (let ((clatter-prompt-format "%n> "))
+    (with-temp-buffer
+      (clatter-mode)
+      (setq-local clatter--network "testnet")
+      (setq-local clatter--target "#test")
+      (let ((conn (clatter-test-make-connection "testnet" "alice")))
+        (unwind-protect
+            (progn
+              (clatter--setup-prompt (current-buffer))
+              (goto-char (clatter--input-end))
+              (insert "draft")
+              (goto-char (+ (marker-position clatter--input-marker) 2))
+              (setf (clatter-connection-nick conn) "bob")
+              (clatter--refresh-prompt)
+              (should (string-prefix-p "bob> draft" (buffer-string)))
+              (should (equal (clatter--get-input) "draft"))
+              (should (= (point) (+ (marker-position clatter--input-marker) 2))))
+          (remhash (clatter-connection-network-id conn) clatter-connections))))))
+
+(ert-deftest clatter-prompt-nick-hook-refreshes-nick-prompts-only ()
+  "Own nick changes refresh nick prompts and preserve other prompt formats."
+  (let ((conn (clatter-test-make-connection "testnet" "alice"))
+        nick-buffer
+        target-buffer)
+    (unwind-protect
+        (progn
+          (setq nick-buffer (clatter-get-or-create-buffer "testnet" "#nick" 'channel))
+          (with-current-buffer nick-buffer
+            (setq-local clatter-prompt-format "%n> ")
+            (clatter--setup-prompt nick-buffer)
+            (goto-char (clatter--input-end))
+            (insert "draft"))
+          (setq target-buffer (clatter-get-or-create-buffer "testnet" "#target" 'channel))
+          (with-current-buffer target-buffer
+            (setq-local clatter-prompt-format "%t> ")
+            (clatter--setup-prompt target-buffer)
+            (should (string-prefix-p "#target> " (buffer-string))))
+          (setf (clatter-connection-nick conn) "bob")
+          (clatter-ui--on-nick conn (clatter-parse-prefix "alice!u@h") "bob")
+          (with-current-buffer nick-buffer
+            (should (string-prefix-p "bob> draft" (buffer-string)))
+            (should (equal (clatter--get-input) "draft")))
+          (with-current-buffer target-buffer
+            (should (string-prefix-p "#target> " (buffer-string)))))
+      (when nick-buffer
+        (clatter-remove-buffer "testnet" "#nick")
+        (when (buffer-live-p nick-buffer)
+          (kill-buffer nick-buffer)))
+      (when target-buffer
+        (clatter-remove-buffer "testnet" "#target")
+        (when (buffer-live-p target-buffer)
+          (kill-buffer target-buffer)))
+      (remhash (clatter-connection-network-id conn) clatter-connections))))
 
 (ert-deftest clatter-input-oldest-first-prompt-at-bottom ()
   "Oldest-first: prompt is on the last line; messages accumulate above it."


### PR DESCRIPTION
Adds string placeholders and function-based prompt formats, refreshing nick-dependent prompts without losing pending input. Focused input tests passed and the branch was manually tested.