### PR TITLE
Add header-line context presets

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -272,6 +272,20 @@ prompt so the character is entered there."
   :type 'boolean
   :group 'clatter)
 
+(defcustom clatter-header-line-preset nil
+  "Preset that moves channel context into the header line.
+When nil, Clatter leaves the header line disabled and preserves the normal
+mode-line.  `topic' shows the full topic in the header line and removes it
+from the mode-line.  `context' shows the network/target, channel modes,
+member count, and full topic in the header line, leaving only the current
+nick in the mode-line.
+
+Typing and activity indicators remain in the mode-line for every preset."
+  :type '(choice (const :tag "Disabled" nil)
+                 (const :tag "Topic" topic)
+                 (const :tag "Full channel context" context))
+  :group 'clatter)
+
 (defcustom clatter-buffer-max-lines 10000
   "Maximum number of lines to keep in a clatter buffer.
 When exceeded, oldest messages are removed.

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -605,20 +605,70 @@ If the input contains multiple lines and exceeds
   '(:eval (clatter--mode-line-string))
   "Mode-line construct for clatter buffers.")
 
+(defun clatter--header-line-string ()
+  "Generate header-line channel context for the current Clatter buffer."
+  (when clatter--network
+    (let* ((target (or clatter--target ""))
+           (base (format "[%s/%s]" clatter--network target))
+           (modes (and clatter--channel-modes
+                       (not (string-empty-p clatter--channel-modes))
+                       clatter--channel-modes))
+           (nicks (clatter-nick-count (current-buffer)))
+           (details (string-join
+                     (delq nil
+                           (list modes
+                                 (when (> nicks 0)
+                                   (format "%d %s" nicks
+                                           (if (= nicks 1) "nick" "nicks")))))
+                     " "))
+           (context (if (string-empty-p details)
+                        base
+                      (format "%s %s" base details))))
+      (if (and clatter--topic (not (string-empty-p clatter--topic)))
+          (format "%s - %s" context clatter--topic)
+        context))))
+
+(defun clatter--header-line-topic-string ()
+  "Generate the topic-only header-line preset for the current buffer.
+Fall back to the network and target when the buffer has no topic."
+  (when clatter--network
+    (if (and clatter--topic (not (string-empty-p clatter--topic)))
+        clatter--topic
+      (format "[%s/%s]" clatter--network (or clatter--target "")))))
+
+(defun clatter--effective-header-line-preset ()
+  "Return the configured header-line preset."
+  clatter-header-line-preset)
+
+(defun clatter--effective-header-line-format ()
+  "Return the header-line construct selected by the preset."
+  (pcase (clatter--effective-header-line-preset)
+    ('topic '(:eval (clatter--header-line-topic-string)))
+    ('context '(:eval (clatter--header-line-string)))
+    (_ nil)))
+
 (defun clatter--mode-line-string ()
   "Generate mode-line string for current clatter buffer."
   (when clatter--network
-    (let* ((conn (clatter-get-connection clatter--network))
+    (let* ((preset (clatter--effective-header-line-preset))
+           (show-identity (not (eq preset 'context)))
+           (show-nicks (not (eq preset 'context)))
+           (conn (clatter-get-connection clatter--network))
            (nick (if conn (clatter-connection-nick conn) "?"))
            (nicks (clatter-nick-count (current-buffer)))
-           (topic-str (if clatter--topic
+           (topic-str (if (and (not (memq preset '(topic context)))
+                               clatter--topic)
                           (truncate-string-to-width clatter--topic 40 nil nil "...")
-                        "")))
-      (format " [%s/%s] %s%s%s"
-              clatter--network
-              (or clatter--target "")
+                        ""))
+           (identity (if show-identity
+                         (format "[%s/%s] "
+                                 clatter--network
+                                 (or clatter--target ""))
+                       "")))
+      (format " %s%s%s%s"
+              identity
               nick
-              (if (> nicks 0) (format " (%d)" nicks) "")
+              (if (and show-nicks (> nicks 0)) (format " (%d)" nicks) "")
               (if (> (length topic-str) 0)
                   (format " - %s" topic-str)
                 "")))))
@@ -640,13 +690,15 @@ If the input contains multiple lines and exceeds
     ;; inside a clatter buffer, not just in the global mode line.
     (setq-local mode-line-format
                 (append
-                 (list " " 'mode-line-buffer-identification
-                       clatter-mode-line-format
+                 (unless (eq (clatter--effective-header-line-preset) 'context)
+                   (list " " 'mode-line-buffer-identification))
+                 (list clatter-mode-line-format
                        '(:eval (clatter--typing-mode-line)))
                  (when (and (boundp 'clatter-track-in-buffer-mode-line)
                             clatter-track-in-buffer-mode-line)
                    (list 'clatter-track-mode-line-item))
                  (list " " 'mode-line-end-spaces)))
+    (setq-local header-line-format (clatter--effective-header-line-format))
     ;; Ensure window margins are synced for timestamp display
     (add-hook 'window-configuration-change-hook
               #'clatter--sync-window-margins nil t)

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -243,6 +243,75 @@
       (should (string-match-p "alice" result))
       (should (string-match-p "msg123" result)))))
 
+;; --- Header-line ---
+
+(ert-deftest clatter-test-header-line-default-disabled ()
+  "Clatter leaves the header line disabled by default."
+  (with-temp-buffer
+    (clatter-mode)
+    (setq-local clatter--network "testnet")
+    (setq-local clatter--target "#emacs")
+    (clatter-ui-setup-buffer (current-buffer))
+    (should-not header-line-format)))
+
+(ert-deftest clatter-test-header-line-renders-channel-context ()
+  "Built-in header-line renderer shows full channel context."
+  (let ((clatter-header-line-preset 'context))
+    (with-temp-buffer
+      (clatter-mode)
+      (setq-local clatter--network "testnet")
+      (setq-local clatter--target "#emacs")
+      (setq-local clatter--topic "A deliberately long topic that is not truncated in the header line")
+      (setq-local clatter--channel-modes "+nt")
+      (setq-local clatter--nick-list (make-hash-table :test 'equal))
+      (puthash "alice" '("" . "alice") clatter--nick-list)
+      (puthash "bob" '("@" . "bob") clatter--nick-list)
+      (clatter-ui-setup-buffer (current-buffer))
+      (should (equal header-line-format
+                     '(:eval (clatter--header-line-string))))
+      (let ((rendered (clatter--header-line-string)))
+        (should (string-match-p "\\[testnet/#emacs\\]" rendered))
+        (should (string-match-p "\\+nt" rendered))
+        (should (string-match-p "2 nicks" rendered))
+        (should (string-match-p "not truncated in the header line" rendered))))))
+
+(ert-deftest clatter-test-header-line-topic-preset-deduplicates-topic ()
+  "The topic preset moves only the topic out of the mode-line."
+  (let ((clatter-header-line-preset 'topic))
+    (with-temp-buffer
+      (clatter-mode)
+      (setq-local clatter--network "testnet")
+      (setq-local clatter--target "#emacs")
+      (setq-local clatter--topic "A full topic")
+      (clatter-ui-setup-buffer (current-buffer))
+      (should (equal header-line-format
+                     '(:eval (clatter--header-line-topic-string))))
+      (should (equal (clatter--header-line-topic-string) "A full topic"))
+      (let ((mode-line (clatter--mode-line-string)))
+        (should (string-match-p "\\[testnet/#emacs\\]" mode-line))
+        (should-not (string-match-p "A full topic" mode-line))))))
+
+(ert-deftest clatter-test-header-line-context-preset-deduplicates-context ()
+  "The context preset leaves only the current nick in the mode-line."
+  (let ((clatter-header-line-preset 'context))
+    (with-temp-buffer
+      (clatter-mode)
+      (setq-local clatter--network "testnet")
+      (setq-local clatter--target "#emacs")
+      (setq-local clatter--topic "A full topic")
+      (setq-local clatter--channel-modes "+nt")
+      (setq-local clatter--nick-list (make-hash-table :test 'equal))
+      (puthash "alice" t clatter--nick-list)
+      (clatter-ui-setup-buffer (current-buffer))
+      (should (equal header-line-format
+                     '(:eval (clatter--header-line-string))))
+      (should-not (memq 'mode-line-buffer-identification mode-line-format))
+      (let ((mode-line (clatter--mode-line-string)))
+        (should (string-match-p "\\?" mode-line))
+        (should-not (string-match-p "testnet/#emacs" mode-line))
+        (should-not (string-match-p "1" mode-line))
+        (should-not (string-match-p "A full topic" mode-line))))))
+
 ;; --- Typing mode-line ---
 
 (ert-deftest clatter-test-typing-mode-line-empty ()


### PR DESCRIPTION
Adds nil, topic, and context header-line presets; context moves channel identity, modes, member count, and topic out of redundant mode-line fields. Focused UI tests passed and the branch was manually tested.