### PR TITLE
Fix smart filter behavior when a nick is active

### DIFF
--- a/clatter-smart.el
+++ b/clatter-smart.el
@@ -101,8 +101,8 @@ Each value is a list (SIGNAL-COUNT NOISE-COUNT ACTIVE-P).")
   (let* ((ratio (clatter-smart-put buf nick elt))
          (key (downcase (if (stringp elt) elt nick)))
          (entry (gethash key (clatter-smart-on buf))))
-    (and (not (clatter-smart--entry-active-p entry))
-         (< ratio clatter-smart-threshold))))
+    (or (not (clatter-smart--entry-active-p entry))
+        (< ratio clatter-smart-threshold))))
 
 (provide 'clatter-smart)
 

--- a/tests/test-smart.el
+++ b/tests/test-smart.el
@@ -1,0 +1,68 @@
+;;; test-smart.el --- Tests for clatter-smart.el -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'test-helper)
+(require 'clatter-smart)
+
+(ert-deftest clatter-test-smart-noise-inactive-nick ()
+  "A nick with only noisy events is considered noisy."
+  (let ((clatter-smart-threshold 0.5)
+        (clatter-smart-noise '(join part)))
+    (with-temp-buffer
+      (should (clatter-smart-eval (current-buffer) "mynick" 'join))
+      (should (clatter-smart-eval (current-buffer) "mynick" 'part)))))
+
+(ert-deftest clatter-test-smart-noise-inactive-then-active-nick ()
+  "A nick with multiple noisy, then non-noisy, then noisy events transitions
+between states based on active-p, then SNR ratios."
+  (let ((clatter-smart-threshold 0.5)
+        (clatter-smart-noise '(join part away)))
+    (with-temp-buffer
+      ;; These are all considered noisy as they do not flip the active-p
+      ;; flag
+      (should (clatter-smart-eval (current-buffer) "mynick" 'join))
+      (should (clatter-smart-eval (current-buffer) "mynick" 'away))
+      (should (clatter-smart-eval (current-buffer) "mynick" 'away))
+      (should (clatter-smart-eval (current-buffer) "mynick" 'away))
+      (should (clatter-smart-eval (current-buffer) "mynick" 'away))
+      ;; Flip active-p by recording a 'privmsg
+      ;; Since active-p is now t, noisiness will be determined solely by SNR.
+      ;;
+      ;; SNR = 1/5  = 0.2  (PRIVMSG=1; NOISE=5)
+      (should (= 0.2 (clatter-smart-put (current-buffer) "mynick" 'privmsg)))
+      ;; SNR = 1/6 ~= 1.6  (PRIVMSG=1; NOISE=6)
+      (should (clatter-smart-eval (current-buffer) "mynick" 'part))
+      ;; SNR = 2/6 ~= 0.33 (PRIVMSG=2; NOISE=6)
+      (should (< 0.3 (clatter-smart-put (current-buffer) "mynick" 'privmsg)))
+      ;; SNR = 3/6  = 0.5  (PRIVMSG=3; NOISE=6)
+      (should (= 0.5 (clatter-smart-put (current-buffer) "mynick" 'privmsg)))
+      ;; SNR = 4/6 ~= 0.66 (PRIVMSG=4; NOISE=6)
+      (should (< 0.6 (clatter-smart-put (current-buffer) "mynick" 'privmsg)))
+      ;; At this point we're above the SNR threshold (0.5), so the following
+      ;; 'away shall not be considered noisy.
+      ;;
+      ;; SNR = 4/7 ~= 0.57 (PRIVMSG=4; NOISE=7)
+      (should-not (clatter-smart-eval (current-buffer) "mynick" 'away))
+      ;; After another 'away, we're exactly at the cutoff point.
+      ;;
+      ;; SNR = 4/8  = 0.5  (PRIVMSG=4; NOISE=8)
+      (should-not (clatter-smart-eval (current-buffer) "mynick" 'away))
+      ;; The next 'away should be deemed noisy, as it pushes us below
+      ;; the cutoff point.
+      ;;
+      ;; SNR = 4/9 ~= 0.44 (PRIVMSG=4; NOISE=9)
+      (should (clatter-smart-eval (current-buffer) "mynick" 'away)))))
+
+(ert-deftest clatter-test-smart-noise-preserves-state-across-nick-change ()
+  "Nick carries over its SNR and active-p values to the new nick."
+  (let ((clatter-smart-noise '(join part quit nick away))
+        (clatter-smart-threshold 0.5))
+    (with-temp-buffer
+      (should (= most-positive-fixnum (clatter-smart-put (current-buffer) "alice" 'privmsg)))
+      (should-not (clatter-smart-eval (current-buffer) "alice" "alice_"))
+      (should-not (clatter-smart-eval (current-buffer) "alice_" 'part))
+      (should (clatter-smart-eval (current-buffer) "alice_" 'part)))))
+
+(provide 'test-smart)
+;;; test-smart.el ends here

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -475,25 +475,6 @@
                                 (ensure-list (get-text-property (match-beginning 0) 'invisible)))))))
       (clatter-test-cleanup))))
 
-(ert-deftest clatter-test-smart-noise-keeps-repeated-noise-from-active-nick ()
-  "Once a nick has signal, later noise stays visible regardless of volume."
-  (let ((clatter-smart-noise '(join part quit nick away))
-        (clatter-smart-threshold 0.5))
-    (with-temp-buffer
-      (clatter-smart-put (current-buffer) "alice" 'privmsg)
-      (dotimes (_ 8)
-        (should-not (clatter-smart-eval (current-buffer) "alice" 'away))))))
-
-(ert-deftest clatter-test-smart-noise-preserves-active-state-across-nick-change ()
-  "Nick changes carry active state to the new nick."
-  (let ((clatter-smart-noise '(join part quit nick away))
-        (clatter-smart-threshold 0.5))
-    (with-temp-buffer
-      (clatter-smart-put (current-buffer) "alice" 'privmsg)
-      (should-not (clatter-smart-eval (current-buffer) "alice" "alice_"))
-      (dotimes (_ 8)
-        (should-not (clatter-smart-eval (current-buffer) "alice_" 'part))))))
-
 (ert-deftest clatter-test-fool-message-gets-dim-face ()
   "Messages with the fool invisibility category get `clatter-fool'."
   (with-temp-buffer


### PR DESCRIPTION
This fixes the smart filter if a nick becomes active (i.e. sends a PRIVMSG, flipping active-p to t), then becomes noisy afterwards.

Also adds a test to verify the behavior.