### PR TITLE
Add compact system message presets

### DIFF
--- a/README.org
+++ b/README.org
@@ -41,6 +41,7 @@ Spiritual successor to [[https://github.com/glenneth1/CLatter][CLatter]] (the Co
 - =auth-source= integration for passwords (.authinfo.gpg, pass, etc.), including server password (PASS)
 - Multi-network support
 - Non-destructive message suppression, per channel (JOIN, PART, QUIT, NICK, etc.) toggled at runtime with =/suppress= and =/unsuppress=; hidden messages are kept and can be revealed again
+- Optional compact presence/moderation events with configurable symbols, burst grouping, and essential, reason, or full context presets
 - Buffer truncation (configurable =clatter-buffer-max-lines=, default 10000)
 - Flyspell spell-checking in input area (built-in, toggle with =clatter-flyspell-enable=)
 - Paste flood protection (warns before sending >3 lines, configurable threshold)

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -121,6 +121,49 @@
   :type 'string
   :group 'clatter)
 
+(defcustom clatter-compact-system-messages nil
+  "Control compact rendering of presence and moderation events.
+
+When nil, render the existing verbose system messages.  The value
+`compact' uses essential context and groups consecutive presence events
+on one line.  The value `essential' shows only the identities and action
+data needed to understand an event without grouping.  The value
+`reasons' additionally shows PART, QUIT, KICK, and AWAY reasons.  The
+value `full' also shows available channel, realname, invitee, and target
+context."
+  :type '(choice (const :tag "Verbose" nil)
+                 (const :tag "Grouped compact events" compact)
+                 (const :tag "Essential context" essential)
+                 (const :tag "Essential context and reasons" reasons)
+                 (const :tag "Full compact context" full))
+  :group 'clatter)
+
+(defcustom clatter-compact-system-group-window 180
+  "Seconds in which consecutive compact events may share a line.
+Only events with compatible visibility are grouped.  Any intervening
+message ends the group."
+  :type 'number
+  :group 'clatter)
+
+(defcustom clatter-compact-system-separator " · "
+  "String inserted between events on a grouped compact system line."
+  :type 'string
+  :group 'clatter)
+
+(defcustom clatter-compact-system-symbols
+  '((join . "→")
+    (part . "←")
+    (quit . "×")
+    (nick . "»")
+    (away . "○")
+    (back . "●")
+    (mode . "±")
+    (kick . "⬾")
+    (invite . "✉"))
+  "Alist mapping compact system event types to prefix symbols."
+  :type '(alist :key-type symbol :value-type string)
+  :group 'clatter)
+
 ;; --- Message insertion ---
 
 (defvar-local clatter--prompt-marker nil
@@ -131,6 +174,19 @@
 
 (defvar-local clatter--messages-marker nil
   "Marker for the start of the message area (below the input line).")
+
+(defvar-local clatter--message-generation 0
+  "Number of messages inserted into the current buffer.")
+
+(defvar-local clatter--compact-system-group nil
+  "Metadata for the most recent grouped compact system line.")
+
+(defvar clatter--compact-system-group-id 0
+  "Monotonic identifier for compact system group lines.")
+
+(defun clatter--compact-system-now ()
+  "Return the current time in seconds for compact event grouping."
+  (float-time))
 
 (defvar-local clatter--prompt-shows-nick nil
   "Non-nil when the current prompt already displays the connection nick.")
@@ -209,6 +265,7 @@ the input line with older ones scrolling down.  When `oldest-first', messages
 append at the bottom like a traditional IRC client."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
+      (cl-incf clatter--message-generation)
       (let ((pre-input (and clatter--input-marker
                             (marker-position clatter--input-marker))))
         (let ((inhibit-read-only t)
@@ -572,6 +629,183 @@ identical messages sent close together each reconcile only one local line."
                             (prog1 (setq text (copy-sequence text))
                               (add-face-text-property 0 (length text) 'clatter-system t text)))))
     (clatter--insert-message buffer formatted nil nil nil invisible)))
+
+(defun clatter--system-event-add-channel (text channel)
+  "Append CHANNEL to compact system event TEXT when available."
+  (if (and channel (not (string= channel "")))
+      (format "%s %s" text channel)
+    text))
+
+(defun clatter--system-event-add-reason (text reason)
+  "Append REASON to compact system event TEXT when available."
+  (if (and reason (not (string= reason "")))
+      (format "%s — %s" text reason)
+    text))
+
+(defun clatter--format-system-event (event fields)
+  "Format compact EVENT using structured plist FIELDS."
+  (let* ((style clatter-compact-system-messages)
+         (nick (plist-get fields :nick))
+         (channel (plist-get fields :channel))
+         (reason (plist-get fields :reason))
+         (show-reason (memq style '(reasons full)))
+         (show-full (eq style 'full)))
+    (pcase event
+      ('join
+       (let ((text nick)
+             (realname (plist-get fields :realname)))
+         (when (and show-full realname (not (string= nick realname)))
+           (setq text (format "%s (%s)" text realname)))
+         (if show-full
+             (clatter--system-event-add-channel text channel)
+           text)))
+      ((or 'part 'quit)
+       (let ((text (if show-full
+                       (clatter--system-event-add-channel nick channel)
+                     nick)))
+         (if show-reason
+             (clatter--system-event-add-reason text reason)
+           text)))
+      ('nick
+       (format "%s → %s" nick (plist-get fields :new-nick)))
+      ((or 'away 'back)
+       (let ((text (if show-full
+                       (clatter--system-event-add-channel nick channel)
+                     nick)))
+         (if (and (eq event 'away) show-reason)
+             (clatter--system-event-add-reason text reason)
+           text)))
+      ('mode
+       (let ((modes (plist-get fields :modes)))
+         (if show-full
+             (format "%s %s %s" nick (or channel "") modes)
+           (format "%s %s" nick modes))))
+      ('kick
+       (let* ((setter (plist-get fields :setter))
+              (text (format "%s ← %s" nick setter)))
+         (when show-full
+           (setq text (clatter--system-event-add-channel text channel)))
+         (if show-reason
+             (clatter--system-event-add-reason text reason)
+           text)))
+      ('invite
+       (if show-full
+           (format "%s → %s %s"
+                   nick (plist-get fields :invitee) channel)
+         (format "%s → %s" nick channel)))
+      (_ (or (plist-get fields :verbose) "")))))
+
+(defun clatter--insert-system-event (buffer event fields invisible)
+  "Insert structured system EVENT with FIELDS into BUFFER.
+INVISIBLE carries the same message categories as `clatter-insert-system'."
+  (if (null clatter-compact-system-messages)
+      (clatter-insert-system buffer (plist-get fields :verbose) invisible)
+    (let* ((symbol (or (alist-get event clatter-compact-system-symbols) "***"))
+           (prefix (clatter--format-system-prefix symbol))
+           (text (clatter--format-system-event event fields))
+           (formatted (concat prefix " "
+                              (prog1 (setq text (copy-sequence text))
+                                (add-face-text-property
+                                 0 (length text) 'clatter-system t text)))))
+      (if (and (eq clatter-compact-system-messages 'compact)
+               (memq event '(join part quit away back))
+               (clatter--append-compact-system-group
+                buffer event text invisible))
+          nil
+        (let ((group-id (and (eq clatter-compact-system-messages 'compact)
+                             (memq event '(join part quit away back))
+                             (cl-incf clatter--compact-system-group-id))))
+          (clatter--insert-message
+           buffer formatted nil
+           (and group-id (list 'clatter-compact-system-group-id group-id))
+           nil invisible)
+          (when group-id
+            (clatter--record-compact-system-group
+             buffer group-id invisible)))))))
+
+(defun clatter--compact-system-visibility (invisible)
+  "Return grouping visibility from event INVISIBLE categories."
+  (seq-remove (lambda (category)
+                (memq category '(join part quit away back)))
+              (ensure-list invisible)))
+
+(defun clatter--append-compact-system-group (buffer event text invisible)
+  "Append TEXT to BUFFER's compatible compact EVENT group.
+Return non-nil when the event was grouped.  INVISIBLE must match the
+existing group's visibility categories."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let* ((group clatter--compact-system-group)
+             (tail (plist-get group :tail)))
+        (when (and group
+                   (equal (clatter--compact-system-visibility invisible)
+                          (plist-get group :visibility))
+                   (= clatter--message-generation
+                      (plist-get group :generation))
+                   (markerp tail)
+                   (eq (marker-buffer tail) buffer))
+          (let ((now (clatter--compact-system-now)))
+            (when (<= (- now (plist-get group :time))
+                      clatter-compact-system-group-window)
+              (let ((pre-input (and clatter--input-marker
+                                    (marker-position clatter--input-marker)))
+                    (start (marker-position tail))
+                    (symbol (or (alist-get event clatter-compact-system-symbols)
+                                "***"))
+                    (separator-invisible
+                     (delete-dups
+                      (append (ensure-list (plist-get group :last-invisible))
+                              (ensure-list invisible)))))
+                (let ((inhibit-read-only t)
+                      (buffer-undo-list t))
+                  (save-excursion
+                    (goto-char tail)
+                    (insert
+                     (propertize clatter-compact-system-separator
+                                 'invisible separator-invisible)
+                     (propertize symbol 'invisible invisible)
+                     (propertize " " 'invisible invisible)
+                     (propertize text 'invisible invisible))
+                    (add-text-properties
+                     start (point)
+                     (list 'face 'clatter-system
+                           'read-only t
+                           'front-sticky nil
+                           'rear-nonsticky t))))
+                (when (and pre-input clatter--input-marker)
+                  (clatter--update-undo-list
+                   (- (marker-position clatter--input-marker) pre-input)))
+                (setf (plist-get clatter--compact-system-group :time) now)
+                (setf (plist-get clatter--compact-system-group :last-invisible)
+                      invisible)
+                t))))))))
+
+(defun clatter--record-compact-system-group (buffer group-id invisible)
+  "Record BUFFER's newly inserted compact GROUP-ID."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((start (text-property-any
+                    (point-min) (point-max)
+                    'clatter-compact-system-group-id group-id)))
+        (when start
+          (let ((inhibit-read-only t))
+            (save-excursion
+              (goto-char start)
+              (let ((end (line-end-position)))
+                (put-text-property start end 'invisible invisible)
+                (put-text-property end (min (1+ end) (point-max))
+                                   'invisible
+                                   (clatter--compact-system-visibility invisible))
+                (dolist (overlay (overlays-at start))
+                  (when (overlay-get overlay 'clatter-timestamp)
+                    (overlay-put overlay 'invisible invisible))))
+              (setq clatter--compact-system-group
+                    (list :visibility
+                          (clatter--compact-system-visibility invisible)
+                          :last-invisible invisible
+                          :generation clatter--message-generation
+                          :time (clatter--compact-system-now)
+                          :tail (copy-marker (line-end-position) t))))))))))
 
 (defun clatter-insert-error (buffer text)
   "Insert an error message TEXT into BUFFER."
@@ -1065,11 +1299,16 @@ the buffer margin-width variables."
          (is-muted (clatter-muted-p sender network))
          (invisible (clatter-sender-invisibility sender network)))
     (clatter-ui-setup-buffer-if-needed buf)
-    (clatter-insert-system buf (format "%s invites %s to join %s"
-                                       sender-nick
-                                       (if (string-equal nick my-nick) "you" nick)
-                                       channel)
-                           (if invisible (list 'invite invisible) 'invite))))
+    (clatter--insert-system-event
+     buf 'invite
+     (list :nick sender-nick
+           :invitee nick
+           :channel channel
+           :verbose (format "%s invites %s to join %s"
+                            sender-nick
+                            (if (string-equal nick my-nick) "you" nick)
+                            channel))
+     (if invisible (list 'invite invisible) 'invite))))
 
 (defun clatter-ui--on-join (conn sender channel _account realname)
   "Show SENDER joining CHANNEL on CONN, noting REALNAME when present."
@@ -1085,17 +1324,23 @@ the buffer margin-width variables."
       (clatter-send conn (clatter-irc-names channel))
       (when clatter-display-on-join
         (display-buffer buf)))
-    (clatter-insert-system buf
-                           (if (and realname (not (string= sender-nick realname)))
-                               (format "%s (%s) has joined %s" sender-nick (clatter-format-parse realname) channel)
-                             (format "%s has joined %s" sender-nick channel))
-                           (append (if invisible (list 'join invisible) '(join))
-                                   (and (not is-muted)
-                                        (not (string-equal-ignore-case my-nick sender-nick))
-                                        (listp (buffer-local-value 'buffer-invisibility-spec buf))
-                                        (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
-                                        (clatter-smart-eval buf sender-nick 'join)
-                                        '(noise))))))
+    (let ((parsed-realname (and realname (clatter-format-parse realname))))
+      (clatter--insert-system-event
+       buf 'join
+       (list :nick sender-nick
+             :channel channel
+             :realname parsed-realname
+             :verbose (if (and realname (not (string= sender-nick realname)))
+                          (format "%s (%s) has joined %s"
+                                  sender-nick parsed-realname channel)
+                        (format "%s has joined %s" sender-nick channel)))
+       (append (if invisible (list 'join invisible) '(join))
+               (and (not is-muted)
+                    (not (string-equal-ignore-case my-nick sender-nick))
+                    (listp (buffer-local-value 'buffer-invisibility-spec buf))
+                    (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
+                    (clatter-smart-eval buf sender-nick 'join)
+                    '(noise)))))))
 
 (defun clatter-ui--on-part (conn sender channel message)
   "Show SENDER leaving CHANNEL on CONN with optional MESSAGE."
@@ -1107,16 +1352,21 @@ the buffer margin-width variables."
          (invisible (clatter-sender-invisibility sender network)))
     (when buf
       (clatter-nick-remove buf sender-nick)
-      (clatter-insert-system buf
-                             (format "%s has left %s%s" sender-nick channel
-                                     (if message (format " (%s)" (clatter-format-parse message)) ""))
-                             (append (if invisible (list 'part invisible) '(part))
-                                     (and (not is-muted)
-                                          (not (string-equal-ignore-case my-nick sender-nick))
-                                          (listp (buffer-local-value 'buffer-invisibility-spec buf))
-                                          (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
-                                          (clatter-smart-eval buf sender-nick 'part)
-                                          '(noise)))))))
+      (let ((reason (and message (clatter-format-parse message))))
+        (clatter--insert-system-event
+         buf 'part
+         (list :nick sender-nick
+               :channel channel
+               :reason reason
+               :verbose (format "%s has left %s%s" sender-nick channel
+                                (if message (format " (%s)" reason) "")))
+         (append (if invisible (list 'part invisible) '(part))
+                 (and (not is-muted)
+                      (not (string-equal-ignore-case my-nick sender-nick))
+                      (listp (buffer-local-value 'buffer-invisibility-spec buf))
+                      (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
+                      (clatter-smart-eval buf sender-nick 'part)
+                      '(noise))))))))
 
 (defun clatter-ui--on-quit (conn sender message)
   "Show SENDER quitting on CONN with optional MESSAGE."
@@ -1129,16 +1379,21 @@ the buffer margin-width variables."
       (when (gethash (downcase sender-nick)
                      (buffer-local-value 'clatter--nick-list buf))
         (clatter-nick-remove buf sender-nick)
-        (clatter-insert-system buf
-                               (format "%s has quit%s" sender-nick
-                                       (if message (format " (%s)" (clatter-format-parse message)) ""))
-                               (append (if invisible (list 'quit invisible) '(quit))
-                                       (and (not is-muted)
-                                            (not (string-equal-ignore-case my-nick sender-nick))
-                                            (listp (buffer-local-value 'buffer-invisibility-spec buf))
-                                            (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
-                                            (clatter-smart-eval buf sender-nick 'quit)
-                                            '(noise))))))))
+        (let ((reason (and message (clatter-format-parse message))))
+          (clatter--insert-system-event
+           buf 'quit
+           (list :nick sender-nick
+                 :channel (buffer-local-value 'clatter--target buf)
+                 :reason reason
+                 :verbose (format "%s has quit%s" sender-nick
+                                  (if message (format " (%s)" reason) "")))
+           (append (if invisible (list 'quit invisible) '(quit))
+                   (and (not is-muted)
+                        (not (string-equal-ignore-case my-nick sender-nick))
+                        (listp (buffer-local-value 'buffer-invisibility-spec buf))
+                        (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
+                        (clatter-smart-eval buf sender-nick 'quit)
+                        '(noise)))))))))
 
 (defun clatter-ui--on-nick (conn sender new-nick)
   "Show SENDER renaming to NEW-NICK on CONN."
@@ -1151,16 +1406,19 @@ the buffer margin-width variables."
       (when (gethash (downcase old-nick)
                      (buffer-local-value 'clatter--nick-list buf))
         (clatter-nick-rename buf old-nick new-nick)
-        (clatter-insert-system buf
-                               (format "%s is now known as %s"
-                                       old-nick new-nick)
-                               (append (if invisible (list 'nick invisible) '(nick))
-                                       (and (not is-muted)
-                                            (not (string-equal-ignore-case my-nick new-nick))
-                                            (listp (buffer-local-value 'buffer-invisibility-spec buf))
-                                            (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
-                                            (clatter-smart-eval buf old-nick new-nick)
-                                            '(noise))))))
+        (clatter--insert-system-event
+         buf 'nick
+         (list :nick old-nick
+               :new-nick new-nick
+               :channel (buffer-local-value 'clatter--target buf)
+               :verbose (format "%s is now known as %s" old-nick new-nick))
+         (append (if invisible (list 'nick invisible) '(nick))
+                 (and (not is-muted)
+                      (not (string-equal-ignore-case my-nick new-nick))
+                      (listp (buffer-local-value 'buffer-invisibility-spec buf))
+                      (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
+                      (clatter-smart-eval buf old-nick new-nick)
+                      '(noise))))))
     ;; The handler has already updated CONN's nick.  Refresh every prompt on
     ;; this network only when this was our own nick change and the configured
     ;; prompt may depend on the nick.
@@ -1205,16 +1463,22 @@ the buffer margin-width variables."
          (invisible (clatter-sender-invisibility sender network)))
     (when buf
       (clatter-nick-remove buf kicked)
-      (clatter-insert-system buf
-                             (format "%s was kicked by %s%s" kicked sender-nick
-                                     (if reason (format " (%s)" (clatter-format-parse reason)) ""))
-                             (append (if invisible (list 'kick invisible) '(kick))
-                                     (and (not is-muted)
-                                          (not (string-equal-ignore-case my-nick sender-nick))
-                                          (listp (buffer-local-value 'buffer-invisibility-spec buf))
-                                          (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
-                                          (clatter-smart-eval buf sender-nick 'kick)
-                                          '(noise)))))))
+      (let ((parsed-reason (and reason (clatter-format-parse reason))))
+        (clatter--insert-system-event
+         buf 'kick
+         (list :nick kicked
+               :setter sender-nick
+               :channel channel
+               :reason parsed-reason
+               :verbose (format "%s was kicked by %s%s" kicked sender-nick
+                                (if reason (format " (%s)" parsed-reason) "")))
+         (append (if invisible (list 'kick invisible) '(kick))
+                 (and (not is-muted)
+                      (not (string-equal-ignore-case my-nick sender-nick))
+                      (listp (buffer-local-value 'buffer-invisibility-spec buf))
+                      (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
+                      (clatter-smart-eval buf sender-nick 'kick)
+                      '(noise))))))))
 
 (defun clatter-ui--on-names (conn channel names-str)
   "Populate the CHANNEL nick list on CONN from NAMES-STR."
@@ -1270,18 +1534,22 @@ the buffer margin-width variables."
     (dolist (buf (clatter-channel-buffers network))
       (when (gethash (downcase sender-nick)
                      (buffer-local-value 'clatter--nick-list buf))
-        (clatter-insert-system buf
-                               (if away-msg
-                                   (format "%s is away: %s"
-                                           sender-nick (clatter-format-parse away-msg))
-                                 (format "%s is back" sender-nick))
-                               (append (if invisible (list 'away invisible) '(away))
-                                       (and (not is-muted)
-                                            (not (string-equal-ignore-case my-nick sender-nick))
-                                            (listp (buffer-local-value 'buffer-invisibility-spec buf))
-                                            (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
-                                            (clatter-smart-eval buf sender-nick 'away)
-                                            '(noise))))))))
+        (let ((reason (and away-msg (clatter-format-parse away-msg))))
+          (clatter--insert-system-event
+           buf (if away-msg 'away 'back)
+           (list :nick sender-nick
+                 :channel (buffer-local-value 'clatter--target buf)
+                 :reason reason
+                 :verbose (if away-msg
+                              (format "%s is away: %s" sender-nick reason)
+                            (format "%s is back" sender-nick)))
+           (append (if invisible (list 'away invisible) '(away))
+                   (and (not is-muted)
+                        (not (string-equal-ignore-case my-nick sender-nick))
+                        (listp (buffer-local-value 'buffer-invisibility-spec buf))
+                        (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
+                        (clatter-smart-eval buf sender-nick 'away)
+                        '(noise)))))))))
 
 (defun clatter-ui--on-mode (conn target setter modes)
   "Show SETTER applying MODES on TARGET on CONN."
@@ -1293,16 +1561,20 @@ the buffer margin-width variables."
          (is-muted (clatter-muted-p setter network))
          (invisible (clatter-sender-invisibility setter network)))
     (when buf
-      (clatter-insert-system buf
-                             (format "%s sets mode %s"
-                                     setter-nick (string-join modes " "))
-                             (append (if invisible (list 'mode invisible) '(mode))
-                                     (and (not is-muted)
-                                          (not (string-equal-ignore-case my-nick setter-nick))
-                                          (listp (buffer-local-value 'buffer-invisibility-spec buf))
-                                          (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
-                                          (clatter-smart-eval buf setter-nick 'mode)
-                                          '(noise)))))))
+      (let ((mode-string (string-join modes " ")))
+        (clatter--insert-system-event
+         buf 'mode
+         (list :nick setter-nick
+               :channel target
+               :modes mode-string
+               :verbose (format "%s sets mode %s" setter-nick mode-string))
+         (append (if invisible (list 'mode invisible) '(mode))
+                 (and (not is-muted)
+                      (not (string-equal-ignore-case my-nick setter-nick))
+                      (listp (buffer-local-value 'buffer-invisibility-spec buf))
+                      (memq 'noise (buffer-local-value 'buffer-invisibility-spec buf))
+                      (clatter-smart-eval buf setter-nick 'mode)
+                      '(noise))))))))
 
 (defun clatter-ui--on-motd (conn lines)
   "Display MOTD LINES on CONN in the server buffer."

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -390,6 +390,182 @@
       (clatter-ui-setup-buffer (current-buffer))
       (should (memq 'noise buffer-invisibility-spec)))))
 
+;; --- Compact system messages ---
+
+(ert-deftest clatter-test-compact-system-event-presets ()
+  "Compact presets format every supported event with the promised context."
+  (dolist
+      (case
+       '((join (:nick "alice" :channel "#test" :realname "Alice")
+               "alice" "alice" "alice (Alice) #test")
+         (part (:nick "alice" :channel "#test" :reason "bye")
+               "alice" "alice — bye" "alice #test — bye")
+         (quit (:nick "alice" :channel "#test" :reason "timeout")
+               "alice" "alice — timeout" "alice #test — timeout")
+         (nick (:nick "alice" :new-nick "alice_")
+               "alice → alice_" "alice → alice_" "alice → alice_")
+         (away (:nick "alice" :channel "#test" :reason "lunch")
+               "alice" "alice — lunch" "alice #test — lunch")
+         (back (:nick "alice" :channel "#test")
+               "alice" "alice" "alice #test")
+         (mode (:nick "alice" :channel "#test" :modes "+o bob")
+               "alice +o bob" "alice +o bob" "alice #test +o bob")
+         (kick (:nick "bob" :setter "alice" :channel "#test" :reason "flooding")
+               "bob ← alice" "bob ← alice — flooding"
+               "bob ← alice #test — flooding")
+         (invite (:nick "alice" :invitee "testnick" :channel "#secret")
+                 "alice → #secret" "alice → #secret"
+                 "alice → testnick #secret")))
+    (pcase-let ((`(,event ,fields ,essential ,reasons ,full) case))
+      (let ((clatter-compact-system-messages 'essential))
+        (should (equal (clatter--format-system-event event fields) essential)))
+      (let ((clatter-compact-system-messages 'reasons))
+        (should (equal (clatter--format-system-event event fields) reasons)))
+      (let ((clatter-compact-system-messages 'full))
+        (should (equal (clatter--format-system-event event fields) full))))))
+
+(ert-deftest clatter-test-compact-system-groups-consecutive-events ()
+  "Compact mode groups adjacent presence actions in either message order."
+  (dolist (order '(oldest-first newest-first))
+    (let ((clatter-compact-system-messages 'compact)
+          (clatter-compact-system-group-window 180)
+          (clatter-message-order order)
+          (times '(100.0 110.0 120.0)))
+      (clatter-test-with-ui-connection conn
+        (let ((buffer (clatter-get-or-create-buffer "testnet" "#test")))
+          (cl-letf (((symbol-function 'clatter--compact-system-now)
+                     (lambda () (pop times))))
+            (clatter--insert-system-event
+             buffer 'quit '(:nick "alcor" :channel "#test") 'quit)
+            (clatter--insert-system-event
+             buffer 'join '(:nick "alcor" :channel "#test") 'join)
+            (clatter--insert-system-event
+             buffer 'away '(:nick "Elouin" :channel "#test") 'away))
+          (with-current-buffer buffer
+            (let ((rendered (buffer-substring-no-properties
+                             (point-min) (point-max))))
+              (should (string-match-p
+                       "× alcor · → alcor · ○ Elouin" rendered)))
+            (goto-char (point-min))
+            (search-forward "×")
+            (should (memq 'quit (ensure-list
+                                 (get-text-property (1- (point)) 'invisible))))
+            (search-forward "→")
+            (should (memq 'join (ensure-list
+                                 (get-text-property (1- (point)) 'invisible))))
+            (search-forward "○")
+            (should (memq 'away (ensure-list
+                                 (get-text-property (1- (point)) 'invisible))))))))))
+
+(ert-deftest clatter-test-compact-system-separator-is-configurable ()
+  "Compact grouped events use the configured separator."
+  (let ((clatter-compact-system-messages 'compact)
+        (clatter-compact-system-separator ", "))
+    (clatter-test-with-ui-connection conn
+      (let ((buffer (clatter-get-or-create-buffer "testnet" "#test")))
+        (clatter--insert-system-event
+         buffer 'join '(:nick "alice" :channel "#test") 'join)
+        (clatter--insert-system-event
+         buffer 'join '(:nick "bob" :channel "#test") 'join)
+        (with-current-buffer buffer
+          (should (string-match-p
+                   "→ alice, → bob"
+                   (buffer-substring-no-properties
+                    (point-min) (point-max)))))))))
+
+(ert-deftest clatter-test-compact-system-intervening-message-ends-group ()
+  "Any intervening line prevents a later event joining an older group."
+  (let ((clatter-compact-system-messages 'compact)
+        (clatter-compact-system-group-window 180))
+    (clatter-test-with-ui-connection conn
+      (let ((buffer (clatter-get-or-create-buffer "testnet" "#test")))
+        (clatter--insert-system-event
+         buffer 'join '(:nick "alice" :channel "#test") 'join)
+        (clatter-insert-system buffer "intervening chat")
+        (clatter--insert-system-event
+         buffer 'join '(:nick "bob" :channel "#test") 'join)
+        (with-current-buffer buffer
+          (should (= (how-many "→" (point-min) (point-max)) 2))
+          (goto-char (point-min))
+          (should-not (search-forward "→ alice · → bob" nil t)))))))
+
+(ert-deftest clatter-test-compact-system-respects-window-and-visibility ()
+  "Expired or differently hidden events start separate compact groups."
+  (let ((clatter-compact-system-messages 'compact)
+        (clatter-compact-system-group-window 180)
+        (times '(100.0 400.0 410.0 420.0 430.0)))
+    (clatter-test-with-ui-connection conn
+      (let ((buffer (clatter-get-or-create-buffer "testnet" "#test")))
+        (cl-letf (((symbol-function 'clatter--compact-system-now)
+                   (lambda () (pop times))))
+          (clatter--insert-system-event
+           buffer 'join '(:nick "alice" :channel "#test") 'join)
+          (clatter--insert-system-event
+           buffer 'join '(:nick "bob" :channel "#test") 'join)
+          (clatter--insert-system-event
+           buffer 'join '(:nick "lurker" :channel "#test") '(join noise)))
+        (with-current-buffer buffer
+          (should (= (cl-count ?→ (buffer-substring-no-properties
+                                   (point-min) (point-max)))
+                     3)))))))
+
+(ert-deftest clatter-test-compact-system-default-preserves-verbose-join ()
+  "The default nil compact setting preserves the existing JOIN sentence."
+  (let ((clatter-compact-system-messages nil)
+        (clatter-smart-enabled nil)
+        (clatter-suppress-messages '(muted)))
+    (clatter-test-with-ui-connection conn
+      (clatter-ui--on-join conn '("alice" nil nil) "#test" nil "Alice")
+      (with-current-buffer (clatter-get-buffer "testnet" "#test")
+        (goto-char (point-min))
+        (should (search-forward "*** alice (Alice) has joined #test" nil t))))))
+
+(ert-deftest clatter-test-compact-system-custom-symbol-preserves-noise ()
+  "Compact JOINs use configured prefixes without losing noise metadata."
+  (let ((clatter-compact-system-messages 'essential)
+        (clatter-compact-system-symbols '((join . "+")))
+        (clatter-smart-enabled t)
+        (clatter-smart-noise '(join))
+        (clatter-suppress-messages '(muted)))
+    (clatter-test-with-ui-connection conn
+      (cl-letf (((symbol-function 'clatter-smart-eval)
+                 (lambda (&rest _args) t)))
+        (clatter-ui--on-join conn '("lurker" nil nil) "#test" nil nil))
+      (with-current-buffer (clatter-get-buffer "testnet" "#test")
+        (goto-char (point-min))
+        (should (search-forward "+ lurker" nil t))
+        (let ((start (match-beginning 0)))
+          (should (eq (get-text-property start 'face) 'clatter-system))
+          (should (memq 'join
+                        (ensure-list (get-text-property start 'invisible))))
+          (should (memq 'noise
+                        (ensure-list (get-text-property start 'invisible)))))))))
+
+(ert-deftest clatter-test-compact-system-handlers-use-event-renderer ()
+  "Every supported handler emits its compact event form."
+  (let ((clatter-compact-system-messages 'essential)
+        (clatter-smart-enabled nil)
+        (clatter-suppress-messages '(muted)))
+    (clatter-test-with-ui-connection conn
+      (clatter-ui--on-join conn '("alice" nil nil) "#test" nil nil)
+      (clatter-ui--on-mode conn "#test" '("op" nil nil) '("+o" "alice"))
+      (clatter-ui--on-away conn '("alice" nil nil) "lunch")
+      (clatter-ui--on-away conn '("alice" nil nil) nil)
+      (clatter-ui--on-nick conn '("alice" nil nil) "alice_")
+      (clatter-ui--on-join conn '("bob" nil nil) "#test" nil nil)
+      (clatter-ui--on-part conn '("bob" nil nil) "#test" "bye")
+      (clatter-ui--on-join conn '("carol" nil nil) "#test" nil nil)
+      (clatter-ui--on-quit conn '("carol" nil nil) "timeout")
+      (clatter-ui--on-join conn '("dave" nil nil) "#test" nil nil)
+      (clatter-ui--on-kick conn "#test" '("op" nil nil) "dave" "flooding")
+      (clatter-ui--on-invite conn '("op" nil nil) "testnick" "#test")
+      (with-current-buffer (clatter-get-buffer "testnet" "#test")
+        (let ((rendered (buffer-substring-no-properties (point-min) (point-max))))
+          (dolist (expected '("→ alice" "± op +o alice" "○ alice" "● alice"
+                              "» alice → alice_" "← bob" "× carol"
+                              "⬾ dave ← op" "✉ op → #test"))
+            (should (string-match-p (regexp-quote expected) rendered))))))))
+
 (ert-deftest clatter-test-smart-noise-tags-noisy-events-in-new-buffer ()
   "A smart-filtered event in a new buffer carries the hidden noise category."
   (let ((clatter-smart-enabled t)


### PR DESCRIPTION
## Summary

Adds compact, configurable rendering for join, part, quit, nick, away, back, mode, kick, and invite events while preserving the existing verbose output by default.

## Configuration

```elisp
;; nil keeps the current verbose sentences.
(setopt clatter-compact-system-messages 'compact)

;; Other presets:
;; 'essential — terse individual event lines without grouping
;; 'reasons — include PART, QUIT, KICK, and AWAY reasons
;; 'full    — also include available channel, realname, invitee,
;;            and target context
```

`compact` groups consecutive join, part, quit, away, and back events with
compatible visibility. Any intervening chat or other event ends the group,
preserving honest chronology. The grouping window defaults to three minutes:

```elisp
(setopt clatter-compact-system-group-window 180)
```

The separator is configurable and defaults to a middle dot:

```elisp
(setopt clatter-compact-system-separator " · ")
```

The default symbols are customizable:

```elisp
(setopt clatter-compact-system-symbols
        '((join . "+")
          (part . "-")
          (quit . "x")
          (nick . ">")
          (away . "o")
          (back . "*")
          (mode . "±")
          (kick . "!")
          (invite . "@")))
```

## Examples

With the built-in symbols:

```text
× alcor · → alcor · ○ Elouin
» alice → alice_
± alice +o bob
⬾ bob ← alice — flooding
✉ alice → #secret
```

`compact` uses essential detail for grouped presence events. `essential` keeps
the shortest useful form without grouping, `reasons` adds relevant reasons,
and `full` adds available context such as `#test` and real names. Mode, kick,
invite, and nick-change events remain individual so their relationships stay
clear.

Smart-noise and suppression metadata continue to apply to these messages.
Events with different visibility metadata are never combined, so noisy nicks
cannot hide active ones.

## Tests

- Covers every supported event across all four presets.
- Covers mixed-action compact grouping in oldest-first and newest-first order.
- Covers custom compact separators.
- Verifies grouping ends after intervening messages, timeout, or visibility changes.
- Verifies the default remains backward-compatible.
- Verifies custom symbols and suppression metadata.
