### PR TITLE
Fix read-marker target tracking

### DIFF
--- a/clatter-read-marker.el
+++ b/clatter-read-marker.el
@@ -15,6 +15,7 @@
 
 (require 'cl-lib)
 (require 'clatter-config)
+(require 'clatter-protocol)
 (require 'clatter-connection)
 (require 'clatter-model)
 
@@ -110,33 +111,60 @@ PARAMS format: (target timestamp=TIMESTAMP)"
 
 ;; --- Auto-mark on buffer focus ---
 
-(defun clatter-read-marker--on-buffer-switch ()
-  "Send MARKREAD when switching to a clatter buffer."
+(defun clatter-read-marker--mark-buffer-read (buffer)
+  "Send MARKREAD for BUFFER when it is a readable Clatter target."
   (when (and clatter-read-marker-enabled
              clatter-read-marker-auto-send
-             (derived-mode-p 'clatter-mode)
-             clatter--target
-             clatter--buffer-type
-             (not (eq 'server clatter--buffer-type))
-             clatter--network
-             clatter-read-marker--local-msgid)
-    (let ((conn (clatter-get-connection clatter--network)))
-      (when (and conn (clatter-read-marker--available-p conn))
-        (clatter-read-marker--send conn clatter--target
-                                   clatter-read-marker--local-msgid)
-        ;; Clear the visual marker since everything is now read
-        (when clatter-read-marker--overlay
-          (delete-overlay clatter-read-marker--overlay)
-          (setq clatter-read-marker--overlay nil))))))
+             (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (when (and (derived-mode-p 'clatter-mode)
+                 clatter--target
+                 clatter--buffer-type
+                 (not (eq 'server clatter--buffer-type))
+                 clatter--network
+                 clatter-read-marker--local-msgid)
+        (let ((conn (clatter-get-connection clatter--network)))
+          (when (and conn (clatter-read-marker--available-p conn))
+            (clatter-read-marker--send conn clatter--target
+                                       clatter-read-marker--local-msgid)
+            ;; Clear the visual marker since everything is now read.
+            (when clatter-read-marker--overlay
+              (delete-overlay clatter-read-marker--overlay)
+              (setq clatter-read-marker--overlay nil))))))))
+
+(defun clatter-read-marker--on-buffer-switch ()
+  "Send MARKREAD for the current buffer."
+  (clatter-read-marker--mark-buffer-read (current-buffer)))
 
 ;; --- Track msgids ---
 
-(defun clatter-read-marker--track-msgid (_conn _sender _target _text server-time)
+(defun clatter-read-marker--target-buffer (conn sender target)
+  "Return the Clatter buffer for SENDER and TARGET on CONN."
+  (let* ((network (clatter-connection-network-id conn))
+         (sender-nick (clatter-prefix-nick sender))
+         (my-nick (clatter-connection-nick conn))
+         (is-channel (clatter-channel-name-p target))
+         (buffer-target (if is-channel
+                            target
+                          (if (string-equal-ignore-case target my-nick)
+                              sender-nick
+                            target))))
+    (and buffer-target
+         (clatter-get-or-create-buffer network buffer-target
+                                       (if is-channel 'channel 'query)))))
+
+(defun clatter-read-marker--track-msgid (conn sender target _text server-time)
   "Track the latest msgid for read-marker purposes.
 Uses SERVER-TIME as a proxy when msgid tags are not available."
   (when server-time
-    (setq-local clatter-read-marker--local-msgid
-                (format-time-string "%Y-%m-%dT%H:%M:%S.000Z" server-time t))))
+    (let ((buf (clatter-read-marker--target-buffer conn sender target)))
+      (when buf
+        (with-current-buffer buf
+          (setq-local clatter-read-marker--local-msgid
+                      (format-time-string "%Y-%m-%dT%H:%M:%S.000Z"
+                                          server-time t)))
+        (when (eq buf (window-buffer (selected-window)))
+          (clatter-read-marker--mark-buffer-read buf))))))
 
 ;; --- Interactive ---
 
@@ -167,16 +195,17 @@ Uses SERVER-TIME as a proxy when msgid tags are not available."
 
 ;; --- Enable/disable ---
 
-(defun clatter-read-marker--window-change (&rest _)
-  "Send MARKREAD when the selected window's buffer changes.
-Ignores its arguments; suitable for `window-buffer-change-functions'."
-  (clatter-read-marker--on-buffer-switch))
+(defun clatter-read-marker--window-change (window &rest _)
+  "Send MARKREAD when WINDOW's buffer changes.
+Suitable for `window-buffer-change-functions'."
+  (clatter-read-marker--mark-buffer-read (window-buffer window)))
 
 (defun clatter-read-marker-enable ()
   "Enable read-marker hooks."
   (interactive)
   (add-hook 'window-buffer-change-functions #'clatter-read-marker--window-change)
   (add-hook 'clatter-privmsg-hook #'clatter-read-marker--track-msgid)
+  (add-hook 'clatter-action-hook #'clatter-read-marker--track-msgid)
   (when (called-interactively-p 'interactive)
     (message "[clatter-read-marker] Enabled")))
 
@@ -185,6 +214,7 @@ Ignores its arguments; suitable for `window-buffer-change-functions'."
   (interactive)
   (remove-hook 'window-buffer-change-functions #'clatter-read-marker--window-change)
   (remove-hook 'clatter-privmsg-hook #'clatter-read-marker--track-msgid)
+  (remove-hook 'clatter-action-hook #'clatter-read-marker--track-msgid)
   (when (called-interactively-p 'interactive)
     (message "[clatter-read-marker] Disabled")))
 

--- a/tests/test-read-marker.el
+++ b/tests/test-read-marker.el
@@ -1,0 +1,118 @@
+;;; test-read-marker.el --- Tests for clatter-read-marker.el -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'test-helper)
+(require 'clatter-read-marker)
+
+(defun clatter-test-read-marker--timestamp (time)
+  "Return read-marker timestamp string for TIME."
+  (format-time-string "%Y-%m-%dT%H:%M:%S.000Z" time t))
+
+(ert-deftest clatter-test-read-marker-tracks-channel-buffer ()
+  "PRIVMSG timestamps are recorded in the message target buffer."
+  (let ((conn (clatter-test-make-connection "testnet" "me"))
+        (time (encode-time 1 2 3 4 5 2026 t))
+        buf)
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (clatter-mode)
+            (clatter-read-marker--track-msgid
+             conn '("alice" nil nil) "#emacs" "hello" time)
+            (should-not clatter-read-marker--local-msgid))
+          (setq buf (clatter-get-buffer "testnet" "#emacs"))
+          (should (buffer-live-p buf))
+          (with-current-buffer buf
+            (should (eq clatter--buffer-type 'channel))
+            (should (equal clatter-read-marker--local-msgid
+                           (clatter-test-read-marker--timestamp time)))))
+      (clatter-test-cleanup)
+      (when buf
+        (clatter-remove-buffer "testnet" "#emacs")
+        (when (buffer-live-p buf)
+          (kill-buffer buf))))))
+
+(ert-deftest clatter-test-read-marker-tracks-query-sender-buffer ()
+  "PRIVMSGs to our nick are recorded in the sender query buffer."
+  (let ((conn (clatter-test-make-connection "testnet" "me"))
+        (time (encode-time 1 2 3 4 5 2026 t))
+        buf)
+    (unwind-protect
+        (progn
+          (clatter-read-marker--track-msgid
+           conn '("alice" nil nil) "me" "hello" time)
+          (setq buf (clatter-get-buffer "testnet" "alice"))
+          (should (buffer-live-p buf))
+          (with-current-buffer buf
+            (should (eq clatter--buffer-type 'query))
+            (should (equal clatter-read-marker--local-msgid
+                           (clatter-test-read-marker--timestamp time)))))
+      (clatter-test-cleanup)
+      (when buf
+        (clatter-remove-buffer "testnet" "alice")
+        (when (buffer-live-p buf)
+          (kill-buffer buf))))))
+
+(ert-deftest clatter-test-read-marker-enable-tracks-actions ()
+  "Read-marker mode tracks both PRIVMSG and CTCP ACTION hooks."
+  (unwind-protect
+      (progn
+        (clatter-read-marker-enable)
+        (should (memq #'clatter-read-marker--track-msgid clatter-privmsg-hook))
+        (should (memq #'clatter-read-marker--track-msgid clatter-action-hook)))
+    (clatter-read-marker-disable)))
+
+(ert-deftest clatter-test-read-marker-window-change-marks-window-buffer ()
+  "Window-change hooks send MARKREAD for the changed window's buffer."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("draft/read-marker") "testnet" "me"))
+        (old-buffer (window-buffer (selected-window)))
+        (timestamp "2026-05-04T03:02:01.000Z")
+        buf)
+    (unwind-protect
+        (progn
+          (setq buf (clatter-get-or-create-buffer "testnet" "#emacs" 'channel))
+          (with-current-buffer buf
+            (setq-local clatter-read-marker--local-msgid timestamp))
+          (clatter-test-with-mock-send
+            (set-window-buffer (selected-window) buf)
+            (with-temp-buffer
+              (clatter-mode)
+              (clatter-read-marker--window-change (selected-window)))
+            (should (equal (clatter-test-last-sent)
+                           (format "MARKREAD #emacs timestamp=%s" timestamp)))))
+      (set-window-buffer (selected-window) old-buffer)
+      (clatter-test-cleanup)
+      (when buf
+        (clatter-remove-buffer "testnet" "#emacs")
+        (when (buffer-live-p buf)
+          (kill-buffer buf))))))
+
+(ert-deftest clatter-test-read-marker-live-selected-buffer-sends-update ()
+  "Messages arriving in the selected target buffer advance MARKREAD."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("draft/read-marker") "testnet" "me"))
+        (old-buffer (window-buffer (selected-window)))
+        (time (encode-time 1 2 3 4 5 2026 t))
+        buf)
+    (unwind-protect
+        (progn
+          (setq buf (clatter-get-or-create-buffer "testnet" "#emacs" 'channel))
+          (clatter-test-with-mock-send
+            (set-window-buffer (selected-window) buf)
+            (clatter-read-marker--track-msgid
+             conn '("alice" nil nil) "#emacs" "hello" time)
+            (should (equal (clatter-test-last-sent)
+                           (format "MARKREAD #emacs timestamp=%s"
+                                   (clatter-test-read-marker--timestamp time))))))
+      (set-window-buffer (selected-window) old-buffer)
+      (clatter-test-cleanup)
+      (when buf
+        (clatter-remove-buffer "testnet" "#emacs")
+        (when (buffer-live-p buf)
+          (kill-buffer buf))))))
+
+(provide 'test-read-marker)
+
+;;; test-read-marker.el ends here


### PR DESCRIPTION
## Summary
- record read-marker timestamps in the actual channel/query buffer instead of the process/current buffer
- send MARKREAD for the window buffer passed by window-buffer-change-functions
- advance MARKREAD for messages arriving in the selected buffer, including CTCP ACTIONs

## Tests
- HOME=/tmp emacs --batch --eval '(setq load-prefer-newer t)' -L . -L tests -l test-helper -l tests/test-read-marker.el -f ert-run-tests-batch-and-exit
- HOME=/tmp emacs --batch --eval '(setq load-prefer-newer t)' -L . -L tests -l test-helper -l tests/test-handlers.el -f ert-run-tests-batch-and-exit