### PR TITLE
Move point to prompt area when cycling the input ring + inhibit inserts in message area

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -720,7 +720,9 @@ messages."
 (defun clatter--set-input (input)
   "Replace the prompt input with INPUT."
   (clatter--clear-input)
-  (insert input))
+  (when clatter--input-marker
+    (goto-char clatter--input-marker)
+    (insert input)))
 
 (defun clatter--move-to-prompt ()
   "Move point to the input line before a self-inserting command.

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -258,8 +258,7 @@ append at the bottom like a traditional IRC client."
                   (overlay-put ov 'invisible invisible)))
               (add-text-properties start (point)
                                    (list 'read-only t
-                                         'front-sticky nil
-                                         'rear-nonsticky t
+                                         'front-sticky t
                                          'wrap-prefix wrap-prefix
                                          'line-prefix ""))
               (when msg-props


### PR DESCRIPTION
This ensures point is always moved to the input area when cycling the input ring with *M-p* / *M-n*.

Also fixes a regression introduced in 601976559b4205eb2ce64f0385e122caa27ed84c which allowed inserts into the message area, which was being masked by the move-to-prompt functionality.