### PR TITLE
Extend message splitting to CTCP ACTION (/me) + take tags into account when splitting

### DIFF
--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -118,8 +118,7 @@ INPUT is the full string including the leading /."
   (let ((conn (clatter--require-conn)))
     (when conn
       (when (and clatter--target (not (string= clatter--target "*server*")))
-        (let ((ctcp-msg (format "\C-aACTION %s\C-a" args)))
-          (clatter-ui--send-privmsg conn clatter--target (cons args ctcp-msg) 'action (current-buffer)))))))
+        (clatter-ui--send-privmsg conn clatter--target args 'action (current-buffer))))))
 
 (defun clatter-cmd-nick (args)
   "Change nick to the NEWNICK given in ARGS."

--- a/clatter-protocol.el
+++ b/clatter-protocol.el
@@ -260,7 +260,6 @@ command, and parameters including trailing."
            with backslash = "\\"
            with linefeed = "\r"
            with newline = "\n"
-           with skip = ""
            for chr across tag with escape-p
            if escape-p
            concat (progn
@@ -272,8 +271,7 @@ command, and parameters including trailing."
                      ((eq ?r chr) linefeed)
                      ((eq ?n chr) newline)
                      (t (char-to-string chr))))
-           else concat (if (setq escape-p (eq ?\\ chr))
-                           skip
+           else concat (unless (setq escape-p (eq ?\\ chr))
                          (char-to-string chr))))
 
 (defun clatter-escape-tag (tag)
@@ -314,6 +312,21 @@ Tags format: key1=value1;key2=value2;key3"
 (defun clatter-get-tag (tags-string key)
   "Get the value of KEY from TAGS-STRING."
   (clatter-get-parsed-tag (clatter-parse-tags tags-string) key))
+
+(defun clatter-format-tagged-command (command &optional tags-alist)
+  "Format a tagged COMMAND with TAGS-ALIST."
+  (let ((tags-prefix (clatter-encode-tags tags-alist)))
+    (if (seq-empty-p tags-prefix)
+        command
+      (format "@%s %s" tags-prefix command))))
+
+(defun clatter-irc-format-tagged-privmsg (&optional tags-alist)
+  "Format PRIVMSG tagged with TAGS-ALIST."
+   (clatter-format-tagged-command "PRIVMSG" tags-alist))
+
+(defun clatter-irc-format-tagged-notice (&optional tags-alist)
+  "Format NOTICE tagged with TAGS-ALIST."
+   (clatter-format-tagged-command "NOTICE" tags-alist))
 
 (defun clatter-get-parsed-server-time (tags-alist)
   "Extract server-time from IRCv3 TAGS-ALIST.
@@ -381,19 +394,15 @@ The last param is treated as trailing if it contains spaces."
 
 (defun clatter-irc-privmsg (target text &optional tags-alist)
   "Format PRIVMSG tagged with TAGS-ALIST to TARGET with TEXT."
-  (let* ((tags-prefix (clatter-encode-tags tags-alist))
-         (command (if (seq-empty-p tags-prefix)
-                      "PRIVMSG"
-                    (format "@%s PRIVMSG" tags-prefix))))
-    (clatter-format-line command target text)))
+  (clatter-format-line
+   (clatter-irc-format-tagged-privmsg tags-alist)
+   target text))
 
 (defun clatter-irc-notice (target text &optional tags-alist)
   "Format NOTICE tagged with TAGS-ALIST to TARGET with TEXT."
-  (let* ((tags-prefix (clatter-encode-tags tags-alist))
-         (command (if (seq-empty-p tags-prefix)
-                      "NOTICE"
-                    (format "@%s NOTICE" tags-prefix))))
-    (clatter-format-line command target text)))
+  (clatter-format-line
+   (clatter-irc-format-tagged-notice tags-alist)
+   target text))
 
 (defun clatter-irc-quit (&optional message)
   "Format QUIT command with optional MESSAGE."
@@ -477,19 +486,23 @@ The last param is treated as trailing if it contains spaces."
 
 ;; --- CTCP ---
 
+(defun clatter-irc-ctcp-format (command &optional text)
+  "Format a CTCP message for COMMAND with optional TEXT."
+  (if text
+      (format "\C-a%s %s\C-a" command text)
+    (format "\C-a%s\C-a" command)))
+
+(defun clatter-irc-ctcp-action-format (&optional text)
+  "Format a CTCP ACTION message containing TEXT."
+  (clatter-irc-ctcp-format "ACTION" (or text "")))
+
 (defun clatter-irc-ctcp-reply (target command &optional text)
   "Format a CTCP reply (via NOTICE) to TARGET for COMMAND with optional TEXT."
-  (let ((ctcp-text (if text
-                       (format "\C-a%s %s\C-a" command text)
-                     (format "\C-a%s\C-a" command))))
-    (clatter-irc-notice target ctcp-text)))
+    (clatter-irc-notice target (clatter-irc-ctcp-format command text)))
 
 (defun clatter-irc-ctcp-request (target command &optional text)
   "Format a CTCP request (via PRIVMSG) to TARGET for COMMAND with optional TEXT."
-  (let ((ctcp-text (if text
-                       (format "\C-a%s %s\C-a" command text)
-                     (format "\C-a%s\C-a" command))))
-    (clatter-irc-privmsg target ctcp-text)))
+    (clatter-irc-privmsg target (clatter-irc-ctcp-format command text)))
 
 ;; --- TAGMSG / Typing ---
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -731,27 +731,20 @@ reconciliation.  BUFFER defaults to the current buffer."
                 (remove-text-properties start end '(clatter-self-echo-nonce nil))))))
         (setq clatter--pending-self-echoes nil)))))
 
-(defun clatter-ui--send-privmsg (conn target text &optional msg-type buffer tags)
+(defun clatter-ui--send-privmsg-1 (conn target text &optional msg-type buffer tags)
   "Send TEXT to TARGET and render it according to `clatter-self-echo-mode'.
 MSG-TYPE is `privmsg' or `action'; BUFFER receives the local echo.  TAGS, when
-non-nil, are the message tags to be affixed to the message.
-If TEXT is a pair of strings its CAR will be considered the display text, while
-(CDR TEXT) will be considered the raw text to be sent as-is."
+non-nil, are the message tags to be affixed to the message."
   (let* ((msg-type (or msg-type 'privmsg))
          (buffer (or buffer (current-buffer)))
          (sender (clatter-connection-nick conn))
          (echo-message-p (member "echo-message" (clatter-connection-cap-enabled conn))))
-    (clatter-send
-     conn
-     (clatter-irc-privmsg
-      target
-      ;; If TEXT is a pair, this is a CTCP message of the form
-      ;; (TEXT . CTCP-TEXT), where TEXT is the displayed text
-      ;; and CTCP-TEXT is the actual CTCP message to be sent.
-      (if (consp text)
-          (prog1 (cdr text) (setq text (car text)))
-        text)
-      tags))
+    (clatter-send conn (clatter-irc-privmsg
+                        target
+                        (if (eq 'action msg-type)
+                            (clatter-irc-ctcp-action-format text)
+                          text)
+                        tags))
     (cond
      ;; If the server has echo-message and clatter-self-echo-mode is
      ;; 'optimistic, we can tentatively echo the message locally in the
@@ -777,6 +770,20 @@ If TEXT is a pair of strings its CAR will be considered the display text, while
                                (list sender "*" "*")       ;; * = Placeholder
                                target text
                                nil)))))))
+
+(defun clatter-ui--send-privmsg (conn target text &optional msg-type buffer tags)
+  "Split and send TEXT to TARGET, rendering sent parts according to
+`clatter-self-echo-mode'. MSG-TYPE is `privmsg' or `action';  BUFFER
+receives the local echo.  TAGS, when non-nil, are the message tags to be
+affixed to the message."
+  (let* ((command+overhead (concat (clatter-irc-format-tagged-privmsg tags)
+                                   ;; Include CTCP ^AACTION ...^A overhead
+                                   (when (eq msg-type 'action)
+                                     (clatter-irc-ctcp-action-format))))
+         (parts (clatter-split-long-message target text command+overhead)))
+    (mapc (lambda (part)
+            (clatter-ui--send-privmsg-1 conn target part msg-type buffer tags))
+          parts)))
 
 (defun clatter-ui--reconcile-self-echo (buffer sender target text msg-type server-time)
   "Reconcile a server echo with its tentative local message in BUFFER.
@@ -1466,9 +1473,7 @@ If the input contains multiple lines and exceeds
          (target clatter--target)
          (conn (clatter-get-connection network)))
     (when (and conn target (not (string= target "*server*")))
-      (let ((parts (clatter-split-long-message target text)))
-        (dolist (part parts)
-          (clatter-ui--send-privmsg conn target part 'privmsg (current-buffer)))))))
+      (clatter-ui--send-privmsg conn target text 'privmsg (current-buffer)))))
 
 (defun clatter--handle-command (input)
   "Parse and execute INPUT as a /command."


### PR DESCRIPTION
Allow overlong CTCP ACTIONs to be split across multiple lines (i.e into multiple CTCP ACTION messages). Overlong /me actions were rejected silently prior to this change.

Additionally, take any tag and CTCP overhead into account along with the command itself when splitting.