### PR TITLE
Add `clatter-timestamp-tooltip-format' to display verbose/customizable timestamps in tooltips

### DIFF
--- a/clatter-config.el
+++ b/clatter-config.el
@@ -120,6 +120,14 @@ See `format-time-string' for format specifiers."
   :type 'string
   :group 'clatter)
 
+(defcustom clatter-timestamp-tooltip-format "%F %T"
+  "Format string for timestamp tooltips.
+See `format-time-string' for format specifiers.
+If nil, no tooltip is displayed."
+  :type '(choice (const :tag "No tooltip" nil)
+                 (string :tag "Format specifier"))
+  :group 'clatter)
+
 (defcustom clatter-timestamp-only-if-changed nil
   "Display a message timestamp only when its formatted value changes.
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -227,6 +227,10 @@ append at the bottom like a traditional IRC client."
                                     (not (equal formatted-timestamp
                                                 clatter--last-formatted-timestamp)))
                                 formatted-timestamp))
+                   (ts-tooltip-str
+                    (unless no-timestamp
+                      (when clatter-timestamp-tooltip-format
+                        (format-time-string clatter-timestamp-tooltip-format time))))
                    (wrap-col (1+ clatter-nick-column-width))
                    (wrap-prefix (make-string wrap-col ?\s))
                    (start (point)))
@@ -253,7 +257,9 @@ append at the bottom like a traditional IRC client."
                                              `((margin ,(if (eq clatter-timestamp-side 'left)
                                                             'left-margin
                                                           'right-margin))
-                                               ,(propertize ts-str 'face '(clatter-timestamp default))))))
+                                               ,(propertize ts-str
+                                                            'face '(clatter-timestamp default)
+                                                            'help-echo ts-tooltip-str)))))
                   (overlay-put ov 'clatter-timestamp t)
                   (overlay-put ov 'invisible invisible)))
               (add-text-properties start (point)


### PR DESCRIPTION
Fixes https://github.com/parenworks/clatter.el/issues/70

Suggested by @krisbalintona.