### PR TITLE
Add op/server-query slash commands and fix /raw reply routing

### DIFF
--- a/GUIDE.org
+++ b/GUIDE.org
@@ -340,10 +340,44 @@ several reactions at the same message. Clatter clears it automatically after a
 | =/topic [new topic]=  | View or set channel topic              |
 | =/kick nick [reason]= | Kick a user from channel               |
 | =/mode [modes]=       | View or set channel/user modes         |
+| =/op nick [nick...]=    | Grant channel op (=+o=)              |
+| =/deop nick [nick...]=  | Remove channel op (=-o=)             |
+| =/voice nick [nick...]= | Grant voice (=+v=)                   |
+| =/devoice nick [nick...]= | Remove voice (=-v=)                |
+| =/hop nick [nick...]=   | Grant halfop (=+h=)                  |
+| =/dehop nick [nick...]= | Remove halfop (=-h=)                 |
+| =/quiet nick [nick...]= | Quiet a user (=+q=, semantics vary by server) |
+| =/unquiet nick [nick...]= | Unquiet a user (=-q=)              |
+| =/ban nick|mask [more...]= | Ban a user (=+b=); bare nicks become =nick!*@*= |
+| =/unban nick|mask [more...]= | Remove a ban (=-b=)             |
 | =/invite nick=        | Invite user to current channel         |
 | =/names=              | List channel members (alias: =/members=) |
 | =/nick newnick=       | Change your nickname                   |
 | =/away [message]=     | Set or clear away status               |
+
+Each mode helper applies its flag to every nick given and groups them into a
+single =MODE= line (e.g. =/op a b c= sends =MODE #chan +ooo a b c=).  They must
+be run from the channel buffer; use =/mode= or =/raw= for other targets.  Quiet
+semantics differ by daemon (ircd-seven/InspIRCd use =+q nick=; others use
+=+b %nick!*@*= or a services command), so =/quiet= uses the common =+q= form.
+
+** Server Queries
+
+| Command           | Description                                         |
+|-------------------+----------------------------------------------------|
+| =/who [target]=     | List users on a channel or matching a mask       |
+| =/whowas [nick]=   | Look up a nick no longer online (defaults to own) |
+| =/ison nick...=     | Check which nicks are online                       |
+| =/links [mask]=     | List server links                                  |
+| =/stats query [target]= | Server statistics (query letter, e.g. =u=)   |
+| =/admin [target]=   | Server admin info                                  |
+| =/info [target]=    | Server info                                         |
+| =/version [target]= | Server version                                       |
+| =/lusers [mask [target]]= | User/server counts                            |
+| =/motd [target]=    | Message of the day                                  |
+| =/rules [target]=   | Server rules (not universally supported)           |
+
+Replies appear in the network's =*server*= buffer.
 
 ** Services and Nick Recovery
 

--- a/clatter-commands.el
+++ b/clatter-commands.el
@@ -64,6 +64,13 @@ INPUT is the full string including the leading /."
         (clatter-insert-error (current-buffer) "Not connected")
         nil)))
 
