### PR TITLE
Update nick from 001 RPL_WELCOME response

### DIFF
--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -259,6 +259,12 @@ Return the trimmed character."
 
       ;; --- Registration complete ---
       ("001"
+       ;; Update nick from server response: the bouncer may assign us a
+       ;; different nick than what we configured (e.g. our upstream nick).
+       ;; Without this, DM routing breaks because clatter compares the
+       ;; PRIVMSG target against the configured nick, not the actual one.
+       (when (and params (stringp (nth 0 params)) (not (string-empty-p (nth 0 params))))
+         (setf (clatter-connection-nick conn) (nth 0 params)))
        (clatter--watchdog "REGISTERED %s nick=%s"
                           (clatter-connection-network-id conn)
                           (clatter-connection-nick conn))


### PR DESCRIPTION
When connecting through a bouncer, the configured nick may differ from the upstream nick. The 001 RPL_WELCOME reply contains the nick the server actually registered us as. Standard IRC clients update their nick from this response.

Without this fix, DM routing breaks because clatter compares the PRIVMSG target against the configured nick instead of the actual nick assigned by the server/bouncer. All DMs end up in a single buffer named after the upstream nick instead of per-sender buffers.

Reproduction: Configure clatter with nick "glenn" for a bouncer connection where the upstream nick is "glenneth". All incoming DMs route to a single "glenneth" buffer instead of individual per-sender buffers.