### PR TITLE
Add configurable tracker styling

### DIFF
--- a/README.org
+++ b/README.org
@@ -117,6 +117,7 @@ Example:
 *** Activity Tracking (clatter-track)
 - Global mode-line activity indicator
 - Unread counts and mention detection per channel
+- Configurable mention/DM/activity indicators, faces, and count styles
 - Priority sorting: mentions > DMs > regular activity
 - Clickable mode-line entries (switch to buffer on click)
 - Channel mute/unmute support

--- a/clatter-track.el
+++ b/clatter-track.el
@@ -40,6 +40,7 @@ Example: (\"#spam\" \"#bots\")"
 
 (defcustom clatter-track-faces-alist
   '((mention . clatter-track-mention)
+    (dm . clatter-track-dm)
     (activity . clatter-track-activity)
     (muted . clatter-track-muted))
   "Alist mapping activity types to faces for the track indicator."
@@ -55,6 +56,33 @@ Removes the clatter: prefix and network name."
 (defcustom clatter-track-show-counts t
   "Show unread message counts in the track indicator."
   :type 'boolean
+  :group 'clatter)
+
+(defcustom clatter-track-indicators
+  '((mention . "@")
+    (dm . "*")
+    (activity . ""))
+  "Alist mapping activity types to prefix indicators.
+An explicit nil or empty value hides that indicator.  Missing entries
+fall back to the legacy indicator for their activity type."
+  :type '(alist :key-type (choice (const mention)
+                                  (const dm)
+                                  (const activity))
+                :value-type (choice (const :tag "No indicator" nil)
+                                    string))
+  :group 'clatter)
+
+(defcustom clatter-track-count-style 'suffix
+  "Style used to display unread counts in the activity tracker.
+The value `suffix' renders the legacy :N form.  `superscript' and
+`subscript' raise or lower the exact count.  `glyph' renders one as ·,
+two as :, three as ⋮, and larger counts as a raised +N.  `none' hides
+the count.  `clatter-track-show-counts' remains the master switch."
+  :type '(choice (const :tag "Colon suffix (:N)" suffix)
+                 (const :tag "Raised number" superscript)
+                 (const :tag "Lowered number" subscript)
+                 (const :tag "Compact glyphs" glyph)
+                 (const :tag "No count" none))
   :group 'clatter)
 
 (defcustom clatter-track-in-buffer-mode-line nil
@@ -150,25 +178,70 @@ Returns list of plists sorted by priority: mentions > DMs > activity."
 
 ;; --- Format track string ---
 
+(defun clatter-track--entry-type (info)
+  "Return the primary activity type represented by INFO."
+  (cond
+   ((plist-get info :mention) 'mention)
+   ((plist-get info :dm) 'dm)
+   (t 'activity)))
+
+(defun clatter-track--legacy-indicator (type)
+  "Return the legacy tracker indicator for TYPE."
+  (pcase type
+    ('mention "@")
+    ('dm "*")
+    (_ "")))
+
+(defun clatter-track--indicator (type)
+  "Return the configured tracker indicator for TYPE."
+  (let ((entry (assq type clatter-track-indicators)))
+    (if entry
+        (or (cdr entry) "")
+      (clatter-track--legacy-indicator type))))
+
+(defun clatter-track--legacy-face (type)
+  "Return the legacy tracker face for TYPE."
+  (pcase type
+    ('mention 'clatter-track-mention)
+    ('dm 'clatter-track-dm)
+    ('muted 'clatter-track-muted)
+    (_ 'clatter-track-activity)))
+
+(defun clatter-track--face (type muted)
+  "Return the configured tracker face for TYPE, respecting MUTED."
+  (let* ((face-type (if muted 'muted type))
+         (entry (assq face-type clatter-track-faces-alist)))
+    (or (cdr entry) (clatter-track--legacy-face face-type))))
+
+(defun clatter-track--format-count (unread)
+  "Format UNREAD according to the configured tracker count style."
+  (if (or (not clatter-track-show-counts)
+          (<= unread 0)
+          (eq clatter-track-count-style 'none))
+      ""
+    (pcase clatter-track-count-style
+      ('superscript
+       (propertize (number-to-string unread) 'display '(raise 0.3)))
+      ('subscript
+       (propertize (number-to-string unread) 'display '(raise -0.3)))
+      ('glyph
+       (pcase unread
+         (1 "·")
+         (2 ":")
+         (3 "⋮")
+         (_ (propertize (format "+%d" unread) 'display '(raise 0.3)))))
+      (_ (format ":%d" unread)))))
+
 (defun clatter-track--format-entry (info)
   "Format a single track INFO plist into a propertized string."
   (let* ((name (plist-get info :name))
          (unread (plist-get info :unread))
          (mention (plist-get info :mention))
          (muted (plist-get info :muted))
-         (dm (plist-get info :dm))
-         (face (cond
-                (muted 'clatter-track-muted)
-                (mention 'clatter-track-mention)
-                (dm 'clatter-track-dm)
-                (t 'clatter-track-activity)))
-         (prefix (cond
-                  (mention "@")
-                  (dm "*")
-                  (t "")))
-         (count-str (if (and clatter-track-show-counts (> unread 0))
-                        (format ":%d" unread)
-                      "")))
+         (type (clatter-track--entry-type info))
+         (face (clatter-track--face type muted))
+         (prefix (clatter-track--indicator type))
+         (count-str (clatter-track--format-count unread)))
     (propertize (format "%s%s%s" prefix name count-str)
                 'face face
                 'help-echo (format "%s - %d unread%s"

--- a/tests/test-track-styling.el
+++ b/tests/test-track-styling.el
@@ -1,0 +1,108 @@
+;;; test-track-styling.el --- Tracker presentation tests -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'test-helper)
+(require 'clatter-track)
+
+(defun clatter-track-styling-test--info (&rest overrides)
+  "Return tracker info with OVERRIDES applied."
+  (let ((info (list :buffer (current-buffer)
+                    :name "#test"
+                    :unread 3
+                    :mention nil
+                    :muted nil
+                    :dm nil)))
+    (while overrides
+      (setq info (plist-put info (pop overrides) (pop overrides))))
+    info))
+
+(ert-deftest clatter-track-styling-defaults-preserve-output ()
+  "Default tracker styling reproduces the legacy strings and faces."
+  (let ((clatter-track-indicators '((mention . "@") (dm . "*") (activity . "")))
+        (clatter-track-count-style 'suffix)
+        (clatter-track-show-counts t))
+    (let ((mention (clatter-track--format-entry
+                    (clatter-track-styling-test--info :mention t)))
+          (dm (clatter-track--format-entry
+               (clatter-track-styling-test--info :name "alice" :unread 1 :dm t)))
+          (activity (clatter-track--format-entry
+                     (clatter-track-styling-test--info :unread 5))))
+      (should (equal (substring-no-properties mention) "@#test:3"))
+      (should (equal (substring-no-properties dm) "*alice:1"))
+      (should (equal (substring-no-properties activity) "#test:5"))
+      (should (eq (get-text-property 0 'face mention) 'clatter-track-mention))
+      (should (eq (get-text-property 0 'face dm) 'clatter-track-dm)))))
+
+(ert-deftest clatter-track-styling-indicators-support-nil-and-fallbacks ()
+  "Explicit nil hides an indicator while missing entries use legacy values."
+  (let ((clatter-track-indicators '((mention . nil)))
+        (clatter-track-count-style 'suffix))
+    (should
+     (equal (substring-no-properties
+             (clatter-track--format-entry
+              (clatter-track-styling-test--info :mention t)))
+            "#test:3"))
+    (should
+     (equal (substring-no-properties
+             (clatter-track--format-entry
+              (clatter-track-styling-test--info :name "alice" :unread 1 :dm t)))
+            "*alice:1"))))
+
+(ert-deftest clatter-track-styling-count-display-styles ()
+  "Raised, lowered, and disabled count styles preserve exact counts."
+  (dolist (case '((superscript (raise 0.3))
+                  (subscript (raise -0.3))))
+    (let* ((clatter-track-count-style (car case))
+           (entry (clatter-track--format-entry
+                   (clatter-track-styling-test--info)))
+           (count-pos (1- (length entry))))
+      (should (equal (substring-no-properties entry) "#test3"))
+      (should (equal (get-text-property count-pos 'display entry) (cadr case)))))
+  (let ((clatter-track-count-style 'none))
+    (should
+     (equal (substring-no-properties
+             (clatter-track--format-entry (clatter-track-styling-test--info)))
+            "#test")))
+  (let ((clatter-track-count-style 'suffix)
+        (clatter-track-show-counts nil))
+    (should
+     (equal (substring-no-properties
+             (clatter-track--format-entry (clatter-track-styling-test--info)))
+            "#test"))))
+
+(ert-deftest clatter-track-styling-glyph-counts-are-exact ()
+  "Glyph counts use compact marks and retain exact larger values."
+  (let ((clatter-track-count-style 'glyph))
+    (dolist (case '((1 "#test·") (2 "#test:") (3 "#test⋮") (12 "#test+12")))
+      (let ((entry (clatter-track--format-entry
+                    (clatter-track-styling-test--info :unread (car case)))))
+        (should (equal (substring-no-properties entry) (cadr case)))
+        (when (> (car case) 3)
+          (should (equal (get-text-property (- (length entry) 2) 'display entry)
+                         '(raise 0.3))))))))
+
+(ert-deftest clatter-track-styling-uses-configured-faces ()
+  "The public face alist controls entries and safely falls back."
+  (let ((clatter-track-faces-alist '((mention . bold))))
+    (let ((mention (clatter-track--format-entry
+                    (clatter-track-styling-test--info :mention t)))
+          (dm (clatter-track--format-entry
+               (clatter-track-styling-test--info :name "alice" :dm t)))
+          (muted (clatter-track--format-entry
+                  (clatter-track-styling-test--info :muted t))))
+      (should (eq (get-text-property 0 'face mention) 'bold))
+      (should (eq (get-text-property 0 'face dm) 'clatter-track-dm))
+      (should (eq (get-text-property 0 'face muted) 'clatter-track-muted)))))
+
+(ert-deftest clatter-track-styling-preserves-interaction-properties ()
+  "Styled entries retain help, mouse, and click-map properties."
+  (let ((entry (clatter-track--format-entry
+                (clatter-track-styling-test--info :mention t))))
+    (should (stringp (get-text-property 0 'help-echo entry)))
+    (should (eq (get-text-property 0 'mouse-face entry) 'highlight))
+    (should (keymapp (get-text-property 0 'local-map entry)))))
+
+(provide 'test-track-styling)
+
+;;; test-track-styling.el ends here


### PR DESCRIPTION
## Summary

Makes activity-tracker indicators, unread-count presentation, and faces configurable without changing the existing defaults.

## Configuration

Customize the indicators for mentions, DMs, and ordinary activity:

```elisp
(setopt clatter-track-indicators
        '((mention . "◆")
          (dm . "✉")
          (activity . "•")))
```

An explicit `nil` or empty string hides an indicator. A missing entry uses the legacy default.

Choose how unread counts are displayed:

```elisp
(setopt clatter-track-count-style 'glyph)

;; Available values:
;; 'suffix      => #clatter:3
;; 'superscript => #clatter³ (visually raised exact count)
;; 'subscript   => #clatter₃ (visually lowered exact count)
;; 'glyph       => #clatter·  #clatter:  #clatter⋮  #clatter+12
;; 'none        => #clatter
```

`clatter-track-show-counts` remains the master count switch. Existing `clatter-track-faces-alist` customization now controls mention, DM, activity, and muted entry faces.

## Example

```elisp
(setopt clatter-track-indicators
        '((mention . "@") (dm . "*") (activity . ""))
        clatter-track-count-style 'glyph)
```

This can render entries such as:

```text
@#clatter⋮  *alice·  #emacs+12
```

## Tests

- Covers custom, hidden, and fallback indicators.
- Covers all count styles and exact glyph thresholds.
- Verifies configured faces and the existing count master switch.