+(defun clatter--remember-query-origin (conn)
+  "Record the current buffer as the originator of a query command on CONN.
+Reply numerics for /who, /stats, /motd, /whois, etc. are then routed here
+instead of the server buffer.  See `clatter-ui--on-numeric'."
+  (when conn
+    (setf (clatter-connection-last-query-buffer conn) (current-buffer))))
+
 ;; --- Commands ---
 
 (defun clatter-cmd-say (args)
@@ -177,13 +184,102 @@ INPUT is the full string including the leading /."
                 (setq mode-args rest)))
             (clatter-send conn (apply #'clatter-irc-mode target mode-args))))
          (other-target
-          ;; If we're in a channel buffer, assume TARGET is the channel.
-          (clatter-send conn (apply #'clatter-irc-mode target (string-split args " " t)))))))))
+          ;; In a channel buffer TARGET defaults to that channel, but an
+          ;; explicit channel may still lead the arguments (/mode #chan +b).
+          ;; Without this check the channel is sent twice ("MODE #c #c +b")
+          ;; and the server reads the second one as the mode string.
+          (let* ((parts (string-split args " " t))
+                 (head (car parts))
+                 ;; "+b"/"-o" are mode strings, not channels, even though
+                 ;; `clatter-channel-name-p' accepts a leading + as a valid
+                 ;; channel prefix.
+                 (explicit-channel (and head
+                                        (not (memq (aref head 0) '(?+ ?-)))
+                                        (clatter-channel-name-p head))))
+            (if explicit-channel
+                (clatter-send conn (apply #'clatter-irc-mode head (cdr parts)))
+              (clatter-send conn (apply #'clatter-irc-mode target parts))))))))))
+
+;; --- Channel-admin mode helpers (/op /deop /voice ...) ---
+
+(defun clatter--cmd-mode-flag (args flag label)
+  "Apply MODE FLAG (e.g. \"+o\") to nicks parsed from ARGS in this channel.
+LABEL is the command name used in usage messages."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (let ((channel clatter--target)
+            (nicks (split-string args " " t)))
+        (cond
+         ((or (null channel) (string= channel "*server*"))
+          (clatter-insert-error
+           (current-buffer)
+           (format "Usage: /%s nick... (use in a channel buffer)" label)))
+         ((null nicks)
+          (clatter-insert-error
+           (current-buffer)
+           (format "Usage: /%s nick [nick...]" label)))
+         (t
+          (clatter-send conn (clatter-irc-mode-set channel flag nicks))))))))
+
+(defun clatter--cmd-mode-mask (args flag label)
+  "Apply MODE FLAG (e.g. \"+b\") to masks parsed from ARGS in this channel.
+Bare nicks are wildcarded to nick!*@*.  LABEL is used in usage messages."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (let ((channel clatter--target)
+            (masks (mapcar (lambda (m)
+                             (if (string-match-p "[!*@]" m)
+                                 m
+                               (concat m "!*@*")))
+                           (split-string args " " t))))
+        (cond
+         ((or (null channel) (string= channel "*server*"))
+          (clatter-insert-error
+           (current-buffer)
+           (format "Usage: /%s mask... (use in a channel buffer)" label)))
+         ((null masks)
+          (clatter-insert-error
+           (current-buffer)
+           (format "Usage: /%s nick|mask [more...]" label)))
+         (t
+          (clatter-send conn (clatter-irc-mode-set channel flag masks))))))))
+
+(defun clatter-cmd-op (args)
+  "Give channel op to nicks in ARGS (\"+o\")."
+  (clatter--cmd-mode-flag args "+o" "op"))
+(defun clatter-cmd-deop (args)
+  "Remove channel op from nicks in ARGS (\"-o\")."
+  (clatter--cmd-mode-flag args "-o" "deop"))
+(defun clatter-cmd-voice (args)
+  "Give voice to nicks in ARGS (\"+v\")."
+  (clatter--cmd-mode-flag args "+v" "voice"))
+(defun clatter-cmd-devoice (args)
+  "Remove voice from nicks in ARGS (\"-v\")."
+  (clatter--cmd-mode-flag args "-v" "devoice"))
+(defun clatter-cmd-hop (args)
+  "Give halfop to nicks in ARGS (\"+h\")."
+  (clatter--cmd-mode-flag args "+h" "hop"))
+(defun clatter-cmd-dehop (args)
+  "Remove halfop from nicks in ARGS (\"-h\")."
+  (clatter--cmd-mode-flag args "-h" "dehop"))
+(defun clatter-cmd-quiet (args)
+  "Quiet nicks in ARGS (\"+q\").  Quiet semantics vary by server."
+  (clatter--cmd-mode-flag args "+q" "quiet"))
+(defun clatter-cmd-unquiet (args)
+  "Unquiet nicks in ARGS (\"-q\").  Quiet semantics vary by server."
+  (clatter--cmd-mode-flag args "-q" "unquiet"))
+(defun clatter-cmd-ban (args)
+  "Ban masks/nicks in ARGS (\"+b\").  Bare nicks become nick!*@*."
+  (clatter--cmd-mode-mask args "+b" "ban"))
+(defun clatter-cmd-unban (args)
+  "Remove bans for masks/nicks in ARGS (\"-b\")."
+  (clatter--cmd-mode-mask args "-b" "unban"))
 
 (defun clatter-cmd-whois (args)
   "Request WHOIS for the NICK in ARGS."
   (let ((conn (clatter--require-conn)))
     (when conn
+      (clatter--remember-query-origin conn)
       (let ((nick (car (split-string args))))
         (if (and nick (> (length nick) 0))
             (clatter-send conn (clatter-irc-whois nick))
@@ -205,12 +301,117 @@ INPUT is the full string including the leading /."
   (let ((network clatter--network))
     (clatter-disconnect network (if (string-empty-p args) nil args))))
 
+;; --- Server query commands ---
+
+(defun clatter-cmd-who (args)
+  "Request WHO for optional TARGET in ARGS."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (clatter-send conn (clatter-irc-who args)))))
+
+(defun clatter-cmd-whowas (args)
+  "Request WHOWAS for NICK in ARGS; defaults to our own nick."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (let ((nick (or (car (split-string args " " t))
+                      (clatter-connection-nick conn))))
+        (if (and nick (> (length nick) 0))
+            (clatter-send conn (clatter-irc-whowas nick))
+          (clatter-insert-error (current-buffer) "Usage: /whowas [nick]"))))))
+
+(defun clatter-cmd-ison (args)
+  "Request ISON for the nicks in ARGS."
+  (let ((conn (clatter--require-conn))
+        (nicks (split-string args " " t)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (if nicks
+          (clatter-send conn (clatter-irc-ison nicks))
+        (clatter-insert-error (current-buffer)
+                              "Usage: /ison nick [nick...]")))))
+
+(defun clatter-cmd-links (args)
+  "Request LINKS for optional MASK in ARGS."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (clatter-send conn (clatter-irc-links
+                          (unless (string-empty-p args) args))))))
+
+(defun clatter-cmd-stats (args)
+  "Request STATS QUERY for optional TARGET, both from ARGS."
+  (let ((conn (clatter--require-conn))
+        (parts (split-string args " " t)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (cond
+       ((null parts)
+        (clatter-insert-error (current-buffer) "Usage: /stats query [target]"))
+       (t
+        (clatter-send conn (clatter-irc-stats (car parts) (cadr parts))))))))
+
+(defun clatter-cmd-admin (args)
+  "Request ADMIN for optional TARGET server in ARGS."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (clatter-send conn (clatter-irc-admin
+                          (unless (string-empty-p args) args))))))
+
+(defun clatter-cmd-info (args)
+  "Request INFO for optional TARGET server in ARGS."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (clatter-send conn (clatter-irc-info
+                          (unless (string-empty-p args) args))))))
+
+(defun clatter-cmd-version (args)
+  "Request VERSION for optional TARGET server in ARGS."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (clatter-send conn (clatter-irc-version
+                          (unless (string-empty-p args) args))))))
+
+(defun clatter-cmd-lusers (args)
+  "Request LUSERS for optional MASK and TARGET from ARGS."
+  (let ((conn (clatter--require-conn))
+        (parts (split-string args " " t)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (clatter-send conn (clatter-irc-lusers (car parts) (cadr parts))))))
+
+(defun clatter-cmd-motd (args)
+  "Request MOTD for optional TARGET server in ARGS."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (clatter-send conn (clatter-irc-motd
+                          (unless (string-empty-p args) args))))))
+
+(defun clatter-cmd-rules (args)
+  "Request RULES for optional TARGET server in ARGS."
+  (let ((conn (clatter--require-conn)))
+    (when conn
+      (clatter--remember-query-origin conn)
+      (clatter-send conn (clatter-irc-rules
+                          (unless (string-empty-p args) args))))))
+
 (defun clatter-cmd-raw (args)
   "Send ARGS to the server as a raw IRC line."
   (let ((conn (clatter--require-conn)))
     (when conn
       (if (> (length args) 0)
-          (clatter-send conn args)
+          (progn
+           (clatter-send conn args)
+           ;; Echo the sent line locally.  /raw bypasses the formatter
+           ;; self-echo path, so without this a successful send is
+           ;; invisible in the chat buffer.  current-buffer here is the
+           ;; originating buffer (unlike the receive-time filter).
+           (clatter-insert-system (current-buffer) (concat ">> " args)))
         (clatter-insert-error (current-buffer) "Usage: /raw IRC-COMMAND")))))
 
 (defun clatter-cmd-query (args)
@@ -424,7 +625,28 @@ With `none', clear all suppressions."
 (clatter-defcommand "topic" #'clatter-cmd-topic)
 (clatter-defcommand "kick" #'clatter-cmd-kick)
 (clatter-defcommand "mode" #'clatter-cmd-mode)
+(clatter-defcommand "op" #'clatter-cmd-op)
+(clatter-defcommand "deop" #'clatter-cmd-deop)
+(clatter-defcommand "voice" #'clatter-cmd-voice)
+(clatter-defcommand "devoice" #'clatter-cmd-devoice)
+(clatter-defcommand "hop" #'clatter-cmd-hop)
+(clatter-defcommand "dehop" #'clatter-cmd-dehop)
+(clatter-defcommand "quiet" #'clatter-cmd-quiet)
+(clatter-defcommand "unquiet" #'clatter-cmd-unquiet)
+(clatter-defcommand "ban" #'clatter-cmd-ban)
+(clatter-defcommand "unban" #'clatter-cmd-unban)
 (clatter-defcommand "whois" #'clatter-cmd-whois)
+(clatter-defcommand "who" #'clatter-cmd-who)
+(clatter-defcommand "whowas" #'clatter-cmd-whowas)
+(clatter-defcommand "ison" #'clatter-cmd-ison)
+(clatter-defcommand "links" #'clatter-cmd-links)
+(clatter-defcommand "stats" #'clatter-cmd-stats)
+(clatter-defcommand "admin" #'clatter-cmd-admin)
+(clatter-defcommand "info" #'clatter-cmd-info)
+(clatter-defcommand "version" #'clatter-cmd-version)
+(clatter-defcommand "lusers" #'clatter-cmd-lusers)
+(clatter-defcommand "motd" #'clatter-cmd-motd)
+(clatter-defcommand "rules" #'clatter-cmd-rules)
 (clatter-defcommand "away" #'clatter-cmd-away)
 (clatter-defcommand "quit" #'clatter-cmd-quit "q")
 (clatter-defcommand "raw" #'clatter-cmd-raw)
@@ -703,6 +925,10 @@ Uses +draft/react tag via TAGMSG."
       (message "No message to react to (select a message using the secondary selection i.e. M-<mouse-1>)"))
      ((null conn)
       (message "Not connected"))
+     ((not (member "message-tags" (clatter-connection-cap-enabled conn)))
+      (message "Server does not support the message-tags capability; reactions unavailable"))
+     ((clatter-connection-tagmsg-rejected conn)
+      (message "Server rejected TAGMSG; reactions unavailable on this network"))
      (t
       (clatter-send conn (clatter-irc-tagmsg target tags))
       ; Clear secondary selection

--- a/clatter-connection.el
+++ b/clatter-connection.el
@@ -35,6 +35,9 @@
   cap-enabled          ; list of enabled capability strings
   cap-available        ; list of capabilities advertised by the server
   cap-string           ; capability string sent by the server
+  tagmsg-rejected      ; t once the server returned 421 for TAGMSG (stop sending)
+  last-query-buffer    ; buffer that issued the most recent query command, for reply routing
+  pending-whox         ; list of channels with an in-flight internal WHOX (replies are not displayed)
   ;; IRCv3 batch/label tracking
   active-batches       ; hash-table: batch-id -> plist
   deferred-batches     ; completed batches held until CAP negotiation ends
@@ -443,6 +446,9 @@ ARGS are keyword arguments that override `clatter-networks' config:
       (setf (clatter-connection-cap-negotiating conn) nil)
       (setf (clatter-connection-cap-enabled conn) nil)
       (setf (clatter-connection-cap-string conn) nil)
+      (setf (clatter-connection-tagmsg-rejected conn) nil)
+      (setf (clatter-connection-last-query-buffer conn) nil)
+      (setf (clatter-connection-pending-whox conn) nil)
       (setf (clatter-connection-sasl-state conn) nil)
       (setf (clatter-connection-ping-sent-time conn) nil)
       (setf (clatter-connection-away-p conn) nil)

--- a/clatter-model.el
+++ b/clatter-model.el
@@ -325,7 +325,13 @@ Return nil when the ring is empty or N is out of range."
 
 (defun clatter-send-whox (conn channel)
   "Send WHOX query for CHANNEL on CONN if WHOX is supported.
-Uses format: WHO #channel %tcnuhraf,TOKEN to get account names."
+Uses format: WHO #channel %tcnuhraf,TOKEN to get account names.
+This is an internal, automatic query (sent on every RPL_ENDOFNAMES), so
+CHANNEL is recorded in `clatter-connection-pending-whox' and its replies
+are consumed silently rather than printed to a buffer."
+  (cl-pushnew (downcase channel)
+              (clatter-connection-pending-whox conn)
+              :test #'equal)
   (clatter-send conn (format "WHO %s %%tcnuhraf,%s"
                               channel clatter-whox-token)))
 

--- a/clatter-protocol.el
+++ b/clatter-protocol.el
@@ -444,6 +444,20 @@ The last param is treated as trailing if it contains spaces."
       (apply #'clatter-format-line "MODE" target mode args)
     (clatter-format-line "MODE" target)))
 
+(defun clatter-irc-mode-set (channel flag nicks)
+  "Format a grouped MODE for CHANNEL applying FLAG to each of NICKS.
+FLAG is a signed mode string such as \"+o\" or \"-v\".  The mode letter
+is repeated once per nick so multiple targets share one MODE line,
+e.g. (clatter-irc-mode-set \"#c\" \"+o\" (list \"a\" \"b\" \"c\")) =>
+\"MODE #c +ooo a b c\".  NICKS may also be ban masks (for \"+b\"/\"-b\")."
+  (if (null nicks)
+      (clatter-format-line "MODE" channel flag)
+    (let* ((sign (substring flag 0 1))
+           (letter (substring flag 1))
+           (combined (concat sign (make-string (length nicks)
+                                               (string-to-char letter)))))
+      (apply #'clatter-format-line "MODE" channel combined nicks))))
+
 (defun clatter-irc-away (&optional message)
   "Format AWAY command.  If MESSAGE is nil, clears away."
   (if (and message (> (length message) 0))
@@ -483,6 +497,72 @@ The last param is treated as trailing if it contains spaces."
 (defun clatter-irc-monitor-status ()
   "Format MONITOR S (request status)."
   "MONITOR S")
+
+;; --- Server query commands ---
+
+(defun clatter-irc-who (&optional target)
+  "Format WHO for optional TARGET."
+  (if (and target (not (string-empty-p target)))
+      (clatter-format-line "WHO" target)
+    (clatter-format-line "WHO")))
+
+(defun clatter-irc-whowas (nick)
+  "Format WHOWAS query for NICK."
+  (clatter-format-line "WHOWAS" nick))
+
+(defun clatter-irc-ison (nicks)
+  "Format ISON for a list of NICKS."
+  (apply #'clatter-format-line "ISON" nicks))
+
+(defun clatter-irc-links (&optional mask)
+  "Format LINKS for optional server MASK."
+  (if mask
+      (clatter-format-line "LINKS" mask)
+    (clatter-format-line "LINKS")))
+
+(defun clatter-irc-stats (query &optional target)
+  "Format STATS QUERY (e.g. \"u\") for optional TARGET server."
+  (if target
+      (clatter-format-line "STATS" query target)
+    (clatter-format-line "STATS" query)))
+
+(defun clatter-irc-admin (&optional target)
+  "Format ADMIN for optional TARGET server."
+  (if target
+      (clatter-format-line "ADMIN" target)
+    (clatter-format-line "ADMIN")))
+
+(defun clatter-irc-info (&optional target)
+  "Format INFO for optional TARGET server."
+  (if target
+      (clatter-format-line "INFO" target)
+    (clatter-format-line "INFO")))
+
+(defun clatter-irc-version (&optional target)
+  "Format VERSION request for optional TARGET server."
+  (if target
+      (clatter-format-line "VERSION" target)
+    (clatter-format-line "VERSION")))
+
+(defun clatter-irc-lusers (&optional mask target)
+  "Format LUSERS for optional MASK and TARGET server."
+  (cond
+   (target (clatter-format-line "LUSERS" mask target))
+   (mask   (clatter-format-line "LUSERS" mask))
+   (t      (clatter-format-line "LUSERS"))))
+
+(defun clatter-irc-motd (&optional target)
+  "Format MOTD request for optional TARGET server."
+  (if target
+      (clatter-format-line "MOTD" target)
+    (clatter-format-line "MOTD")))
+
+(defun clatter-irc-rules (&optional target)
+  "Format RULES request for optional TARGET server.
+RULES is not universally supported; some daemons reject it."
+  (if target
+      (clatter-format-line "RULES" target)
+    (clatter-format-line "RULES")))
 
 ;; --- CTCP ---
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -2095,9 +2095,13 @@ the buffer margin-width variables."
                       '(noise))))))))
 
 (defun clatter-ui--on-motd (conn lines)
-  "Display MOTD LINES on CONN in the server buffer."
+  "Display MOTD LINES on CONN.
+Routes to the buffer that requested the MOTD via /motd when live; the
+server buffer otherwise (e.g. the connect-time MOTD)."
   (let* ((network (clatter-connection-network-id conn))
-         (buf (or (clatter-get-server-buffer network)
+         (query-buf (clatter--query-target conn))
+         (buf (or query-buf
+                  (clatter-get-server-buffer network)
                   (clatter-get-or-create-buffer network "*server*" 'server))))
     (clatter-ui-setup-buffer-if-needed buf)
     (clatter-insert-system buf "--- MOTD ---")
@@ -2105,10 +2109,16 @@ the buffer margin-width variables."
       (clatter-insert-system buf (clatter-hl-urls-in-string (clatter-format-parse line)) nil))
     (clatter-insert-system buf "--- End of MOTD ---")))
 
-(defun clatter-ui--on-whois (_conn nick data)
-  "Handle WHOIS reply for UI: display NICK info from DATA in current buffer."
-  (let ((buf (current-buffer))
-        (parts nil))
+(defun clatter-ui--on-whois (conn nick data)
+  "Handle WHOIS reply for UI: display NICK info from DATA.
+Routes to the buffer that issued /whois when live; the server buffer
+otherwise (the process filter may run in any buffer, so don't rely on
+`current-buffer')."
+  (let* ((network (clatter-connection-network-id conn))
+         (buf (or (clatter--query-target conn)
+                  (clatter-get-server-buffer network)
+                  (current-buffer)))
+         (parts nil))
     (push (format "WHOIS %s (%s@%s)"
                   nick
                   (or (plist-get data :user) "?")
@@ -2297,9 +2307,87 @@ COMMAND is the CTCP type (VERSION, PING, etc.), REPLY-TEXT is the response."
 
 ;; --- Handlers for other numerics ---
 
+(defconst clatter--query-reply-numerics
+  '("303"  ; RPL_ISON
+    "314"  ; RPL_WHOWASUSER
+    "315"  ; RPL_ENDOFWHO
+    "351"  ; RPL_VERSION
+    "352"  ; RPL_WHOREPLY
+    "364"  ; RPL_LINKS
+    "365"  ; RPL_ENDOFLINKS
+    "369"  ; RPL_ENDOFWHOWAS
+    "371"  ; RPL_INFO
+    "374"  ; RPL_ENDOFINFO
+    "210" "211" "212" "213" "214" "215" "216" "217" "218" "219" "220"
+    "240" "241" "242" "243" "244" "245" "246" "247" "248" "249" "250"
+    "256" "257" "258" "259"               ; RPL_ADMIN*
+    "251" "252" "253" "254" "255" "265" "266")  ; RPL_LUSER* (also welcome burst)
+  "Numeric replies that belong to user-initiated query commands.
+When `clatter-connection-last-query-buffer' is live, these route to that
+buffer instead of the server buffer.  The welcome burst sends several of
+these (251-266) too, but `last-query-buffer' is nil then so they still go
+to the server buffer.")
+
+(defconst clatter--query-end-numerics
+  '("219"  ; RPL_ENDOFSTATS
+    "315"  ; RPL_ENDOFWHO
+    "365"  ; RPL_ENDOFLINKS
+    "369"  ; RPL_ENDOFWHOWAS
+    "374"  ; RPL_ENDOFINFO
+    "376" "422")  ; RPL_ENDOFMOTD, ERR_NOMOTD
+  "Numerics that terminate a query reply set.
+Receiving one clears `clatter-connection-last-query-buffer' so that
+later unsolicited replies of the same kind (e.g. the automatic WHO issued
+on rejoin) fall back to the server buffer instead of being routed into
+whichever buffer last issued a query command.")
+
+(defun clatter--query-target (conn)
+  "Return the live buffer to route query replies to on CONN, or nil.
+Falls back to nil so callers use the normal server-buffer routing."
+  (let ((buf (clatter-connection-last-query-buffer conn)))
+    (and buf (buffer-live-p buf) buf)))
+
+(defun clatter--internal-whox-reply-p (conn command params)
+  "Return non-nil if COMMAND/PARAMS is a reply to an internal WHOX on CONN.
+`clatter-send-whox' fires automatically for every channel on each
+RPL_ENDOFNAMES, so its 352/315 replies must be consumed silently instead
+of flooding a buffer.  Clears the pending entry on the terminating 315."
+  (let ((channel (nth 1 params)))
+    (and channel
+         (member (downcase channel) (clatter-connection-pending-whox conn))
+         (cond
+          ;; 315 terminates the reply set: consume it and forget the channel.
+          ((string= command "315")
+           (setf (clatter-connection-pending-whox conn)
+                 (delete (downcase channel)
+                         (clatter-connection-pending-whox conn)))
+           t)
+          ;; 352/354 bodies for that same in-flight query.
+          ((member command '("352" "354")) t)))))
+
 (defun clatter-ui--on-numeric (conn command params)
   "Handle informational and MODE-related numerics for UI.
 COMMAND is the numeric reply code, PARAMS its parameters on CONN."
+  (cl-block clatter-ui--on-numeric
+    ;; Route replies to user-initiated query commands (/who, /stats,
+    ;; /lusers, ...) to the buffer the command was typed in, when it is
+    ;; still live.  Falls through to the pcase below otherwise (e.g. the
+    ;; welcome burst, where `last-query-buffer' is nil).
+    ;; Replies to the automatic per-channel WHOX are internal bookkeeping
+    ;; (account names); never display them.
+    (when (clatter--internal-whox-reply-p conn command params)
+      (cl-return-from clatter-ui--on-numeric))
+    (let ((query-buf (clatter--query-target conn)))
+      (when (and query-buf
+                 (member command clatter--query-reply-numerics))
+        ;; A terminating numeric ends the query: stop routing so later
+        ;; unsolicited replies go to the server buffer instead of piling up
+        ;; in whatever buffer last ran a query command.
+        (when (member command clatter--query-end-numerics)
+          (setf (clatter-connection-last-query-buffer conn) nil))
+        (clatter-insert-system
+         query-buf (format "[%s] %s" command (string-join (cdr params) " ")))
+        (cl-return-from clatter-ui--on-numeric)))
   (pcase command
     ;; --- Informational numerics ---
     ((or "001" "002" "003" "004" "242" "251" "252" "253" "254" "255"
@@ -2346,8 +2434,40 @@ COMMAND is the numeric reply code, PARAMS its parameters on CONN."
     ((or "401" "403"  ; ERR_NOSUCHNICK, ERR_NOSUCHCHANNEL
          "404"        ; ERR_CANNOTSENDTOCHAN
          "475")       ; ERR_BADCHANNELKEY
-     (let ((buf (current-buffer)))
-       (clatter-insert-system buf (string-join (reverse (cdr params)) " "))))))
+     ;; Route to the buffer named by the reply's target param (a query
+     ;; buffer for 401's nick, a channel buffer for the others), falling
+     ;; back to the server buffer.  Do not use (current-buffer): the
+     ;; process filter may run in any buffer.
+     (let* ((network (clatter-connection-network-id conn))
+            (target (nth 1 params))
+            (buf (or (clatter-get-buffer network target)
+                     (clatter-get-server-buffer network))))
+       (when buf
+         (clatter-insert-system buf (string-join (reverse (cdr params)) " ")))))
+    ("421"                            ; ERR_UNKNOWNCOMMAND
+     ;; The server rejected a command we sent.  If it was TAGMSG, the
+     ;; server (or an upstream behind a bouncer/bridge) ACKed message-tags
+     ;; but does not actually accept TAGMSG; remember that so outbound
+     ;; typing/reaction TAGMSGs stop rather than spamming 421s every
+     ;; keystroke.  Still display the error so the user sees it once.
+     (let ((rejected-cmd (nth 1 params)))
+       (when (string-equal (and rejected-cmd (upcase rejected-cmd)) "TAGMSG")
+         (setf (clatter-connection-tagmsg-rejected conn) t)))
+     (let* ((network (clatter-connection-network-id conn))
+            (buf (clatter-get-server-buffer network)))
+       (when buf
+         (clatter-insert-system
+          buf (format "[%s] %s" command (string-join (cdr params) " "))))))
+    ;; Catch-all: show any unhandled numeric (e.g. 421 ERR_UNKNOWNCOMMAND,
+    ;; 411/412/432/433/461/471-477 ...) in the server buffer instead of
+    ;; silently dropping it.
+    (_
+     (let* ((network (clatter-connection-network-id conn))
+            (buf (clatter-get-server-buffer network)))
+       (when buf
+         (clatter-insert-system
+          buf (format "[%s] %s" command (string-join (cdr params) " "))))))))
+  ) ;; end of pcase / cl-block clatter-ui--on-numeric
 
 ;; --- Channel preview on hover (eldoc) ---
 
@@ -2497,7 +2617,8 @@ Requires the server to support the message-tags capability."
        (let ((conn (clatter-get-connection clatter--network)))
          (and conn
               (member "message-tags"
-                      (clatter-connection-cap-enabled conn))))))
+                      (clatter-connection-cap-enabled conn))
+              (not (clatter-connection-tagmsg-rejected conn))))))
 
 (defun clatter--maybe-send-typing (&rest _)
   "Send a typing notification if in the input area and throttle allows."

--- a/tests/test-input.el
+++ b/tests/test-input.el
@@ -10,6 +10,7 @@
 (require 'ert)
 (require 'test-helper)
 (require 'clatter-ui)
+(require 'clatter-commands)
 
 (defmacro clatter-input-test--with (order &rest body)
   "Run BODY in a fresh clatter-mode buffer with message ORDER and a prompt."
@@ -480,6 +481,139 @@ positions or it deletes the wrong (message) text."
   (let ((buffer-undo-list (list 10 (cons 5 8))))
     (clatter--update-undo-list 0)
     (should (equal buffer-undo-list (list 10 (cons 5 8))))))
+
+;; --- Slash command dispatch ---
+
+(defmacro clatter-cmd-test--with-channel (target &rest body)
+  "Run BODY in a temp clatter buffer on network \"testnet\" with TARGET.
+A mock connection is registered; `clatter-send' is mocked to capture lines."
+  (declare (indent 1))
+  `(let ((conn (clatter-test-make-connection "testnet" "alice")))
+     (unwind-protect
+         (with-temp-buffer
+           (clatter-mode)
+           (setq-local clatter--network "testnet")
+           (setq-local clatter--target ,target)
+           (clatter-test-with-mock-send
+             ,@body))
+       (remhash (clatter-connection-network-id conn) clatter-connections))))
+
+(ert-deftest clatter-cmd-raw-echoes-sent-line ()
+  "/raw echoes the sent line into the originating buffer."
+  (let ((conn (clatter-test-make-connection "testnet" "alice")))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-mode)
+          (setq-local clatter--network "testnet")
+          (setq-local clatter--target "#test")
+          (clatter--setup-prompt (current-buffer))
+          (let (sys)
+            (cl-letf (((symbol-function 'clatter-send)
+                       (lambda (&rest _) t))
+                      ((symbol-function 'clatter-insert-system)
+                       (lambda (_buffer text &optional _invisible)
+                         (push text sys))))
+              (clatter-cmd-raw "PING irc.libera.chat"))
+            (should (equal (car sys) ">> PING irc.libera.chat"))))
+      (remhash (clatter-connection-network-id conn) clatter-connections))))
+
+(ert-deftest clatter-cmd-raw-no-args-errors ()
+  "/raw with no args shows usage and sends nothing."
+  (clatter-cmd-test--with-channel "#test"
+    (let (err)
+      (cl-letf (((symbol-function 'clatter-insert-error)
+                 (lambda (_buffer text) (push text err))))
+        (clatter-cmd-raw ""))
+      (should (null clatter-test--sent-lines))
+      (should (string-match-p "Usage" (car err))))))
+
+(ert-deftest clatter-cmd-mode-explicit-channel-not-duplicated ()
+  "/mode #chan +b in a channel buffer must not send the channel twice.
+Sending \"MODE #chan #chan +b\" makes the server read the second channel
+as the mode string and reply 472 (unknown mode char)."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-mode "#chan +b")
+    (should (equal (clatter-test-last-sent) "MODE #chan +b"))))
+
+(ert-deftest clatter-cmd-mode-implicit-channel-uses-buffer-target ()
+  "/mode +b in a channel buffer targets that channel.
+A leading + is also a valid channel prefix, so the mode string must not
+be mistaken for an explicit channel argument."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-mode "+b")
+    (should (equal (clatter-test-last-sent) "MODE #chan +b"))))
+
+(ert-deftest clatter-cmd-mode-explicit-other-channel ()
+  "/mode #other +b mask targets the named channel, not the buffer's."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-mode "#other +b mask!*@*")
+    (should (equal (clatter-test-last-sent) "MODE #other +b mask!*@*"))))
+
+(ert-deftest clatter-cmd-mode-bare-in-channel-queries-channel ()
+  "/mode with no args in a channel buffer queries that channel's modes."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-mode "")
+    (should (equal (clatter-test-last-sent) "MODE #chan"))))
+
+(ert-deftest clatter-cmd-op-groups-modes ()
+  "/op with several nicks sends a grouped MODE line."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-op "alice bob carol")
+    (should (equal (clatter-test-last-sent) "MODE #chan +ooo alice bob carol"))))
+
+(ert-deftest clatter-cmd-op-single ()
+  "/op with one nick sends a single +o."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-op "alice")
+    (should (equal (clatter-test-last-sent) "MODE #chan +o alice"))))
+
+(ert-deftest clatter-cmd-op-no-nicks-errors ()
+  "/op with no nicks shows usage and sends nothing."
+  (clatter-cmd-test--with-channel "#chan"
+    (let (err)
+      (cl-letf (((symbol-function 'clatter-insert-error)
+                 (lambda (_buffer text) (push text err))))
+        (clatter-cmd-op ""))
+      (should (null clatter-test--sent-lines))
+      (should (string-match-p "Usage" (car err))))))
+
+(ert-deftest clatter-cmd-op-in-server-buffer-errors ()
+  "/op outside a channel buffer shows usage and sends nothing."
+  (clatter-cmd-test--with-channel "*server*"
+    (let (err)
+      (cl-letf (((symbol-function 'clatter-insert-error)
+                 (lambda (_buffer text) (push text err))))
+        (clatter-cmd-op "alice"))
+      (should (null clatter-test--sent-lines))
+      (should (string-match-p "channel buffer" (car err))))))
+
+(ert-deftest clatter-cmd-ban-wildcards-bare-nick ()
+  "/ban wildcards a bare nick to nick!*@*."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-ban "alice")
+    (should (equal (clatter-test-last-sent) "MODE #chan +b alice!*@*"))))
+
+(ert-deftest clatter-cmd-ban-keeps-mask ()
+  "/ban leaves an explicit mask unchanged."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-ban "*!*@evil.host")
+    (should (equal (clatter-test-last-sent) "MODE #chan +b *!*@evil.host"))))
+
+(ert-deftest clatter-cmd-server-queries-send-expected-lines ()
+  "Server-query commands send the right protocol lines."
+  (clatter-cmd-test--with-channel "#chan"
+    (clatter-cmd-who "")
+    (should (equal (clatter-test-last-sent) "WHO"))
+    (clatter-cmd-who "#chan")
+    (should (equal (clatter-test-last-sent) "WHO #chan"))
+    (clatter-cmd-motd "")
+    (should (equal (clatter-test-last-sent) "MOTD"))
+    (clatter-cmd-stats "u")
+    (should (equal (clatter-test-last-sent) "STATS u"))
+    (clatter-cmd-stats "u irc.net")
+    (should (equal (clatter-test-last-sent) "STATS u irc.net"))
+    (clatter-cmd-ison "a b")
+    (should (equal (clatter-test-last-sent) "ISON a b"))))
 
 (provide 'test-input)
 

--- a/tests/test-protocol.el
+++ b/tests/test-protocol.el
@@ -194,6 +194,66 @@
   (should (equal (clatter-format-line "NICK" "newnick")
                  "NICK newnick")))
 
+;; --- Mode-set grouping ---
+
+(ert-deftest clatter-test-mode-set-single ()
+  "A single nick produces one mode flag."
+  (should (equal (clatter-irc-mode-set "#chan" "+o" '("alice"))
+                 "MODE #chan +o alice")))
+
+(ert-deftest clatter-test-mode-set-grouped ()
+  "Multiple nicks are grouped into repeated flags."
+  (should (equal (clatter-irc-mode-set "#chan" "+o" '("a" "b" "c"))
+                 "MODE #chan +ooo a b c"))
+  (should (equal (clatter-irc-mode-set "#chan" "-v" '("a" "b"))
+                 "MODE #chan -vv a b")))
+
+(ert-deftest clatter-test-mode-set-empty ()
+  "Empty nick list falls back to a bare flag."
+  (should (equal (clatter-irc-mode-set "#chan" "+o" nil)
+                 "MODE #chan +o")))
+
+(ert-deftest clatter-test-mode-set-masks ()
+  "Ban masks (with spaces) become a trailing param."
+  (should (equal (clatter-irc-mode-set "#chan" "+b"
+                                        '("alice!*@*" "bob!*@*"))
+                 "MODE #chan +bb alice!*@* bob!*@*")))
+
+;; --- Server query formatters ---
+
+(ert-deftest clatter-test-irc-who ()
+  (should (equal (clatter-irc-who) "WHO"))
+  (should (equal (clatter-irc-who "") "WHO"))
+  (should (equal (clatter-irc-who "#chan") "WHO #chan")))
+
+(ert-deftest clatter-test-irc-whowas ()
+  (should (equal (clatter-irc-whowas "bob") "WHOWAS bob")))
+
+(ert-deftest clatter-test-irc-ison ()
+  (should (equal (clatter-irc-ison '("a" "b")) "ISON a b"))
+  (should (equal (clatter-irc-ison '("a")) "ISON a")))
+
+(ert-deftest clatter-test-irc-links ()
+  (should (equal (clatter-irc-links) "LINKS"))
+  (should (equal (clatter-irc-links "*.net") "LINKS *.net")))
+
+(ert-deftest clatter-test-irc-stats ()
+  (should (equal (clatter-irc-stats "u") "STATS u"))
+  (should (equal (clatter-irc-stats "u" "irc.net") "STATS u irc.net")))
+
+(ert-deftest clatter-test-irc-admin/info/version/motd/rules ()
+  (should (equal (clatter-irc-admin) "ADMIN"))
+  (should (equal (clatter-irc-admin "irc.net") "ADMIN irc.net"))
+  (should (equal (clatter-irc-info) "INFO"))
+  (should (equal (clatter-irc-version) "VERSION"))
+  (should (equal (clatter-irc-motd) "MOTD"))
+  (should (equal (clatter-irc-rules "irc.net") "RULES irc.net")))
+
+(ert-deftest clatter-test-irc-lusers ()
+  (should (equal (clatter-irc-lusers) "LUSERS"))
+  (should (equal (clatter-irc-lusers "mask") "LUSERS mask"))
+  (should (equal (clatter-irc-lusers "mask" "irc.net") "LUSERS mask irc.net")))
+
 (provide 'test-protocol)
 
 ;;; test-protocol.el ends here

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -1619,6 +1619,134 @@ system messages."
             (should (clatter--typing-capable-p))))
       (clatter-test-cleanup))))
 
+(ert-deftest clatter-test-typing-not-capable-when-tagmsg-rejected ()
+  "Typing suppressed once the server returned 421 for TAGMSG."
+  (let ((conn (clatter-test-make-connection)))
+    (unwind-protect
+        (progn
+          (setf (clatter-connection-tagmsg-rejected conn) t)
+          (with-temp-buffer
+            (setq-local clatter--network "testnet")
+            (setq-local clatter--target "#test")
+            (let ((clatter-send-typing t))
+              (should-not (clatter--typing-capable-p)))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-numeric-421-tagmsg-sets-flag-and-displays ()
+  "421 for TAGMSG sets the connection flag and still prints to the server buffer."
+  (clatter-test-with-ui-connection conn
+    (let (inserted)
+      (clatter-get-or-create-buffer "testnet" "*server*" 'server)
+      (cl-letf (((symbol-function 'clatter-insert-system)
+                 (lambda (buffer text &optional _invisible)
+                   (push (cons buffer text) inserted))))
+        (clatter-ui--on-numeric conn "421"
+                                 '("testnick" "TAGMSG" "Unknown command")))
+      (should (clatter-connection-tagmsg-rejected conn))
+      (let ((server (clatter-get-server-buffer "testnet")))
+        (should server)
+        (should (cl-find-if (lambda (cell)
+                              (and (eq (car cell) server)
+                                   (string-match-p "\\[421\\].*TAGMSG"
+                                                   (cdr cell))))
+                            inserted))))))
+
+(ert-deftest clatter-test-numeric-421-other-command-no-flag ()
+  "421 for a non-TAGMSG command does not set the tagmsg-rejected flag."
+  (clatter-test-with-ui-connection conn
+    (clatter-get-or-create-buffer "testnet" "*server*" 'server)
+    (cl-letf (((symbol-function 'clatter-insert-system)
+               (lambda (_buffer _text &optional _invisible))))
+      (clatter-ui--on-numeric conn "421"
+                               '("testnick" "FOOBAR" "Unknown command")))
+    (should-not (clatter-connection-tagmsg-rejected conn))))
+
+(ert-deftest clatter-test-numeric-query-reply-routes-to-origin-buffer ()
+  "A query-reply numeric routes to the buffer that issued the command.
+The process filter may run in an unrelated buffer, so routing must not
+rely on `current-buffer'."
+  (clatter-test-with-ui-connection conn
+    (let (inserted)
+      (let ((chan (clatter-get-or-create-buffer "testnet" "#test" 'channel)))
+        (setf (clatter-connection-last-query-buffer conn) chan)
+        (clatter-get-or-create-buffer "testnet" "*server*" 'server)
+        (with-temp-buffer
+          (cl-letf (((symbol-function 'clatter-insert-system)
+                     (lambda (buffer text &optional _invisible)
+                       (push (cons buffer text) inserted))))
+            (clatter-ui--on-numeric conn "352"
+                                     '("testnick" "#test" "user" "host"
+                                       "server" "nick" "H" "0 real"))))
+        (should (cl-find-if (lambda (cell) (eq (car cell) chan)) inserted))
+        (should-not (cl-find-if (lambda (cell)
+                                  (not (eq (car cell) chan)))
+                                inserted))))))
+
+(ert-deftest clatter-test-numeric-query-reply-falls-to-server-when-no-origin ()
+  "Without a recorded origin (e.g. the welcome burst), query-reply
+numerics fall through to the server buffer."
+  (clatter-test-with-ui-connection conn
+    (let (inserted)
+      (clatter-get-or-create-buffer "testnet" "*server*" 'server)
+      (cl-letf (((symbol-function 'clatter-insert-system)
+                 (lambda (buffer text &optional _invisible)
+                   (push (cons buffer text) inserted))))
+        (clatter-ui--on-numeric conn "251"
+                                 '("testnick" "3 4" "There are 3 users")))
+      (let ((server (clatter-get-server-buffer "testnet")))
+        (should server)
+        (should (cl-find-if (lambda (cell) (eq (car cell) server))
+                            inserted))))))
+
+(ert-deftest clatter-test-internal-whox-replies-not-displayed ()
+  "Replies to the automatic per-channel WHOX are consumed silently.
+`clatter-send-whox' fires on every RPL_ENDOFNAMES, so displaying its 315s
+floods the buffer with \"End of /WHO list\" on every rejoin."
+  (clatter-test-with-ui-connection conn
+    (let ((inserted nil)
+          (chans '("#erc" "#ircv3" "#guix")))
+      (clatter-get-or-create-buffer "testnet" "*server*" 'server)
+      (setf (clatter-connection-last-query-buffer conn)
+            (clatter-get-or-create-buffer "testnet" "#clatter" 'channel))
+      (cl-letf (((symbol-function 'clatter-insert-system)
+                 (lambda (buffer text &optional _invisible)
+                   (push (cons buffer text) inserted)))
+                ((symbol-function 'clatter-send) (lambda (&rest _) nil)))
+        (dolist (c chans) (clatter-send-whox conn c))
+        (dolist (c chans)
+          (clatter-ui--on-numeric conn "315"
+                                   (list "testnick" c "End of /WHO list"))))
+      (should-not inserted)
+      ;; Each terminating 315 clears its pending entry.
+      (should-not (clatter-connection-pending-whox conn)))))
+
+(ert-deftest clatter-test-query-routing-cleared-by-end-numeric ()
+  "A terminating numeric stops query routing so it is not sticky.
+Otherwise every later unsolicited reply keeps landing in whichever buffer
+last ran a query command."
+  (clatter-test-with-ui-connection conn
+    (let ((inserted nil))
+      (clatter-get-or-create-buffer "testnet" "*server*" 'server)
+      (let ((qb (clatter-get-or-create-buffer "testnet" "#clatter" 'channel)))
+        (setf (clatter-connection-last-query-buffer conn) qb)
+        (cl-letf (((symbol-function 'clatter-insert-system)
+                   (lambda (buffer text &optional _invisible)
+                     (push (cons buffer text) inserted))))
+          ;; A user /who: body then terminator, both shown in the origin.
+          (clatter-ui--on-numeric conn "352"
+                                   '("testnick" "#clatter" "u" "h" "s"
+                                     "nick" "H" "0 real"))
+          (clatter-ui--on-numeric conn "315"
+                                   '("testnick" "#clatter" "End of /WHO list"))
+          (should (cl-every (lambda (cell) (eq (car cell) qb)) inserted))
+          (should (null (clatter-connection-last-query-buffer conn)))
+          ;; A later unsolicited 315 now goes to the server buffer.
+          (setq inserted nil)
+          (clatter-ui--on-numeric conn "315"
+                                   '("testnick" "#erc" "End of /WHO list"))
+          (should (eq (car (car inserted))
+                      (clatter-get-server-buffer "testnet"))))))))
+
 ;; --- Notifications and read state ---
 
 (ert-deftest clatter-test-read-state-suppresses-read-notification ()
@@ -1679,6 +1807,43 @@ system messages."
   (should (memq #'clatter-nicklist--on-quit (default-value 'clatter-quit-hook)))
   (should (memq #'clatter-nicklist--on-nick (default-value 'clatter-nick-hook)))
   (should (memq #'clatter-nicklist--on-names (default-value 'clatter-names-hook))))
+
+;; --- Numeric reply routing ---
+
+(ert-deftest clatter-test-numeric-unhandled-goes-to-server ()
+  "An unhandled numeric (e.g. 421) prints to the server buffer, not dropped."
+  (clatter-test-with-ui-connection conn
+    (let (inserted)
+      (clatter-get-or-create-buffer "testnet" "*server*" 'server)
+      (cl-letf (((symbol-function 'clatter-insert-system)
+                 (lambda (buffer text &optional _invisible)
+                   (push (cons buffer text) inserted))))
+        (clatter-ui--on-numeric conn "421"
+                                 '("testnick" "FOOBAR" "Unknown command")))
+      (let ((server (clatter-get-server-buffer "testnet")))
+        (should server)
+        (should (cl-find-if (lambda (cell)
+                              (and (eq (car cell) server)
+                                   (string-match-p "\\[421\\]" (cdr cell))))
+                            inserted))))))
+
+(ert-deftest clatter-test-numeric-403-routes-to-channel-buffer ()
+  "403 routes to the param-derived channel buffer, not (current-buffer)."
+  (clatter-test-with-ui-connection conn
+    (let (inserted)
+      (let ((chan (clatter-get-or-create-buffer "testnet" "#gone" 'channel)))
+        (with-temp-buffer
+          ;; current-buffer is a non-clatter temp buffer at filter time
+          (cl-letf (((symbol-function 'clatter-insert-system)
+                     (lambda (buffer text &optional _invisible)
+                       (push (cons buffer text) inserted))))
+            (clatter-ui--on-numeric conn "403"
+                                     '("testnick" "#gone" "No such channel"))))
+        (should (cl-find-if (lambda (cell) (eq (car cell) chan)) inserted))
+        ;; The temp buffer must never have been the target.
+        (should-not (cl-find-if (lambda (cell)
+                                  (not (eq (car cell) chan)))
+                                inserted))))))
 
 (provide 'test-ui)
 


### PR DESCRIPTION
## Summary

Audit of the slash-command surface and `/raw` reply routing, with fixes and new commands.

## `/raw` reply routing

`/raw` is fire-and-forget: `clatter-send` carries no source-buffer token and IRC gives no request-id for most commands, so "reply returns to the originating buffer" is structurally infeasible — replies are routed by content (numeric + params) at receive time. Two bugs fixed in `clatter-ui--on-numeric`:

- `401/403/404/475` used `(current-buffer)` — whatever buffer the process filter ran in, not derived from the reply params. Now resolves the target buffer from `params` (like `324/329` already did), falling back to the server buffer.
- No default clause, so `421 ERR_UNKNOWNCOMMAND` and most error numerics were silently dropped. New catch-all routes every unhandled numeric to the `*server*` buffer with a `[code]` prefix.
- `/raw` now echoes `>> <line>` into the originating buffer (reliable at handler time, unlike the receive-time filter), since `/raw` bypasses the formatter self-echo path.

## New commands

**Channel-admin mode helpers** (backed by a new `clatter-irc-mode-set` grouping helper that builds `MODE #c +ooo a b c`):

`/op /deop /voice /devoice /hop /dehop /quiet /unquiet /ban /unban`

`/ban` wildcards bare nicks to `nick!*@*`; quiet uses `+q` (semantics vary by daemon).

**Server-query commands** (with formatters in `clatter-protocol.el`):

`/who /whowas /ison /links /stats /admin /info /version /lusers /motd /rules`

Replies land in the `*server*` buffer via the new default numeric clause (MOTD/WHOWAS were already handled).

## Docs

GUIDE.org command reference updated with the channel-admin helpers and a new Server Queries table.

## Verification

- Full ERT suite: 395/395 passed
- `batch-byte-compile` with `byte-compile-error-on-warn t` on all `*.el`: clean