### PR TITLE
Ensure M-p inserts the latest (newest) input history item

### DIFF
--- a/clatter-model.el
+++ b/clatter-model.el
@@ -244,7 +244,7 @@ TYPE is server, channel, or query (auto-detected if nil)."
 (defun clatter-input-ring-add (input)
   "Add INPUT to the input history ring."
   (ring-insert clatter-input-ring input)
-  (setq clatter-input-ring-index 0))
+  (setq clatter-input-ring-index -1))
 
 (defun clatter-input-ring-nth (n)
   "Get element N steps back in the input history ring.


### PR DESCRIPTION
After adding a new item to the input ring, the index should refer to the bottom of the ring, so that *M-p* (`clatter-set-prev-input`) would insert the newest item.

Currently, *M-n* inserts the newest item, while *M-p* inserts the last. This changeset makes the history ring behave more like eshell/shell history rings.