### PR TITLE
Fetch unread DM history via CHATHISTORY TARGETS on connect

### DIFF
--- a/clatter-chathistory.el
+++ b/clatter-chathistory.el
@@ -18,6 +18,7 @@
 (require 'clatter-config)
 (require 'clatter-connection)
 (require 'clatter-model)
+(require 'clatter-protocol)
 
 ;; --- Configuration ---
 
@@ -104,6 +105,53 @@ Used on reconnect to fill in gaps."
       (clatter-send conn
                     (format "CHATHISTORY AFTER %s timestamp=%s %d"
                             target ts n)))))
+
+;; --- TARGETS (DM discovery) ---
+
+(defun clatter-chathistory-fetch-targets (conn &optional limit)
+  "Request CHATHISTORY TARGETS on CONN to discover DM targets with history.
+LIMIT defaults to `clatter-chathistory-limit'.  The server responds with a
+batch of type `chathistory-targets' listing channels and DM partners that
+have history, each with the timestamp of their latest message."
+  (when (clatter-chathistory--available-p conn)
+    (let ((n (or limit clatter-chathistory-limit)))
+      (clatter-send conn
+                    (format "CHATHISTORY TARGETS * * %d" n)))))
+
+(defun clatter-chathistory--on-welcome (conn _nick)
+  "On welcome (001), request CHATHISTORY TARGETS to discover missed DMs.
+This is essential when connecting through a bouncer: channels get their
+history fetched on JOIN, but DM buffers are only created on demand.
+Without TARGETS, DMs received while offline are never fetched."
+  (when (and clatter-chathistory-enabled
+             (clatter-chathistory--available-p conn))
+    (clatter-chathistory-fetch-targets conn)))
+
+(defun clatter-chathistory--on-targets-batch (conn _batch-type _target messages)
+  "Process a completed chathistory-targets batch.
+MESSAGES is a list of plists with :target and :time keys.  For each
+target that is a DM (not a channel), fetch latest history if we don't
+already have a buffer for it, or fetch since the last known timestamp
+if we do."
+  (when (and clatter-chathistory-enabled
+             (clatter-chathistory--available-p conn))
+    (let ((network (clatter-connection-network-id conn))
+          (my-nick (clatter-connection-nick conn)))
+      (dolist (entry messages)
+        (let ((target (plist-get entry :target)))
+          (when (and target
+                     (not (clatter-channel-name-p target))
+                     (not (string-equal target my-nick)))
+            (let ((buf (clatter-get-buffer network target)))
+              (if (and buf
+                       (buffer-local-value 'clatter-chathistory--last-timestamp buf))
+                  ;; Existing buffer: fetch since last known message
+                  (when clatter-chathistory-on-reconnect
+                    (clatter-chathistory-fetch-since
+                     conn target
+                     (buffer-local-value 'clatter-chathistory--last-timestamp buf)))
+                ;; New DM target: fetch latest
+                (clatter-chathistory-fetch-latest conn target)))))))))
 
 ;; --- Automatic fetch hooks ---
 
@@ -195,6 +243,9 @@ COUNT defaults to `clatter-chathistory-limit'."
   (add-hook 'clatter-privmsg-hook #'clatter-chathistory--track-timestamp)
   (add-hook 'clatter-batch-complete-hook
             #'clatter-chathistory--track-batch-timestamp)
+  (add-hook 'clatter-welcome-hook #'clatter-chathistory--on-welcome)
+  (add-hook 'clatter-batch-complete-hook
+            #'clatter-chathistory--on-targets-batch)
   (when (called-interactively-p 'interactive)
     (message "[clatter-chathistory] Enabled")))
 
@@ -205,6 +256,9 @@ COUNT defaults to `clatter-chathistory-limit'."
   (remove-hook 'clatter-privmsg-hook #'clatter-chathistory--track-timestamp)
   (remove-hook 'clatter-batch-complete-hook
                #'clatter-chathistory--track-batch-timestamp)
+  (remove-hook 'clatter-welcome-hook #'clatter-chathistory--on-welcome)
+  (remove-hook 'clatter-batch-complete-hook
+               #'clatter-chathistory--on-targets-batch)
   (message "[clatter-chathistory] Disabled"))
 
 ;; Enabled by `clatter-setup' when `clatter-chathistory-enabled' is

--- a/clatter-handlers.el
+++ b/clatter-handlers.el
@@ -596,6 +596,19 @@ Return the trimmed character."
            (run-hook-with-args 'clatter-react-hook
                                conn parsed-prefix target react-emoji react-msgid))))
 
+      ;; --- CHATHISTORY (IRCv3 - TARGETS response entries) ---
+      ("CHATHISTORY"
+       (let* ((parsed-tags (clatter-parse-tags tags))
+              (batch-id (clatter-get-parsed-tag parsed-tags "batch"))
+              (server-time (clatter-get-parsed-server-time parsed-tags)))
+         (when batch-id
+           (let ((batch (gethash batch-id (clatter-connection-active-batches conn))))
+             (when batch
+               (push (list :type 'chathistory-targets
+                           :target (nth 0 params)
+                           :time server-time)
+                     (plist-get batch :messages)))))))
+
       ;; --- MARKREAD (IRCv3 read-marker) ---
       ("MARKREAD"
        (when (fboundp 'clatter-read-marker--handle)

--- a/tests/test-chathistory.el
+++ b/tests/test-chathistory.el
@@ -37,6 +37,140 @@ It must not error on (downcase nil) and must not touch any buffer."
           (should-not (clatter-get-buffer "testnet" nil)))
       (clatter-test-cleanup))))
 
+
+;; --- CHATHISTORY TARGETS tests ---
+
+(ert-deftest clatter-chathistory-fetch-targets-sends-command ()
+  "fetch-targets sends CHATHISTORY TARGETS with the limit."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory"))))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory-fetch-targets conn 50)
+          (should (clatter-test-sent-matching
+                   "^CHATHISTORY TARGETS \\* \\* 50$")))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-chathistory-fetch-targets-no-cap-no-op ()
+  "fetch-targets is a no-op when chathistory cap is not enabled."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags"))))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory-fetch-targets conn)
+          (should-not clatter-test--sent-lines))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-chathistory-on-welcome-sends-targets ()
+  "Welcome hook fires TARGETS request when chathistory is available."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory"))))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory--on-welcome conn "testnick")
+          (should (clatter-test-sent-matching
+                   "^CHATHISTORY TARGETS ")))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-chathistory-on-welcome-disabled-no-op ()
+  "Welcome hook does nothing when chathistory is disabled."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory")))
+        (clatter-chathistory-enabled nil))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory--on-welcome conn "testnick")
+          (should-not clatter-test--sent-lines))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-chathistory-targets-batch-fetches-latest-for-new-dm ()
+  "TARGETS batch with a new DM target triggers CHATHISTORY LATEST."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory"))))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory--on-targets-batch
+           conn "chathistory-targets" nil
+           (list (list :target "alcor" :time (encode-time 0 0 12 1 1 2026 t))))
+          (should (clatter-test-sent-matching
+                   "^CHATHISTORY LATEST alcor \\* 50$")))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-chathistory-targets-batch-fetches-since-for-existing-dm ()
+  "TARGETS batch with an existing DM buffer triggers CHATHISTORY AFTER."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory")))
+        (clatter-read-state-enabled nil)
+        buf)
+    (unwind-protect
+        (progn
+          (setq buf (clatter-get-or-create-buffer "testnet" "alcor" 'query))
+          (with-current-buffer buf
+            (setq clatter-chathistory--last-timestamp
+                  (encode-time 0 0 10 1 1 2026 t)))
+          (clatter-test-with-mock-send
+            (clatter-chathistory--on-targets-batch
+             conn "chathistory-targets" nil
+             (list (list :target "alcor" :time (encode-time 0 0 12 1 1 2026 t))))
+            (should (clatter-test-sent-matching
+                     "^CHATHISTORY AFTER alcor timestamp="))))
+      (clatter-test-cleanup)
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest clatter-chathistory-targets-batch-skips-channels ()
+  "TARGETS batch skips channel targets (channels are handled on JOIN)."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory"))))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory--on-targets-batch
+           conn "chathistory-targets" nil
+           (list (list :target "#emacs" :time (encode-time 0 0 12 1 1 2026 t))))
+          (should-not clatter-test--sent-lines))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-chathistory-targets-batch-skips-own-nick ()
+  "TARGETS batch skips entries where the target is our own nick."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory")
+               "testnet" "testnick")))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory--on-targets-batch
+           conn "chathistory-targets" nil
+           (list (list :target "testnick" :time (encode-time 0 0 12 1 1 2026 t))))
+          (should-not clatter-test--sent-lines))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-chathistory-targets-batch-multiple-dm-targets ()
+  "TARGETS batch with multiple DM targets fetches history for each."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory"))))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory--on-targets-batch
+           conn "chathistory-targets" nil
+           (list (list :target "alcor" :time (encode-time 0 0 12 1 1 2026 t))
+                 (list :target "jazzah" :time (encode-time 0 0 11 1 1 2026 t))
+                 (list :target "#emacs" :time (encode-time 0 0 10 1 1 2026 t))))
+          (should (clatter-test-sent-matching "^CHATHISTORY LATEST alcor "))
+          (should (clatter-test-sent-matching "^CHATHISTORY LATEST jazzah "))
+          ;; Channel target should NOT trigger a fetch
+          (should-not (clatter-test-sent-matching "^CHATHISTORY.*#emacs")))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-chathistory-targets-batch-empty-messages ()
+  "TARGETS batch with no messages is a harmless no-op."
+  (let ((conn (clatter-test-make-connection-with-caps
+               '("server-time" "batch" "message-tags" "chathistory"))))
+    (unwind-protect
+        (clatter-test-with-mock-send
+          (clatter-chathistory--on-targets-batch
+           conn "chathistory-targets" nil nil)
+          (should-not clatter-test--sent-lines))
+      (clatter-test-cleanup))))
+
 (provide 'test-chathistory)
 
 ;;; test-chathistory.el ends here


### PR DESCRIPTION
When connecting through a bouncer, clatter only fetched CHATHISTORY for joined channels (on JOIN). DMs received while offline were never discovered because query buffers are created on demand.

This implements the IRCv3 CHATHISTORY TARGETS subcommand to discover all targets with history on connect, then fetches LATEST (or AFTER for existing buffers) for each DM target.

The server responds with a batch of type `chathistory-targets` listing channels and DM partners that have history. For each DM target (non-channel, non-own-nick), clatter fetches:

- **CHATHISTORY LATEST** for new DM targets (no existing buffer)
- **CHATHISTORY AFTER** for existing DM buffers with a known last timestamp

Channel targets are skipped (channels are already handled on JOIN).

**Future enhancement:** Pair with MARKREAD GET to fetch only unread messages for each target, rather than LATEST/AFTER based on local state. This requires async request/response correlation for MARKREAD GET replies.

Fixes #117
