### PR TITLE
Persist local read state

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -272,6 +272,24 @@ prompt so the character is entered there."
   :type 'boolean
   :group 'clatter)
 
+(defcustom clatter-read-state-enabled t
+  "Persist local last-read timestamps for Clatter buffers.
+This is a local fallback for bouncers or servers that replay backlog
+without IRCv3 read-marker support."
+  :type 'boolean
+  :group 'clatter)
+
+(defcustom clatter-read-state-file
+  (locate-user-emacs-file "clatter/read-state.el")
+  "File where Clatter persists local read state."
+  :type 'file
+  :group 'clatter)
+
+(defcustom clatter-read-state-save-delay 2
+  "Seconds to debounce writes to `clatter-read-state-file'."
+  :type 'number
+  :group 'clatter)
+
 (defcustom clatter-buffer-max-lines 10000
   "Maximum number of lines to keep in a clatter buffer.
 When exceeded, oldest messages are removed.

--- a/clatter-model.el
+++ b/clatter-model.el
@@ -57,6 +57,114 @@ Populated by WHOX (extended WHO) replies.")
 (defvar-local clatter--buffer-type nil
   "Buffer type: server, channel, or query.")
 
+;; --- Local read state ---
+
+(defvar-local clatter--last-read-time nil
+  "Newest server-time persisted as read for this buffer.")
+
+(defvar-local clatter--latest-message-time nil
+  "Newest server-time inserted into this buffer.")
+
+(defvar clatter-read-state--table (make-hash-table :test 'equal)
+  "Hash table of persisted local read timestamps keyed by network/target.")
+
+(defvar clatter-read-state--loaded nil
+  "Non-nil once `clatter-read-state-file' has been loaded.")
+
+(defvar clatter-read-state--save-timer nil
+  "Pending debounce timer for saving local read state.")
+
+(defun clatter-read-state--key (network target)
+  "Return the read-state key for NETWORK and TARGET."
+  (cons network (downcase target)))
+
+(defun clatter-read-state--load ()
+  "Load local read state from `clatter-read-state-file' once."
+  (when (and clatter-read-state-enabled
+             (not clatter-read-state--loaded))
+    (setq clatter-read-state--loaded t)
+    (clrhash clatter-read-state--table)
+    (when (file-readable-p clatter-read-state-file)
+      (condition-case err
+          (with-temp-buffer
+            (insert-file-contents clatter-read-state-file)
+            (dolist (entry (read (current-buffer)))
+              (when (and (consp entry) (consp (car entry)))
+                (puthash (car entry) (cdr entry) clatter-read-state--table))))
+        (error
+         (message "[clatter] Could not load read state: %s"
+                  (error-message-string err)))))))
+
+(defun clatter-read-state--alist ()
+  "Return `clatter-read-state--table' as an alist."
+  (let (entries)
+    (maphash (lambda (key value)
+               (push (cons key value) entries))
+             clatter-read-state--table)
+    entries))
+
+(defun clatter-read-state--save-now ()
+  "Write local read state to `clatter-read-state-file'."
+  (when clatter-read-state--save-timer
+    (cancel-timer clatter-read-state--save-timer)
+    (setq clatter-read-state--save-timer nil))
+  (when clatter-read-state-enabled
+    (let ((dir (file-name-directory clatter-read-state-file)))
+      (when dir
+        (make-directory dir t)))
+    (with-temp-file clatter-read-state-file
+      (let ((print-length nil)
+            (print-level nil))
+        (prin1 (clatter-read-state--alist) (current-buffer))))))
+
+(defun clatter-read-state--schedule-save ()
+  "Debounce saving local read state."
+  (when clatter-read-state-enabled
+    (when clatter-read-state--save-timer
+      (cancel-timer clatter-read-state--save-timer))
+    (setq clatter-read-state--save-timer
+          (run-with-timer clatter-read-state-save-delay nil
+                          #'clatter-read-state--save-now))
+    (add-hook 'kill-emacs-hook #'clatter-read-state--save-now)))
+
+(defun clatter-read-state-restore-buffer (buffer)
+  "Restore persisted read state into BUFFER."
+  (when clatter-read-state-enabled
+    (clatter-read-state--load)
+    (when (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (when (and clatter--network clatter--target)
+          (setq clatter--last-read-time
+                (gethash (clatter-read-state--key clatter--network clatter--target)
+                         clatter-read-state--table)))))))
+
+(defun clatter-read-state-record-buffer (buffer)
+  "Persist BUFFER's latest message time as read."
+  (when (and clatter-read-state-enabled (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (when (and clatter--network clatter--target clatter--latest-message-time)
+        (let ((key (clatter-read-state--key clatter--network clatter--target)))
+          (setq clatter--last-read-time clatter--latest-message-time)
+          (puthash key clatter--last-read-time clatter-read-state--table)
+          (clatter-read-state--schedule-save))))))
+
+(defun clatter-note-message-time (buffer server-time)
+  "Record SERVER-TIME as the newest message time seen in BUFFER."
+  (when (and server-time (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (when (or (null clatter--latest-message-time)
+                (time-less-p clatter--latest-message-time server-time))
+        (setq clatter--latest-message-time server-time)))))
+
+(defun clatter-read-state-message-read-p (buffer server-time)
+  "Return non-nil if SERVER-TIME is already read in BUFFER."
+  (and clatter-read-state-enabled
+       server-time
+       (buffer-live-p buffer)
+       (with-current-buffer buffer
+         (and clatter--last-read-time
+              (not (time-less-p clatter--last-read-time server-time))))))
+
 ;; --- Buffer registry ---
 
 (defvar clatter--buffer-alist nil
@@ -88,7 +196,8 @@ TYPE is server, channel, or query (auto-detected if nil)."
           (setq clatter--target target)
           (setq clatter--buffer-type buf-type)
           (when (eq buf-type 'channel)
-            (setq clatter--nick-list (make-hash-table :test 'equal))))
+            (setq clatter--nick-list (make-hash-table :test 'equal)))
+          (clatter-read-state-restore-buffer buf))
         ;; Register
         (let ((key (cons network (downcase target))))
           (setf (alist-get key clatter--buffer-alist nil nil #'equal) buf))
@@ -269,7 +378,8 @@ Handles prefixes like @nick, +nick, ~nick."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (setq clatter--unread-count 0)
-      (setq clatter--has-mention nil))))
+      (setq clatter--has-mention nil))
+    (clatter-read-state-record-buffer buffer)))
 
 ;; --- Major mode (minimal, UI fills in details) ---
 

--- a/clatter-notify.el
+++ b/clatter-notify.el
@@ -243,7 +243,7 @@ Prevents notification spam from rapid messages."
 
 ;; --- Notification logic ---
 
-(defun clatter-notify--should-notify-p (sender target text conn)
+(defun clatter-notify--should-notify-p (sender target text conn &optional server-time)
   "Determine if SENDER's TEXT to TARGET on CONN should notify.
 Returns a symbol indicating the reason: mention, dm, keyword, or nil."
   (when clatter-notify-enabled
@@ -269,6 +269,8 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
            (text-lower (downcase (or text ""))))
       (let ((reason
              (cond
+              ;; Already-read history has already been seen elsewhere.
+              ((and buf (clatter-read-state-message-read-p buf server-time)) nil)
               ;; Own messages (echo-message)
               (is-self nil)
               ;; Muted
@@ -319,9 +321,9 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
 
 ;; --- Hooks ---
 
-(defun clatter-notify--on-privmsg (conn sender target text &rest _args)
+(defun clatter-notify--on-privmsg (conn sender target text &optional server-time)
   "Notify for SENDER's PRIVMSG TEXT to TARGET on CONN."
-  (let ((reason (clatter-notify--should-notify-p sender target text conn)))
+  (let ((reason (clatter-notify--should-notify-p sender target text conn server-time)))
     (when reason
       (let* ((channel-prefixes (let ((isup (clatter-connection-isupport conn)))
                                  (or (and isup (gethash "CHANTYPES" isup))
@@ -334,9 +336,9 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
            (clatter-notify--format-title reason sender-nick target)
            (format "<%s> %s" sender-nick text)))))))
 
-(defun clatter-notify--on-action (conn sender target text &rest _args)
+(defun clatter-notify--on-action (conn sender target text &optional server-time)
   "Notify for SENDER's ACTION TEXT to TARGET on CONN."
-  (let ((reason (clatter-notify--should-notify-p sender target text conn)))
+  (let ((reason (clatter-notify--should-notify-p sender target text conn server-time)))
     (when reason
       (let* ((channel-prefixes (let ((isup (clatter-connection-isupport conn)))
                                  (or (and isup (gethash "CHANTYPES" isup))

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -397,6 +397,9 @@ SERVER-TIME overrides the current time for the timestamp."
                       'clatter-text text)))
     (when msgid
       (setq props (plist-put props 'clatter-msgid msgid)))
+    (when server-time
+      (setq props (plist-put props 'clatter-server-time server-time)))
+    (clatter-note-message-time buffer server-time)
     (clatter--insert-message buffer formatted nil props server-time invisible)
     (when (and (not clatter--suppress-image-scan)
                (fboundp 'clatter-image--scan-message))
@@ -404,8 +407,10 @@ SERVER-TIME overrides the current time for the timestamp."
                           (copy-marker
                            (or clatter--messages-marker (point-max))))))
         (clatter-image--scan-message text buffer img-marker)))
-    (unless (eq buffer (current-buffer))
-      (clatter-mark-activity buffer is-mention))))
+    (if (eq buffer (current-buffer))
+        (clatter-read-state-record-buffer buffer)
+      (unless (clatter-read-state-message-read-p buffer server-time)
+        (clatter-mark-activity buffer is-mention)))))
 
 (defun clatter-insert-privmsg (buffer sender text conn &optional server-time invisible)
   "Insert a PRIVMSG from SENDER with TEXT into BUFFER using CONN context.

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -6,6 +6,7 @@
 (require 'clatter-ui)
 (require 'clatter-commands)
 (require 'clatter-nicklist)
+(require 'clatter-track)
 
 ;; --- Timestamp margins ---
 
@@ -242,6 +243,71 @@
       (should result)
       (should (string-match-p "alice" result))
       (should (string-match-p "msg123" result)))))
+
+;; --- Read state ---
+
+(ert-deftest clatter-test-read-state-clear-persists-and-restores ()
+  "Clearing activity persists and restores the latest read timestamp."
+  (let* ((file (make-temp-file "clatter-read-state"))
+         (clatter-read-state-enabled t)
+         (clatter-read-state-file file)
+         (clatter-read-state--table (make-hash-table :test 'equal))
+         (clatter-read-state--loaded t)
+         (clatter-read-state--save-timer nil)
+         (time (encode-time 0 0 12 1 1 2026 t)))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (clatter-mode)
+            (setq-local clatter--network "libera")
+            (setq-local clatter--target "#emacs")
+            (setq-local clatter--latest-message-time time)
+            (clatter-clear-activity (current-buffer)))
+          (clatter-read-state--save-now)
+          (setq clatter-read-state--table (make-hash-table :test 'equal))
+          (setq clatter-read-state--loaded nil)
+          (with-temp-buffer
+            (clatter-mode)
+            (setq-local clatter--network "libera")
+            (setq-local clatter--target "#emacs")
+            (clatter-read-state-restore-buffer (current-buffer))
+            (should (equal clatter--last-read-time time))))
+      (when clatter-read-state--save-timer
+        (cancel-timer clatter-read-state--save-timer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest clatter-test-read-state-suppresses-read-history-activity ()
+  "History at or before the last-read timestamp does not mark activity."
+  (let ((conn (clatter-test-make-connection "libera" "me"))
+        (buf nil)
+        (clatter-read-state-enabled t))
+    (unwind-protect
+        (let* ((last-read (encode-time 0 0 12 1 1 2026 t))
+               (old (encode-time 0 59 11 1 1 2026 t))
+               (equal-time (encode-time 0 0 12 1 1 2026 t))
+               (new (encode-time 0 1 12 1 1 2026 t)))
+          (setq buf (clatter-get-or-create-buffer "libera" "#emacs" 'channel))
+          (with-current-buffer buf
+            (clatter-ui-setup-buffer buf)
+            (setq-local clatter--last-read-time last-read))
+          (with-temp-buffer
+            (clatter-insert-privmsg buf "alice" "old" conn old)
+            (clatter-insert-privmsg buf "alice" "equal" conn equal-time)
+            (clatter-insert-privmsg buf "alice" "new" conn new))
+          (with-current-buffer buf
+            (should (= clatter--unread-count 1)))
+          (let* ((infos (clatter-track--collect))
+                 (info (cl-find buf infos
+                                :key (lambda (entry)
+                                       (plist-get entry :buffer)))))
+            (should info)
+            (should (= (plist-get info :unread) 1))))
+      (clatter-test-cleanup)
+      (when buf
+        (clatter-remove-buffer "libera" "#emacs")
+        (when (buffer-live-p buf)
+          (kill-buffer buf))))))
 
 ;; --- Typing mode-line ---
 

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -7,6 +7,7 @@
 (require 'clatter-commands)
 (require 'clatter-nicklist)
 (require 'clatter-track)
+(require 'clatter-notify)
 
 ;; --- Timestamp margins ---
 
@@ -387,6 +388,57 @@
           (setq-local clatter--target "#test")
           (let ((clatter-send-typing t))
             (should (clatter--typing-capable-p))))
+      (clatter-test-cleanup))))
+
+;; --- Notifications and read state ---
+
+(ert-deftest clatter-test-read-state-suppresses-read-notification ()
+  "Messages at or before the last-read timestamp do not notify."
+  (let ((clatter-notify-enabled t)
+        (clatter-notify-on-mention t)
+        (clatter-notify-current-buffer t)
+        (clatter-notify-cooldown 0)
+        (clatter-read-state-enabled t)
+        (clatter--buffer-alist nil)
+        (clatter-notify--last-times (make-hash-table :test 'equal))
+        (sent nil)
+        (conn (clatter-test-make-connection "testnet" "trev"))
+        (last-read (encode-time 0 0 12 1 1 2026 t)))
+    (unwind-protect
+        (let ((buf (clatter-get-or-create-buffer "testnet" "#test")))
+          (with-current-buffer buf
+            (setq-local clatter--last-read-time last-read))
+          (cl-letf (((symbol-function 'clatter-notify--send)
+                     (lambda (title body)
+                       (push (list title body) sent))))
+            (clatter-notify--on-privmsg
+             conn '("alice" nil nil) "#test" "trev: already saw this" last-read)
+            (should-not sent)))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-read-state-allows-unread-notification ()
+  "Messages after the last-read timestamp can still notify."
+  (let ((clatter-notify-enabled t)
+        (clatter-notify-on-mention t)
+        (clatter-notify-current-buffer t)
+        (clatter-notify-cooldown 0)
+        (clatter-read-state-enabled t)
+        (clatter--buffer-alist nil)
+        (clatter-notify--last-times (make-hash-table :test 'equal))
+        (sent nil)
+        (conn (clatter-test-make-connection "testnet" "trev"))
+        (last-read (encode-time 0 0 12 1 1 2026 t))
+        (unread-time (encode-time 1 0 12 1 1 2026 t)))
+    (unwind-protect
+        (let ((buf (clatter-get-or-create-buffer "testnet" "#test")))
+          (with-current-buffer buf
+            (setq-local clatter--last-read-time last-read))
+          (cl-letf (((symbol-function 'clatter-notify--send)
+                     (lambda (title body)
+                       (push (list title body) sent))))
+            (clatter-notify--on-privmsg
+             conn '("alice" nil nil) "#test" "trev: new message" unread-time)
+            (should sent)))
       (clatter-test-cleanup))))
 
 ;; --- Nicklist hooks registered ---


### PR DESCRIPTION
Adds debounced local read-state persistence and restoration keyed by network and target, with configurable storage and server read-marker precedence. Focused UI tests passed and the branch was manually tested.