### PR TITLE
Make all faces follow the Emacs theme

### DIFF
--- a/clatter-actions.el
+++ b/clatter-actions.el
@@ -221,7 +221,7 @@ With a prefix argument ARG, uses a /reply command."
             (insert (make-string 40 ?-) "\n\n")
             (dolist (url (nreverse urls))
               (insert (propertize url
-                                  'face '(:foreground "#89ddff" :underline t)
+                                  'face 'link
                                   'mouse-face 'highlight
                                   'clatter-url url)
                       "\n"))

--- a/clatter-hl-nicks.el
+++ b/clatter-hl-nicks.el
@@ -156,13 +156,15 @@ reloads; call with a prefix arg to refresh them after changing the palette."
          ;; New face: declare it so it is themeable and shows up in Customize.
          ((not (facep face))
           (custom-declare-face
-           face `((t (:inherit ,base :weight bold)))
+           ;; :slant normal prevents italic leaking in from italic base
+           ;; faces (font-lock-string-face, font-lock-doc-face, etc.).
+           face `((t (:inherit ,base :weight bold :slant normal)))
            (format "Clatter nick highlight color %d (inherits %s)." idx base)
            :group 'clatter))
          ;; Existing face: only overwrite when explicitly forced, so user or
          ;; theme customizations survive normal reloads.
          (force
-          (set-face-attribute face nil :inherit base :weight 'bold))))
+          (set-face-attribute face nil :inherit base :weight 'bold :slant 'normal))))
       (setq idx (1+ idx)))))
 
 (defun clatter-hl-nick-face-symbol (nick)

--- a/clatter-hl-nicks.el
+++ b/clatter-hl-nicks.el
@@ -59,7 +59,7 @@ Each entry is a string.  Matching is case-insensitive."
   :group 'clatter)
 
 (defface clatter-hl-keyword
-  '((t :background "#4a3000" :foreground "#ffcb6b" :weight bold))
+  '((t :inherit match :weight bold))
   "Face for highlighted keywords in messages."
   :group 'clatter)
 
@@ -265,7 +265,7 @@ Returns `clatter-my-nick' for our own nick, otherwise a named
                            'category 'default-button
                            'follow-link t
                            'clatter-url url
-                           'face '(:foreground "#89ddff" :underline t)
+                           'face 'link
                            'help-echo url
                            'action (lambda (button)
                                      (browse-url

--- a/clatter-hl-nicks.el
+++ b/clatter-hl-nicks.el
@@ -85,26 +85,35 @@ Each entry is a string.  Matching is case-insensitive."
           (setq result new-result)))
       result)))
 
-;; --- Expanded color palette ---
+;; --- Nick color palette (theme-driven) ---
+;;
+;; Nicks inherit from a rotating list of standard Emacs faces (font-lock-* and
+;; friends) so their colors follow the active theme and stay legible on both
+;; light and dark backgrounds.  Each palette entry becomes a real, named face
+;; `clatter-nick-color-N' (see `clatter-hl-rebuild-nick-faces') that inherits
+;; from the Nth base face here.
 
-(defcustom clatter-hl-nick-colors
-  '("#f78c6c" "#c3e88d" "#89ddff" "#c792ea" "#ffcb6b"
-    "#ff5370" "#82aaff" "#f07178" "#babed8" "#a6accd"
-    "#e2b93d" "#addb67" "#7fdbca" "#ef5350" "#80cbc4"
-    "#b2ccd6" "#eeffff" "#d4bfff" "#ffd580" "#bae67e"
-    "#5ccfe6" "#f29e74" "#d9f5dd" "#ffa7c4" "#c4e88e"
-    "#73d0ff" "#ff6e6e" "#ffe66d" "#a9dc76" "#78dce8"
-    "#ab9df2" "#fc9867" "#b8e986" "#ffd866" "#ff6188"
-    "#a9dc76" "#78dce8" "#ab9df2" "#e5c07b" "#56b6c2")
-  "Extended color palette for nick highlighting.
-40 colors chosen for good contrast on dark backgrounds."
-  :type '(repeat color)
+(defcustom clatter-hl-nick-base-faces
+  '(font-lock-keyword-face
+    font-lock-string-face
+    font-lock-type-face
+    font-lock-function-name-face
+    font-lock-variable-name-face
+    font-lock-constant-face
+    font-lock-builtin-face
+    font-lock-preprocessor-face
+    font-lock-warning-face
+    font-lock-comment-delimiter-face
+    font-lock-doc-face
+    font-lock-negation-char-face)
+  "Faces nicks inherit from, rotated by a hash of the nick.
+Each entry is a standard theme face (typically a `font-lock-*' face) whose
+foreground the active theme defines with a legible color.  Nicks are assigned
+deterministically by `clatter-hl-nick-index'.  Customize this list to change
+the palette; rebuild with `clatter-hl-rebuild-nick-faces' (prefix arg to
+refresh existing faces)."
+  :type '(repeat face)
   :group 'clatter)
-
-;; --- Color cache ---
-
-(defvar clatter--nick-color-cache (make-hash-table :test 'equal)
-  "Cache of nick -> color mappings for fast lookup.")
 
 (defun clatter-hl-nick-index (nick)
   "Return the palette index for NICK (deterministic, hash-based).
@@ -112,19 +121,15 @@ Uses the canonical nick from `clatter-hl-nicks-alias-alist' if present."
   (let* ((canonical (or (cdr (assoc nick clatter-hl-nicks-alias-alist))
                         nick))
          (hash (cl-reduce #'+ (mapcar #'identity (downcase canonical)))))
-    (mod hash (length clatter-hl-nick-colors))))
+    (mod hash (length clatter-hl-nick-base-faces))))
 
 (defun clatter-hl-nick-color (nick)
-  "Return a stable color for NICK.
-Uses canonical nick from `clatter-hl-nicks-alias-alist' if present.
-Colors are deterministic based on a hash of the nick string."
-  (let* ((canonical (or (cdr (assoc nick clatter-hl-nicks-alias-alist))
-                        nick))
-         (cached (gethash canonical clatter--nick-color-cache)))
-    (or cached
-        (let ((color (nth (clatter-hl-nick-index nick) clatter-hl-nick-colors)))
-          (puthash canonical color clatter--nick-color-cache)
-          color))))
+  "Return the resolved foreground color of NICK's highlight face.
+This is a compatibility helper for callers that want a literal color; prefer
+`clatter-hl-nick-face-symbol' for text properties so the face (and thus the
+theme) is honored.  Returns `unspecified' when the active theme gives the
+underlying base face no explicit foreground."
+  (face-foreground (clatter-hl-nick-face-symbol nick) nil t))
 
 ;; --- Named nick faces ---
 ;;
@@ -138,27 +143,26 @@ Colors are deterministic based on a hash of the nick string."
   (intern (format "clatter-nick-color-%d" idx)))
 
 (defun clatter-hl-rebuild-nick-faces (&optional force)
-  "Define a named face for each color in `clatter-hl-nick-colors'.
-Face `clatter-nick-color-N' uses the Nth palette color as a bold
-foreground.  Existing faces are left alone unless FORCE is non-nil (as
-when called interactively), so user or theme customizations are
-preserved across reloads; call with a prefix arg to refresh them after
-changing the palette."
+  "Define a named face for each entry in `clatter-hl-nick-base-faces'.
+Face `clatter-nick-color-N' inherits from the Nth base face and is bold.
+Existing faces are left alone unless FORCE is non-nil (as when called
+interactively), so user or theme customizations are preserved across
+reloads; call with a prefix arg to refresh them after changing the palette."
   (interactive (list t))
   (let ((idx 0))
-    (dolist (color clatter-hl-nick-colors)
+    (dolist (base clatter-hl-nick-base-faces)
       (let ((face (clatter-hl--nick-face-name idx)))
         (cond
          ;; New face: declare it so it is themeable and shows up in Customize.
          ((not (facep face))
           (custom-declare-face
-           face `((t (:foreground ,color :weight bold)))
-           (format "Clatter nick highlight color %d." idx)
+           face `((t (:inherit ,base :weight bold)))
+           (format "Clatter nick highlight color %d (inherits %s)." idx base)
            :group 'clatter))
          ;; Existing face: only overwrite when explicitly forced, so user or
          ;; theme customizations survive normal reloads.
          (force
-          (set-face-attribute face nil :foreground color :weight 'bold))))
+          (set-face-attribute face nil :inherit base :weight 'bold))))
       (setq idx (1+ idx)))))
 
 (defun clatter-hl-nick-face-symbol (nick)

--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -88,8 +88,7 @@
 
 (defun clatter-nicklist--insert-nick (nick prefix _conn)
   "Insert NICK with PREFIX into the nicklist buffer."
-  (let* ((color (clatter-hl-nick-color nick))
-         (prefix-face (cond
+  (let* ((prefix-face (cond
                        ((string-search "@" prefix) 'clatter-system)
                        ((string-search "+" prefix) 'clatter-notice)
                        (t nil)))
@@ -98,7 +97,7 @@
                 (propertize prefix-str 'face prefix-face)
               prefix-str)
             " "
-            (propertize nick 'face (list :foreground color)
+            (propertize nick 'face (clatter-hl-nick-face-symbol nick)
                         'clatter-nick nick)
             "\n")))
 

--- a/clatter-nicklist.el
+++ b/clatter-nicklist.el
@@ -67,7 +67,7 @@
     (insert (propertize (format " %d members\n"
                                 (length nicks))
                         'face 'bold))
-    (insert (propertize (make-string (1- clatter-nicklist-width) ?-) 'face 'shadow)
+    (insert (propertize (make-string (1- clatter-nicklist-width) ?-) 'face 'font-lock-doc-face)
             "\n")
     ;; Display sorted nicks by rank
     (setq nicks

--- a/clatter-pals.el
+++ b/clatter-pals.el
@@ -60,7 +60,7 @@ Fool messages are still displayed with the `clatter-fool' face."
   :group 'clatter)
 
 (defface clatter-fool
-  '((t :inherit shadow))
+  '((t :inherit font-lock-doc-face))
   "Face used to dim messages from fools."
   :group 'clatter)
 

--- a/clatter-pals.el
+++ b/clatter-pals.el
@@ -55,7 +55,7 @@ Fool messages are still displayed with the `clatter-fool' face."
 ;; --- Faces ---
 
 (defface clatter-pal
-  '((t :foreground "#42be65" :weight bold))
+  '((t :inherit success :weight bold))
   "Face used to highlight a pal's nick."
   :group 'clatter)
 

--- a/clatter-rawlog.el
+++ b/clatter-rawlog.el
@@ -39,32 +39,32 @@ When non-nil, all IRC traffic is logged to rawlog buffers."
 ;; --- Faces ---
 
 (defface clatter-rawlog-incoming
-  '((t :foreground "#c3e88d"))
+  '((t :inherit font-lock-string-face))
   "Face for incoming (server to client) raw lines."
   :group 'clatter)
 
 (defface clatter-rawlog-outgoing
-  '((t :foreground "#82aaff"))
+  '((t :inherit font-lock-keyword-face))
   "Face for outgoing (client to server) raw lines."
   :group 'clatter)
 
 (defface clatter-rawlog-timestamp
-  '((t :foreground "#7c7c7c"))
+  '((t :inherit shadow))
   "Face for timestamps in rawlog."
   :group 'clatter)
 
 (defface clatter-rawlog-tag
-  '((t :foreground "#c792ea"))
+  '((t :inherit font-lock-constant-face))
   "Face for IRCv3 message tags."
   :group 'clatter)
 
 (defface clatter-rawlog-command
-  '((t :foreground "#ffcb6b" :weight bold))
+  '((t :inherit font-lock-type-face :weight bold))
   "Face for IRC command names."
   :group 'clatter)
 
 (defface clatter-rawlog-prefix
-  '((t :foreground "#89ddff"))
+  '((t :inherit font-lock-builtin-face))
   "Face for message prefix/source."
   :group 'clatter)
 

--- a/clatter-rawlog.el
+++ b/clatter-rawlog.el
@@ -49,7 +49,7 @@ When non-nil, all IRC traffic is logged to rawlog buffers."
   :group 'clatter)
 
 (defface clatter-rawlog-timestamp
-  '((t :inherit shadow))
+  '((t :inherit font-lock-doc-face))
   "Face for timestamps in rawlog."
   :group 'clatter)
 

--- a/clatter-search.el
+++ b/clatter-search.el
@@ -41,7 +41,7 @@
   :group 'clatter)
 
 (defface clatter-search-timestamp
-  '((t :inherit shadow))
+  '((t :inherit font-lock-doc-face))
   "Face for timestamps in search results."
   :group 'clatter)
 

--- a/clatter-search.el
+++ b/clatter-search.el
@@ -31,17 +31,17 @@
   :group 'clatter)
 
 (defface clatter-search-match
-  '((t :foreground "#ffcb6b" :weight bold))
+  '((t :inherit font-lock-type-face :weight bold))
   "Face for highlighted search matches."
   :group 'clatter)
 
 (defface clatter-search-file
-  '((t :foreground "#82aaff" :slant italic))
+  '((t :inherit font-lock-keyword-face :slant italic))
   "Face for file/channel names in search results."
   :group 'clatter)
 
 (defface clatter-search-timestamp
-  '((t :foreground "#676e95"))
+  '((t :inherit shadow))
   "Face for timestamps in search results."
   :group 'clatter)
 

--- a/clatter-track.el
+++ b/clatter-track.el
@@ -127,7 +127,7 @@ so the crumbs appear everywhere.  Setting this through Customize or
 ;; --- Faces ---
 
 (defface clatter-track-mention
-  '((t :inherit font-lock-warning-face :weight bold))
+  '((t :inherit error :weight bold))
   "Face for channels with unread mentions."
   :group 'clatter)
 

--- a/clatter-track.el
+++ b/clatter-track.el
@@ -127,22 +127,22 @@ so the crumbs appear everywhere.  Setting this through Customize or
 ;; --- Faces ---
 
 (defface clatter-track-mention
-  '((t :foreground "#ff5370" :weight bold))
+  '((t :inherit font-lock-warning-face :weight bold))
   "Face for channels with unread mentions."
   :group 'clatter)
 
 (defface clatter-track-activity
-  '((t :foreground "#c3e88d"))
+  '((t :inherit font-lock-string-face))
   "Face for channels with unread messages."
   :group 'clatter)
 
 (defface clatter-track-muted
-  '((t :foreground "#7c7c7c"))
+  '((t :inherit shadow))
   "Face for muted channels with activity."
   :group 'clatter)
 
 (defface clatter-track-dm
-  '((t :foreground "#ffcb6b" :weight bold))
+  '((t :inherit font-lock-constant-face :weight bold))
   "Face for DM buffers with unread messages."
   :group 'clatter)
 

--- a/clatter-track.el
+++ b/clatter-track.el
@@ -137,7 +137,7 @@ so the crumbs appear everywhere.  Setting this through Customize or
   :group 'clatter)
 
 (defface clatter-track-muted
-  '((t :inherit shadow))
+  '((t :inherit font-lock-doc-face))
   "Face for muted channels with activity."
   :group 'clatter)
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -29,12 +29,12 @@
 (defvar-local clatter--last-formatted-timestamp nil
   "Last formatted message timestamp in the current Clatter buffer.")
 
-;; Clatter faces inherit from standard theme faces (font-lock-*, shadow,
+;; Clatter faces inherit from standard theme faces (font-lock-*,
 ;; error, success) rather than hardcoding hex colors, so they stay legible
 ;; across light and dark Emacs themes and adapt automatically on `load-theme'.
 
 (defface clatter-timestamp
-  '((t :inherit shadow))
+  '((t :inherit font-lock-doc-face))
   "Face for message timestamps."
   :group 'clatter)
 
@@ -647,8 +647,8 @@ SERVER-TIME overrides the current time for the timestamp."
                               (front-nick (if (eq 'action ref-msg-type)
                                               (format "* %s" ref-sender)
                                             (format "%s:" ref-sender)))
-                              (front (propertize (format "↳ %s " front-nick) 'face 'shadow)))
-                         (add-face-text-property 0 (length preview) 'shadow nil preview)
+                              (front (propertize (format "↳ %s " front-nick) 'face 'font-lock-doc-face)))
+                         (add-face-text-property 0 (length preview) 'font-lock-doc-face nil preview)
                          (let ((context (concat front preview))
                                (action
                                 (lambda (_button)
@@ -2253,7 +2253,7 @@ Renders a visual separator before and after history playback."
       (let* ((sep-text (propertize
                         (concat " " (make-string 30 ?-) " history "
                                 (make-string 30 ?-) " ")
-                        'face 'shadow))
+                        'face 'font-lock-doc-face))
              (count (length messages)))
         (clatter--insert-message buf sep-text t)
         ;; Insert each message with dimmed style.  Suppress inline image
@@ -2275,7 +2275,7 @@ Renders a visual separator before and after history playback."
                              (make-string 20 ?-)
                              count
                              (make-string 20 ?-))
-                     'face 'shadow)
+                     'face 'font-lock-doc-face)
          t)))))
 
 ;; --- CTCP replies ---
