### PR TITLE
Use native desktop notifications

### DIFF
--- a/README.org
+++ b/README.org
@@ -126,7 +126,8 @@ Example:
 
 *** Desktop Notifications (clatter-notify)
 - Mention, DM, and keyword-triggered notifications
-- Uses notify-send (Linux) or terminal-notifier (macOS)
+- Uses Emacs-native desktop notifications (D-Bus, Android, Haiku, or Windows), with terminal-notifier on macOS
+- Silent delivery failure by default, with an opt-in echo-area fallback
 - Per-channel and per-nick muting
 - Smart notification rules: per-channel levels (all/mentions/dms/none) with schedule
 - DM priority override (always/rules/never)

--- a/clatter-notify.el
+++ b/clatter-notify.el
@@ -9,17 +9,23 @@
 ;; Desktop notifications for clatter.el with IRC-specific rules.
 ;; Supports mentions, DMs, keyword matching, muted channels,
 ;; and current-buffer suppression.
-;; Uses notify-send on Linux, terminal-notifier on macOS,
-;; or Emacs built-in notifications as fallback.
+;; Uses Emacs-native notification APIs, with terminal-notifier retained
+;; as the macOS backend.
 
 ;;; Code:
 
 (require 'cl-lib)
+(require 'xml)
 (require 'clatter-config)
 (require 'clatter-protocol)
 (require 'clatter-connection)
 (require 'clatter-model)
 (require 'clatter-pals)
+
+(declare-function notifications-notify "notifications" (&rest params))
+(declare-function android-notifications-notify "androidselect.c" (&rest params))
+(declare-function haiku-notifications-notify "haikuselect.c" (&rest params))
+(declare-function w32-notification-notify "w32notify.c" (&rest params))
 
 ;; --- Configuration ---
 
@@ -111,6 +117,13 @@ Set to t for system default, or a path to a specific sound."
   :type 'integer
   :group 'clatter)
 
+(defcustom clatter-notify-echo-area nil
+  "When non-nil, echo a notification after native delivery fails.
+This fallback is disabled by default so mentions and DMs do not spam
+the echo area when no desktop notification service is available."
+  :type 'boolean
+  :group 'clatter)
+
 ;; --- Smart notification rules ---
 
 (defcustom clatter-notify-rules nil
@@ -198,48 +211,123 @@ Prevents notification spam from rapid messages."
 
 ;; --- Notification dispatch ---
 
-(defun clatter-notify--send (title body)
-  "Send a desktop notification with TITLE and BODY."
-  (let ((body-truncated (if (> (length body) clatter-notify-max-length)
-                            (concat (substring body 0 (- clatter-notify-max-length 3)) "...")
-                          body)))
-    (cond
-     ;; Linux: notify-send
-     ((executable-find "notify-send")
-      (let ((args (list "notify-send"
-                        "-t" (number-to-string clatter-notify-timeout)
-                        "-u" (symbol-name clatter-notify-urgency)
-                        "-a" "CLatter")))
-        (when clatter-notify-icon
-          (setq args (append args (list "-i" clatter-notify-icon))))
-        (setq args (append args (list title body-truncated)))
-        (apply #'start-process "clatter-notify" nil args)))
-     ;; macOS: terminal-notifier or osascript
-     ((executable-find "terminal-notifier")
-      (start-process "clatter-notify" nil
-                     "terminal-notifier"
-                     "-title" title
-                     "-message" body-truncated
-                     "-sender" "org.gnu.Emacs"
-                     "-group" "clatter"))
-     ;; Fallback: Emacs message
-     (t
-      (message "[CLatter] %s: %s" title body-truncated)))
-    ;; Optional sound
-    (when clatter-notify-sound
-      (clatter-notify--play-sound))))
+(defun clatter-notify--plain-text (text)
+  "Return notification TEXT without properties or IRC formatting."
+  (clatter-strip-irc-formatting (substring-no-properties text)))
 
-(defun clatter-notify--play-sound ()
-  "Play notification sound if configured."
+(defun clatter-notify--truncate (text)
+  "Return plain notification TEXT truncated to the configured limit."
+  (let* ((plain (clatter-notify--plain-text text))
+         (limit (max 0 clatter-notify-max-length)))
+    (cond
+     ((<= (length plain) limit) plain)
+     ((zerop limit) "")
+     (t (concat (substring plain 0 (1- limit)) "…")))))
+
+(defun clatter-notify--action-params (buffer)
+  "Return native notification action parameters for BUFFER."
+  (when (buffer-live-p buffer)
+    (list :actions '("default" "Open buffer")
+          :on-action (lambda (&rest _)
+                       (when (buffer-live-p buffer)
+                         (pop-to-buffer buffer))))))
+
+(defun clatter-notify--dbus-sound-params ()
+  "Return D-Bus sound parameters for the configured notification sound."
   (cond
+   ((eq clatter-notify-sound t)
+    (list :sound-name "message-new-instant"))
    ((and (stringp clatter-notify-sound)
          (file-exists-p clatter-notify-sound))
-    (start-process "clatter-sound" nil "paplay" clatter-notify-sound))
-   ((eq clatter-notify-sound t)
-    (when (executable-find "paplay")
-      (start-process "clatter-sound" nil
-                     "paplay"
-                     "/usr/share/sounds/freedesktop/stereo/message-new-instant.oga")))))
+    (list :sound-file (expand-file-name clatter-notify-sound)))))
+
+(defun clatter-notify--dbus-send (title body buffer)
+  "Send TITLE and BODY over D-Bus, associated with BUFFER."
+  (condition-case nil
+      (when (require 'notifications nil t)
+        (let ((params (list :title (xml-escape-string title t)
+                            :body (xml-escape-string body t)
+                            :app-name "CLatter"
+                            :timeout clatter-notify-timeout
+                            :urgency clatter-notify-urgency
+                            :category "im.received")))
+          (when clatter-notify-icon
+            (setq params (append params (list :app-icon clatter-notify-icon))))
+          (setq params (append params
+                               (clatter-notify--dbus-sound-params)
+                               (clatter-notify--action-params buffer)))
+          ;; `notifications-notify' demotes D-Bus failures through `message'.
+          ;; Keep automatic delivery silent and let our own fallback policy
+          ;; decide whether anything belongs in the echo area.
+          (let ((inhibit-message t)
+                (message-log-max nil))
+            (apply #'notifications-notify params))))
+    (error nil)))
+
+(defun clatter-notify--android-send (title body buffer)
+  "Send an Android notification with TITLE and BODY for BUFFER."
+  (when (fboundp 'android-notifications-notify)
+    (apply #'android-notifications-notify
+           (append (list :title title
+                         :body body
+                         :timeout clatter-notify-timeout
+                         :urgency clatter-notify-urgency
+                         :group "CLatter")
+                   (clatter-notify--action-params buffer)))))
+
+(defun clatter-notify--haiku-send (title body)
+  "Send a Haiku notification with TITLE and BODY."
+  (when (fboundp 'haiku-notifications-notify)
+    (let ((params (list :title title :body body
+                        :urgency clatter-notify-urgency)))
+      (when clatter-notify-icon
+        (setq params (append params (list :app-icon clatter-notify-icon))))
+      (apply #'haiku-notifications-notify params))))
+
+(defun clatter-notify--w32-send (title body)
+  "Send a native Windows notification with TITLE and BODY."
+  (when (fboundp 'w32-notification-notify)
+    (let ((params (list :title title :body body
+                        :level (if (eq clatter-notify-urgency 'critical)
+                                   'error
+                                 'info))))
+      (when clatter-notify-icon
+        (setq params (append params (list :icon clatter-notify-icon))))
+      (apply #'w32-notification-notify params))))
+
+(defun clatter-notify--mac-send (title body)
+  "Send a macOS notification with TITLE and BODY."
+  (when (executable-find "terminal-notifier")
+    (let ((args (list "clatter-notify" nil
+                      "terminal-notifier"
+                      "-title" title
+                      "-message" body
+                      "-sender" "org.gnu.Emacs"
+                      "-group" "clatter")))
+      (when (eq clatter-notify-sound t)
+        (setq args (append args '("-sound" "default"))))
+      (apply #'start-process args))))
+
+(defun clatter-notify--send-native (title body buffer)
+  "Send TITLE and BODY through the native backend for BUFFER."
+  (condition-case nil
+      (cond
+       ((featurep 'android) (clatter-notify--android-send title body buffer))
+       ((featurep 'haiku) (clatter-notify--haiku-send title body))
+       ((eq system-type 'windows-nt) (clatter-notify--w32-send title body))
+       ((eq system-type 'darwin) (clatter-notify--mac-send title body))
+       (t (clatter-notify--dbus-send title body buffer)))
+    (error nil)))
+
+(defun clatter-notify--send (title body &optional buffer)
+  "Send a desktop notification with TITLE and BODY for BUFFER.
+Return the backend result, `echo' for an echo-area fallback, or nil."
+  (let ((plain-title (clatter-notify--plain-text title))
+        (plain-body (clatter-notify--truncate body)))
+    (or (clatter-notify--send-native plain-title plain-body buffer)
+        (when clatter-notify-echo-area
+          (message "[CLatter] %s: %s" plain-title plain-body)
+          'echo))))
 
 ;; --- Notification logic ---
 
@@ -314,9 +402,9 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
   "Format notification title based on REASON, SENDER, and TARGET."
   (pcase reason
     ('dm (format "DM from %s" sender))
-    ('mention (format "Mentioned in %s" target))
+    ('mention (format "Mention from %s in %s" sender target))
     ('invite (format "Invite from %s" sender))
-    ('keyword (format "Keyword in %s" target))
+    ('keyword (format "Keyword from %s in %s" sender target))
     (_ (format "%s in %s" sender target))))
 
 ;; --- Hooks ---
@@ -334,7 +422,9 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
         (when (clatter-notify--rate-ok-p source)
           (clatter-notify--send
            (clatter-notify--format-title reason sender-nick target)
-           (format "<%s> %s" sender-nick text)))))))
+           text
+           (clatter-get-buffer (clatter-connection-network-id conn)
+                               (if is-channel target sender-nick))))))))
 
 (defun clatter-notify--on-action (conn sender target text &optional server-time)
   "Notify for SENDER's ACTION TEXT to TARGET on CONN."
@@ -349,7 +439,9 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
         (when (clatter-notify--rate-ok-p source)
           (clatter-notify--send
            (clatter-notify--format-title reason sender-nick target)
-           (format "* %s %s" sender-nick text)))))))
+           (format "* %s" text)
+           (clatter-get-buffer (clatter-connection-network-id conn)
+                               (if is-channel target sender-nick))))))))
 
 (defun clatter-notify--on-invite (conn sender nick channel)
   "Notify when SENDER invites NICK to CHANNEL on CONN."
@@ -359,7 +451,10 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
       (when (clatter-notify--rate-ok-p sender-nick)
         (clatter-notify--send
          (clatter-notify--format-title 'invite sender-nick nick)
-         (format "%s invites you to join %s" sender-nick channel))))))
+         (format "Invitation to join %s" channel)
+         (or (clatter-get-buffer (clatter-connection-network-id conn) channel)
+             (clatter-get-server-buffer
+              (clatter-connection-network-id conn))))))))
 
 ;; --- Interactive commands ---
 
@@ -387,7 +482,8 @@ Returns a symbol indicating the reason: mention, dm, keyword, or nil."
 (defun clatter-notify-test ()
   "Send a test notification."
   (interactive)
-  (clatter-notify--send "CLatter Test" "Notifications are working"))
+  (unless (clatter-notify--send "CLatter Test" "Notifications are working")
+    (message "[clatter-notify] Native notification delivery failed")))
 
 (defun clatter-notify-mute-nick (pattern)
   "Add PATTERN to the muted nicks list."

--- a/tests/test-notify.el
+++ b/tests/test-notify.el
@@ -1,0 +1,189 @@
+;;; test-notify.el --- Native desktop notification tests -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'test-helper)
+(require 'clatter-notify)
+
+(ert-deftest clatter-notify-dbus-sanitizes-and-opens-buffer ()
+  "D-Bus delivery strips IRC controls, escapes markup, and opens its buffer."
+  (let ((clatter-notify-max-length 200)
+        (clatter-notify-timeout 1234)
+        (clatter-notify-urgency 'critical)
+        (clatter-notify-sound t)
+        (real-require (symbol-function 'require))
+        captured opened delivery-silenced)
+    (with-temp-buffer
+      (let ((buffer (current-buffer)))
+        (cl-letf (((symbol-function 'require)
+                   (lambda (feature &optional filename noerror)
+                     (if (eq feature 'notifications)
+                         t
+                       (funcall real-require feature filename noerror))))
+                  ((symbol-function 'notifications-notify)
+                   (lambda (&rest params)
+                     (setq captured params
+                           delivery-silenced
+                           (and inhibit-message (null message-log-max)))
+                     42))
+                  ((symbol-function 'start-process)
+                   (lambda (&rest _) (ert-fail "External notifier used")))
+                  ((symbol-function 'pop-to-buffer)
+                   (lambda (target &rest _) (setq opened target))))
+          (should (= (clatter-notify--send "A & B" "\x02<tag>\x02" buffer) 42))
+          (should (equal (plist-get captured :title) "A &amp; B"))
+          (should (equal (plist-get captured :body) "&lt;tag&gt;"))
+          (should-not (plist-member captured :transient))
+          (should (= (plist-get captured :timeout) 1234))
+          (should (eq (plist-get captured :urgency) 'critical))
+          (should (equal (plist-get captured :sound-name)
+                         "message-new-instant"))
+          (should delivery-silenced)
+          (funcall (plist-get captured :on-action) 42 "default")
+          (should (eq opened buffer)))))))
+
+(ert-deftest clatter-notify-dbus-maps-sound-file ()
+  "A configured sound file is passed to the native D-Bus backend."
+  (let ((sound (make-temp-file "clatter-sound")))
+    (unwind-protect
+        (let ((clatter-notify-sound sound)
+              (real-require (symbol-function 'require))
+              captured)
+          (cl-letf (((symbol-function 'require)
+                     (lambda (feature &optional filename noerror)
+                       (if (eq feature 'notifications)
+                           t
+                         (funcall real-require feature filename noerror))))
+                    ((symbol-function 'notifications-notify)
+                     (lambda (&rest params) (setq captured params) 1)))
+            (should (clatter-notify--dbus-send "title" "body" nil))
+            (should (equal (plist-get captured :sound-file)
+                           (expand-file-name sound)))))
+      (delete-file sound))))
+
+(ert-deftest clatter-notify-failure-is-silent-unless-enabled ()
+  "Native failures only reach the echo area when explicitly configured."
+  (let (messages)
+    (cl-letf (((symbol-function 'clatter-notify--send-native)
+               (lambda (&rest _) nil))
+              ((symbol-function 'message)
+               (lambda (format-string &rest args)
+                 (push (apply #'format format-string args) messages))))
+      (let ((clatter-notify-echo-area nil))
+        (should-not (clatter-notify--send "title" "body"))
+        (should-not messages))
+      (let ((clatter-notify-echo-area t))
+        (should (eq (clatter-notify--send "title" "body") 'echo))
+        (should (equal (car messages) "[CLatter] title: body"))))))
+
+(ert-deftest clatter-notify-test-reports-delivery-failure ()
+  "The explicit notification test reports failure despite silent fallback."
+  (let (reported)
+    (cl-letf (((symbol-function 'clatter-notify--send)
+               (lambda (&rest _) nil))
+              ((symbol-function 'message)
+               (lambda (format-string &rest args)
+                 (setq reported (apply #'format format-string args)))))
+      (clatter-notify-test)
+      (should (equal reported
+                     "[clatter-notify] Native notification delivery failed")))))
+
+(ert-deftest clatter-notify-routes-native-platforms ()
+  "Dispatcher selects Android, Haiku, Windows, and macOS backends."
+  (let ((real-featurep (symbol-function 'featurep))
+        platform)
+    (cl-letf (((symbol-function 'clatter-notify--android-send)
+               (lambda (&rest _) 'android))
+              ((symbol-function 'clatter-notify--haiku-send)
+               (lambda (&rest _) 'haiku))
+              ((symbol-function 'clatter-notify--w32-send)
+               (lambda (&rest _) 'windows))
+              ((symbol-function 'clatter-notify--mac-send)
+               (lambda (&rest _) 'mac))
+              ((symbol-function 'featurep)
+               (lambda (feature &optional subfeature)
+                 (if (memq feature '(android haiku))
+                     (eq feature platform)
+                   (funcall real-featurep feature subfeature)))))
+      (setq platform 'android)
+      (should (eq (clatter-notify--send-native "t" "b" nil) 'android))
+      (setq platform 'haiku)
+      (should (eq (clatter-notify--send-native "t" "b" nil) 'haiku))
+      (setq platform nil)
+      (let ((system-type 'windows-nt))
+        (should (eq (clatter-notify--send-native "t" "b" nil) 'windows)))
+      (let ((system-type 'darwin))
+        (should (eq (clatter-notify--send-native "t" "b" nil) 'mac))))))
+
+(ert-deftest clatter-notify-macos-uses-terminal-notifier-only ()
+  "The macOS backend retains terminal-notifier and native sound selection."
+  (let ((clatter-notify-sound t)
+        captured)
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (program) (and (equal program "terminal-notifier") program)))
+              ((symbol-function 'start-process)
+               (lambda (&rest args) (setq captured args) 'process)))
+      (should (eq (clatter-notify--mac-send "title" "body") 'process))
+      (should (equal (nth 2 captured) "terminal-notifier"))
+      (should (member "-sound" captured))
+      (should-not (member "notify-send" captured))
+      (should-not (member "paplay" captured)))))
+
+(ert-deftest clatter-notify-truncates-plain-text-safely ()
+  "Notification truncation counts plain text and handles tiny limits."
+  (let ((clatter-notify-max-length 8))
+    (should (equal (clatter-notify--truncate "abcdefghijk") "abcdefg…")))
+  (let ((clatter-notify-max-length 2))
+    (should (equal (clatter-notify--truncate "abcdef") "a…")))
+  (let ((clatter-notify-max-length 1))
+    (should (equal (clatter-notify--truncate "abcdef") "…")))
+  (let ((clatter-notify-max-length 0))
+    (should (equal (clatter-notify--truncate "abcdef") ""))))
+
+(ert-deftest clatter-notify-hook-formats-sender-in-title ()
+  "Message hooks put the sender in the title, not the body."
+  (let ((conn (clatter-test-make-connection "testnet" "trev"))
+        (clatter-notify-cooldown 0)
+        captured-title
+        captured-body
+        captured-buffer)
+    (unwind-protect
+        (let ((buffer (clatter-get-or-create-buffer "testnet" "#test")))
+          (cl-letf (((symbol-function 'clatter-notify--should-notify-p)
+                     (lambda (&rest _) 'mention))
+                    ((symbol-function 'clatter-notify--send)
+                     (lambda (title body &optional target-buffer)
+                       (setq captured-title title
+                             captured-body body)
+                       (setq captured-buffer target-buffer)
+                       t)))
+            (clatter-notify--on-privmsg
+             conn '("alice" nil nil) "#test" "trev: hello" nil)
+            (should (equal captured-title "Mention from alice in #test"))
+            (should (equal captured-body "trev: hello"))
+            (should-not (string-match-p "alice" captured-body))
+            (should (eq captured-buffer buffer))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-notify-action-and-invite-omit-sender-from-body ()
+  "Action and invite titles carry the sender without repeating it."
+  (let ((conn (clatter-test-make-connection "testnet" "trev"))
+        (clatter-notify-cooldown 0)
+        calls)
+    (cl-letf (((symbol-function 'clatter-notify--should-notify-p)
+               (lambda (&rest _) 'mention))
+              ((symbol-function 'clatter-notify--send)
+               (lambda (title body &optional _buffer)
+                 (push (cons title body) calls)
+                 t)))
+      (clatter-notify--on-action
+       conn '("alice" nil nil) "#test" "waves" nil)
+      (clatter-notify--on-invite
+       conn '("bob" nil nil) "trev" "#clatter")
+      (should (equal (nreverse calls)
+                     '(("Mention from alice in #test" . "* waves")
+                       ("Invite from bob" . "Invitation to join #clatter")))))))
+
+(provide 'test-notify)
+
+;;; test-notify.el ends here

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -906,7 +906,7 @@
           (with-current-buffer buf
             (setq-local clatter--last-read-time last-read))
           (cl-letf (((symbol-function 'clatter-notify--send)
-                     (lambda (title body)
+                     (lambda (title body &optional _buffer)
                        (push (list title body) sent))))
             (clatter-notify--on-privmsg
              conn '("alice" nil nil) "#test" "trev: already saw this" last-read)
@@ -931,7 +931,7 @@
           (with-current-buffer buf
             (setq-local clatter--last-read-time last-read))
           (cl-letf (((symbol-function 'clatter-notify--send)
-                     (lambda (title body)
+                     (lambda (title body &optional _buffer)
                        (push (list title body) sent))))
             (clatter-notify--on-privmsg
              conn '("alice" nil nil) "#test" "trev: new message" unread-time)


### PR DESCRIPTION
## Summary

Moves desktop notification delivery onto Emacs-native platform backends while retaining `terminal-notifier` on macOS. Notifications are sanitized, clickable where supported, persistent in notification-manager history, and silent when native delivery is unavailable unless echo fallback is explicitly enabled.

The sender is shown in the notification subject rather than repeated in the body:

```text
Subject: Mention from alice in #clatter
Body:    trev: hello

Subject: DM from alice
Body:    hello

Subject: Invite from bob
Body:    Invitation to join #clatter
```

## Configuration

Existing notification selection controls remain available:

```elisp
(setopt clatter-notify-on-mention t
        clatter-notify-on-dm t
        clatter-notify-on-invite t
        clatter-notify-on-keyword t
        clatter-notify-keywords '("release" "clatter")
        clatter-notify-muted-channels '("#bots")
        clatter-notify-muted-nicks '("ChanServ" "github-bot"))
```

Native presentation is configurable:

```elisp
(setopt clatter-notify-timeout 5000
        clatter-notify-urgency 'normal ; low, normal, or critical
        clatter-notify-icon "/path/to/clatter.png"
        clatter-notify-sound t         ; nil, t, or a sound-file path
        clatter-notify-max-length 80)
```

Native delivery failures no longer spam the echo area. The old fallback can be enabled explicitly:

```elisp
(setopt clatter-notify-echo-area t)
```

## Capabilities

- D-Bus notifications on POSIX systems through `notifications-notify`.
- Native Android, Haiku, and Windows notification APIs.
- `terminal-notifier` on macOS.
- Click actions open the relevant Clatter buffer where supported.
- IRC formatting and text properties are stripped; D-Bus markup is escaped.
- Notification bodies are truncated safely.
- Notifications are retained by notification managers rather than marked transient.
- Existing mention/DM/keyword, read-state, muting, rule, and cooldown decisions are preserved.

## Tests

- Covers backend routing, sanitization, sound mapping, click targets, persistence hints, truncation, failure handling, and sender/title formatting.
