### PR TITLE
Replace raw tags with structured tags, remove open-coded message tags, and escape tags properly

### DIFF
--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -119,7 +119,7 @@ INPUT is the full string including the leading /."
     (when conn
       (when (and clatter--target (not (string= clatter--target "*server*")))
         (let ((ctcp-msg (format "\C-aACTION %s\C-a" args)))
-          (clatter-ui--send-privmsg conn clatter--target args 'action (current-buffer) ctcp-msg))))))
+          (clatter-ui--send-privmsg conn clatter--target (cons args ctcp-msg) 'action (current-buffer)))))))
 
 (defun clatter-cmd-nick (args)
   "Change nick to the NEWNICK given in ARGS."
@@ -668,6 +668,7 @@ Uses +draft/reply tag to thread the response."
          (msgid (and mouse-secondary-overlay
                      (eq (current-buffer) (overlay-buffer mouse-secondary-overlay))
                      (get-text-property (overlay-start mouse-secondary-overlay) 'clatter-msgid)))
+         (tags `(("+draft/reply" . ,msgid)))
          (target clatter--target)
          (conn (clatter--current-conn)))
     (cond
@@ -678,12 +679,9 @@ Uses +draft/reply tag to thread the response."
      ((null conn)
       (message "Not connected"))
      (t
-      (clatter-ui--send-privmsg conn target text 'privmsg (current-buffer)
-                                 (format "@+draft/reply=%s PRIVMSG %s :%s"
-                                         msgid target text))
+      (clatter-ui--send-privmsg conn target text 'privmsg (current-buffer) tags)
       ; Clear secondary selection
-      (save-mark-and-excursion (secondary-selection-to-region))
-      ))))
+      (save-mark-and-excursion (secondary-selection-to-region))))))
 
 (clatter-defcommand "reply" #'clatter-cmd-reply "r")
 
@@ -695,6 +693,8 @@ Uses +draft/react tag via TAGMSG."
          (msgid (and mouse-secondary-overlay
                      (eq (current-buffer) (overlay-buffer mouse-secondary-overlay))
                      (get-text-property (overlay-start mouse-secondary-overlay) 'clatter-msgid)))
+         (tags `(("+draft/react" . ,emoji)
+                 ("+draft/reply" . ,msgid)))
          (target clatter--target)
          (conn (clatter--current-conn)))
     (cond
@@ -705,8 +705,7 @@ Uses +draft/react tag via TAGMSG."
      ((null conn)
       (message "Not connected"))
      (t
-      (clatter-send conn (format "@+draft/react=%s;+draft/reply=%s TAGMSG %s"
-                                 emoji msgid target))
+      (clatter-send conn (clatter-irc-tagmsg target tags))
       ; Clear secondary selection
       (save-mark-and-excursion (secondary-selection-to-region))))))
 

--- a/clatter-protocol.el
+++ b/clatter-protocol.el
@@ -253,6 +253,38 @@ command, and parameters including trailing."
 
 ;; --- IRCv3 Tag Parsing ---
 
+(defun clatter-unescape-tag (tag)
+  "Unescape an IRCv3 tag."
+  (cl-loop with semicolon = ";"
+           with space = " "
+           with backslash = "\\"
+           with linefeed = "\r"
+           with newline = "\n"
+           with skip = ""
+           for chr across tag with escape-p
+           if escape-p
+           concat (progn
+                    (setq escape-p nil)
+                    (cond
+                     ((eq ?\: chr) semicolon)
+                     ((eq ?s chr) space)
+                     ((eq ?\\ chr) backslash)
+                     ((eq ?r chr) linefeed)
+                     ((eq ?n chr) newline)
+                     (t (char-to-string chr))))
+           else concat (if (setq escape-p (eq ?\\ chr))
+                           skip
+                         (char-to-string chr))))
+
+(defun clatter-escape-tag (tag)
+  "Escape an IRCv3 tag."
+  (setq tag (string-replace "\\" "\\\\" tag))
+  (setq tag (string-replace ";" "\\:" tag))
+  (setq tag (string-replace " " "\\s" tag))
+  (setq tag (string-replace "\r" "\\r" tag))
+  (setq tag (string-replace "\n" "\\n" tag))
+  tag)
+
 (defun clatter-parse-tags (tags-string)
   "Parse IRCv3 TAGS-STRING into an alist of (key . value) pairs.
 Tags format: key1=value1;key2=value2;key3"
@@ -261,9 +293,19 @@ Tags format: key1=value1;key2=value2;key3"
               (let ((eq-pos (cl-position ?= tag)))
                 (if eq-pos
                     (cons (substring tag 0 eq-pos)
-                          (substring tag (1+ eq-pos)))
+                          (clatter-unescape-tag
+                           (substring tag (1+ eq-pos))))
                   (cons tag nil))))
             (split-string tags-string ";"))))
+
+(defun clatter-encode-tags (tags-alist)
+  "Encode TAGS-ALIST into an IRCv3 message tag string."
+  (cl-loop for (tag . value) in tags-alist
+           collect (if (seq-empty-p value)
+                       (format "%s" tag)
+                     (format "%s=%s" tag (clatter-escape-tag value)))
+           into elts
+           finally return (string-join elts ";")))
 
 (defun clatter-get-parsed-tag (tags-alist key)
   "Get the value of KEY from TAGS-ALIST"
@@ -337,13 +379,21 @@ The last param is treated as trailing if it contains spaces."
       (clatter-format-line "PART" channel message)
     (clatter-format-line "PART" channel)))
 
-(defun clatter-irc-privmsg (target text)
-  "Format PRIVMSG to TARGET with TEXT."
-  (clatter-format-line "PRIVMSG" target text))
+(defun clatter-irc-privmsg (target text &optional tags-alist)
+  "Format PRIVMSG tagged with TAGS-ALIST to TARGET with TEXT."
+  (let* ((tags-prefix (clatter-encode-tags tags-alist))
+         (command (if (seq-empty-p tags-prefix)
+                      "PRIVMSG"
+                    (format "@%s PRIVMSG" tags-prefix))))
+    (clatter-format-line command target text)))
 
-(defun clatter-irc-notice (target text)
-  "Format NOTICE to TARGET with TEXT."
-  (clatter-format-line "NOTICE" target text))
+(defun clatter-irc-notice (target text &optional tags-alist)
+  "Format NOTICE tagged with TAGS-ALIST to TARGET with TEXT."
+  (let* ((tags-prefix (clatter-encode-tags tags-alist))
+         (command (if (seq-empty-p tags-prefix)
+                      "NOTICE"
+                    (format "@%s NOTICE" tags-prefix))))
+    (clatter-format-line command target text)))
 
 (defun clatter-irc-quit (&optional message)
   "Format QUIT command with optional MESSAGE."
@@ -443,22 +493,16 @@ The last param is treated as trailing if it contains spaces."
 
 ;; --- TAGMSG / Typing ---
 
-(defun clatter-irc-tagmsg (target &rest tags)
-  "Format a TAGMSG to TARGET with TAGS (plist of name/value pairs)."
-  (let ((tag-parts nil))
-    (cl-loop for (name value) on tags by #'cddr
-             do (push (if value
-                         (format "%s=%s" name value)
-                       name)
-                      tag-parts))
-    (format "@%s TAGMSG %s"
-            (string-join (nreverse tag-parts) ";")
-            target)))
+(defun clatter-irc-tagmsg (target tags-alist)
+  "Format a TAGMSG to TARGET with TAGS-ALIST."
+  (if tags-alist
+      (format "@%s TAGMSG %s" (clatter-encode-tags tags-alist) target)
+    (error "TAGMSG to %S has empty TAGS-ALIST" tags-alist)))
 
 (defun clatter-irc-typing (target state)
   "Format typing indicator to TARGET.
 STATE should be \"active\", \"paused\", or \"done\"."
-  (clatter-irc-tagmsg target "+typing" state))
+  (clatter-irc-tagmsg target `(("+typing" . ,state))))
 
 ;; --- Message Length / Splitting ---
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -649,16 +649,26 @@ reconciliation.  BUFFER defaults to the current buffer."
                 (remove-text-properties start end '(clatter-self-echo-nonce nil))))))
         (setq clatter--pending-self-echoes nil)))))
 
-(defun clatter-ui--send-privmsg (conn target text &optional msg-type buffer line)
+(defun clatter-ui--send-privmsg (conn target text &optional msg-type buffer tags)
   "Send TEXT to TARGET and render it according to `clatter-self-echo-mode'.
-MSG-TYPE is `privmsg' or `action'; BUFFER receives the local echo.  LINE, when
-non-nil, is the already formatted IRC command to send."
+MSG-TYPE is `privmsg' or `action'; BUFFER receives the local echo.  TAGS, when
+non-nil, are the message tags to be affixed to the message.
+If TEXT is a pair of strings its CAR will be considered the display text, while
+(CDR TEXT) will be considered the raw text to be sent as-is."
   (let* ((msg-type (or msg-type 'privmsg))
          (buffer (or buffer (current-buffer)))
          (sender (clatter-connection-nick conn)))
-    (if (eq 'action msg-type)
-        (clatter-send conn (clatter-irc-privmsg target line))
-      (clatter-send conn (or line (clatter-irc-privmsg target text))))
+    (clatter-send
+     conn
+     (clatter-irc-privmsg
+      target
+      ;; If TEXT is a pair, this is a CTCP message of the form
+      ;; (TEXT . CTCP-TEXT), where TEXT is the displayed text
+      ;; and CTCP-TEXT is the actual CTCP message to be sent.
+      (if (consp text)
+          (prog1 (cdr text) (setq text (car text)))
+        text)
+      tags))
     (when (clatter-ui--self-echo-p conn)
       (let* ((nonce (cl-incf clatter--self-echo-nonce))
              (tentative (propertize (copy-sequence text) 'clatter-self-echo-nonce nonce)))

--- a/tests/test-protocol.el
+++ b/tests/test-protocol.el
@@ -95,6 +95,39 @@
   (should (equal (clatter-get-tag "time=2026-01-01T00:00:00Z;msgid=abc" "msgid")
                  "abc")))
 
+(ert-deftest clatter-test-unescape-tag ()
+  (should (equal "normal" (clatter-unescape-tag "normal")))
+  (should (equal "abc" (clatter-unescape-tag "a\\bc")))
+  (should (equal "abc" (clatter-unescape-tag "\\abc")))
+  (should (equal "hello;world" (clatter-unescape-tag "hello\\:world")))
+  (should (equal "hello;world;123" (clatter-unescape-tag "hello\\:world\\:123")))
+  (should (equal "hello world" (clatter-unescape-tag "hello\\sworld")))
+  (should (equal "hello world abc" (clatter-unescape-tag "hello\\sworld\\sabc")))
+  (should (equal "\\hello\\world" (clatter-unescape-tag "\\\\hello\\\\world")))
+  (should (equal "hello\nworld" (clatter-unescape-tag "hello\\nworld")))
+  (should (equal "trailingbackslash" (clatter-unescape-tag "trailingbackslash\\")))
+  (should (equal "first line\nsecond line\rsemi;colon\\backslash"
+                 (clatter-unescape-tag
+                  "first\\sline\\nsecond\\sline\\rsemi\\:colon\\\\backslash\\"))))
+
+(ert-deftest clatter-test-escape-tag ()
+  (should (equal "hello\\:world" (clatter-escape-tag "hello;world")))
+  (should (equal "hello\\:world\\:123" (clatter-escape-tag "hello;world;123")))
+  (should (equal "hello\\sworld" (clatter-escape-tag "hello world")))
+  (should (equal "hello\\sworld\\sabc" (clatter-escape-tag "hello world abc")))
+  (should (equal "\\\\hello\\\\world" (clatter-escape-tag "\\hello\\world")))
+  (should (equal "hello\\nworld" (clatter-escape-tag "hello\nworld")))
+  (should (equal "first\\sline\\nsecond\\sline\\rsemi\\:colon\\\\backslash"
+                 (clatter-escape-tag
+                  "first line\nsecond line\rsemi;colon\\backslash"))))
+
+(ert-deftest clatter-test-encode-tags ()
+  (should (equal "" (clatter-encode-tags nil)))
+  (should (equal "+abc" (clatter-encode-tags '(("+abc")))))
+  (should (equal "+abc=1" (clatter-encode-tags '(("+abc" . "1")))))
+  (should (equal "+abc=semi\\:colon" (clatter-encode-tags '(("+abc" . "semi;colon")))))
+  (should (equal "+abc;def=x123" (clatter-encode-tags '(("+abc") ("def" . "x123"))))))
+
 ;; --- Channel Name Validation ---
 
 (ert-deftest clatter-test-channel-name-p ()


### PR DESCRIPTION
This replaces instances of open-coded (stringly-typed) raw message tags/message with structured (alist) message tag specifications.

Message values are now also escaped as per https://ircv3.net/specs/extensions/message-tags#escaping-values