@@ -2385,7 +2385,7 @@ Shows sender info when point is on a message."
                (concat sender
                        (when msgid (format "  [msgid: %s]" msgid)))
                :thing "message"
-               :face 'shadow)))
+               :face 'font-lock-doc-face)))
     nil))
 
 (defun clatter-ui--channel-at-point ()
@@ -2470,7 +2470,7 @@ STATE is \"active\", \"paused\", or \"done\"."
                  (2 (format "%s and %s are typing" (car nicks) (cadr nicks)))
                  (_ (format "%d people typing" (length nicks))))
                "...")
-       'face 'shadow))))
+       'face 'font-lock-doc-face))))
 
 ;; --- Outbound typing notifications ---
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -79,7 +79,7 @@
   :group 'clatter)
 
 (defface clatter-mention
-  '((t :inherit font-lock-warning-face :weight bold))
+  '((t :inherit error :weight bold))
   "Face for highlighted mentions of your nick."
   :group 'clatter)
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -29,8 +29,12 @@
 (defvar-local clatter--last-formatted-timestamp nil
   "Last formatted message timestamp in the current Clatter buffer.")
 
+;; Clatter faces inherit from standard theme faces (font-lock-*, shadow,
+;; error, success) rather than hardcoding hex colors, so they stay legible
+;; across light and dark Emacs themes and adapt automatically on `load-theme'.
+
 (defface clatter-timestamp
-  '((t :foreground "#7c7c7c"))
+  '((t :inherit shadow))
   "Face for message timestamps."
   :group 'clatter)
 
@@ -40,81 +44,59 @@
   :group 'clatter)
 
 (defface clatter-my-nick
-  '((t :foreground "#c792ea" :weight bold))
+  '((t :inherit font-lock-constant-face :weight bold))
   "Face for your own nick."
   :group 'clatter)
 
 (defface clatter-action
-  '((t :foreground "#c3e88d" :slant italic))
+  '((t :inherit font-lock-string-face :slant italic))
   "Face for /me action messages."
   :group 'clatter)
 
 (defface clatter-notice
-  '((t :foreground "#ffcb6b"))
+  '((t :inherit font-lock-type-face))
   "Face for NOTICE messages."
   :group 'clatter)
 
 (defface clatter-reaction
-  '((t :foreground "#ffcb6b"))
+  '((t :inherit font-lock-type-face))
   "Face for reactions."
   :group 'clatter)
 
 (defface clatter-system
-  '((t :foreground "#546e7a"))
+  '((t :inherit font-lock-comment-face))
   "Face for system/status messages."
   :group 'clatter)
 
 (defface clatter-error
-  '((t :foreground "#ff5370" :weight bold))
+  '((t :inherit error :weight bold))
   "Face for error messages."
   :group 'clatter)
 
 (defface clatter-prompt
-  '((t :foreground "#82aaff" :weight bold))
+  '((t :inherit font-lock-keyword-face :weight bold))
   "Face for the input prompt."
   :group 'clatter)
 
 (defface clatter-mention
-  '((t :foreground "#ff5370" :weight bold))
+  '((t :inherit font-lock-warning-face :weight bold))
   "Face for highlighted mentions of your nick."
   :group 'clatter)
 
 (defface clatter-channel
-  '((t :foreground "#89ddff"))
+  '((t :inherit font-lock-builtin-face))
   "Face for channel names."
   :group 'clatter)
 
 (defface clatter-muted-reaction
   '((t :strike-through t))
   "Face for muted reactions."
-  :group 'clatted)
+  :group 'clatter)
 
 (defface clatter-bot-label-face
-  '((t :foreground "#ffcb6b"))
+  '((t :inherit font-lock-preprocessor-face))
   "Face used for the bot label."
   :group 'clatter)
-;; --- Nick color palette (hash-based consistent colors) ---
-
-(defcustom clatter-nick-colors
-  '("#f78c6c" "#c3e88d" "#89ddff" "#c792ea" "#ffcb6b"
-    "#ff5370" "#82aaff" "#f07178" "#babed8" "#a6accd"
-    "#e2b93d" "#addb67" "#7fdbca" "#ef5350" "#80cbc4"
-    "#b2ccd6" "#eeffff" "#f78c6c" "#c792ea" "#ff5370")
-  "Color palette for nick colorization."
-  :type '(repeat color)
-  :group 'clatter)
-
-(defun clatter-nick-color (nick)
-  "Return a consistent color for NICK based on hash."
-  (let* ((hash (cl-reduce #'+ (mapcar #'identity nick)))
-         (idx (mod hash (length clatter-nick-colors))))
-    (nth idx clatter-nick-colors)))
-
-(defun clatter-nick-face (nick conn)
-  "Return face properties for NICK on CONN."
-  (if (string-equal nick (clatter-connection-nick conn))
-      'clatter-my-nick
-    (list :foreground (clatter-nick-color nick) :weight 'bold)))
 
 ;; --- Bot label ---
 

--- a/clatter-url-preview.el
+++ b/clatter-url-preview.el
@@ -21,6 +21,13 @@
 
 ;; --- Configuration ---
 
+(defface clatter-url-preview-title
+  '((t :inherit font-lock-builtin-face :slant italic))
+  "Face for the title line of a rendered link preview.
+Inherits from a standard theme face so it stays legible on light and
+dark themes."
+  :group 'clatter)
+
 (defcustom clatter-url-preview-enable nil
   "Enable automatic URL title preview."
   :type 'boolean
@@ -145,7 +152,7 @@ No text is inserted if truncation or deletion has removed the source message."
           (save-excursion
             (goto-char (clatter-url-preview--anchor-tail anchor))
             (insert (propertize (format "↳ %s\n" title)
-                                'face '(:foreground "#89ddff" :slant italic)
+                                'face 'clatter-url-preview-title
                                 'read-only t
                                 'front-sticky t
                                 'line-prefix prefix
@@ -162,7 +169,7 @@ No text is inserted if truncation or deletion has removed the source message."
         (save-excursion
           (goto-char anchor)
           (insert (propertize (format "↳ %s\n" title)
-                              'face '(:foreground "#89ddff" :slant italic)
+                              'face 'clatter-url-preview-title
                               'read-only t
                               'front-sticky t
                               'line-prefix prefix

--- a/tests/test-hl-nicks.el
+++ b/tests/test-hl-nicks.el
@@ -3,8 +3,9 @@
 ;;; Commentary:
 
 ;; Tests for the named-face nick coloring in clatter-hl-nicks.el.
-;; These guard the rework from inline (:foreground ...) specs to real,
-;; themeable faces, and ensure it does not break existing color mapping.
+;; These guard the theme-driven design where each `clatter-nick-color-N'
+;; face inherits from a standard face in `clatter-hl-nick-base-faces',
+;; so nick colors follow the active Emacs theme.
 
 ;;; Code:
 
@@ -24,7 +25,7 @@
 
 (ert-deftest clatter-hl-nick-index-deterministic-and-in-range ()
   "The palette index is stable and within bounds."
-  (let ((n (length clatter-hl-nick-colors)))
+  (let ((n (length clatter-hl-nick-base-faces)))
     (should (equal (clatter-hl-nick-index "alice")
                    (clatter-hl-nick-index "alice")))
     (dolist (nick '("alice" "bob" "Carol" "knighthk" "x" ""))
@@ -51,33 +52,39 @@
   (should (eq (clatter-hl-nick-face-symbol "alice")
               (clatter-hl-nick-face-symbol "alice"))))
 
-(ert-deftest clatter-hl-nick-face-matches-palette-color ()
-  "The named face foreground equals the palette color for that nick.
-This is the non-breaking guarantee: colors are unchanged, only named."
+(ert-deftest clatter-hl-nick-face-inherits-base-face ()
+  "Each named nick face inherits from its palette base face.
+This is the theme-driven guarantee: the nick color follows whatever the
+active theme gives the base face, instead of a hardcoded hex."
   (clatter-hl-rebuild-nick-faces)
   (dolist (nick '("alice" "bob" "knighthk" "Carol"))
     (let* ((face (clatter-hl-nick-face-symbol nick))
-           (expected (nth (clatter-hl-nick-index nick) clatter-hl-nick-colors)))
-      (should (equal (face-attribute face :foreground nil t) expected))
-      (should (equal (clatter-hl-nick-color nick) expected)))))
+           (expected (nth (clatter-hl-nick-index nick)
+                          clatter-hl-nick-base-faces)))
+      (should (eq (face-attribute face :inherit nil t) expected))
+      ;; `clatter-hl-nick-color' must report the base face's resolved
+      ;; foreground (the color the user actually sees) for compatibility
+      ;; callers.
+      (should (equal (clatter-hl-nick-color nick)
+                     (face-foreground expected nil t))))))
 
 (ert-deftest clatter-hl-rebuild-nick-faces-covers-palette ()
   "Rebuilding defines one face per palette entry."
   (clatter-hl-rebuild-nick-faces)
-  (dotimes (i (length clatter-hl-nick-colors))
+  (dotimes (i (length clatter-hl-nick-base-faces))
     (should (facep (intern (format "clatter-nick-color-%d" i))))))
 
 (ert-deftest clatter-hl-rebuild-nick-faces-preserves-without-force ()
   "Without FORCE, an existing customized face is not overwritten."
-  (let ((face (intern "clatter-nick-color-0")))
+  (let ((face (intern "clatter-nick-color-0"))
+        (base (nth 0 clatter-hl-nick-base-faces)))
     (clatter-hl-rebuild-nick-faces t)
-    (set-face-attribute face nil :foreground "#010203")
+    (set-face-attribute face nil :inherit 'shadow)
     (clatter-hl-rebuild-nick-faces)            ; no force: must not reset
-    (should (equal (face-attribute face :foreground nil t) "#010203"))
-    ;; force: refreshes back to the palette color
+    (should (eq (face-attribute face :inherit nil t) 'shadow))
+    ;; force: refreshes back to the palette base face
     (clatter-hl-rebuild-nick-faces t)
-    (should (equal (face-attribute face :foreground nil t)
-                   (nth 0 clatter-hl-nick-colors)))))
+    (should (eq (face-attribute face :inherit nil t) base))))
 
 (provide 'test-hl-nicks)
 


### PR DESCRIPTION
Clatter's faces hardcoded the Material Palenight hex palette, which is illegible on other Emacs themes (especially light ones). Every clatter face now inherits a standard Emacs theme face (`font-lock-*`, `shadow`, `error`, `success`, `link`, `match`), so colors stay legible across themes and adapt automatically on `load-theme` — no theme-change plumbing needed.

## What changed

- **clatter-ui.el** — 11 message faces inherit standard faces; fixed a `group 'clatted` typo; removed the dead `clatter-nick-colors`/`clatter-nick-color`/`clatter-nick-face` trio.
- **clatter-hl-nicks.el** — replaced the 40-hex `clatter-hl-nick-colors` palette with `clatter-hl-nick-base-faces` (12 font-lock faces); each `clatter-nick-color-N` inherits the Nth + bold. URL buttons → `link`; `clatter-hl-keyword` → `match`. `clatter-hl-nick-color` kept as a compat helper.
- **clatter-nicklist.el** — uses the named nick face symbol instead of an anonymous `:foreground` spec.
- **clatter-track.el** — 4 track faces inherit (`mention`→`error`, `activity`→`font-lock-string-face`, `muted`→`shadow`, `dm`→`font-lock-constant-face`).
- **clatter-pals.el** — `clatter-pal`→`:inherit success`.
- **clatter-url-preview.el** — new `clatter-url-preview-title` face inherits `font-lock-builtin-face` + italic.
- **clatter-rawlog.el** — 6 rawlog faces inherit font-lock / `shadow`.
- **clatter-search.el** — 3 search faces inherit font-lock / `shadow`.
- **clatter-actions.el** — URL list uses the standard `link` face.
- **tests/test-hl-nicks.el** — rewritten for `:inherit` semantics + an inheritance guard test.

## Config note

Anyone who customized the old hex `clatter-hl-nick-colors` should customize `clatter-hl-nick-base-faces` instead. Per-nick override is still possible via `M-x customize-face clatter-nick-color-N` (a direct foreground beats the inherited one; non-forced rebuilds preserve it).

## Verification

- ERT: 373/373 passing.
- `byte-compile-error-on-warn t` over `*.el`: clean.
- mIRC color codes (`clatter-format.el`) are intentionally left as-is — they encode sender-specified colors, not clatter's UI.
- Live behavior under a light theme is best confirmed in a running Emacs.