### PR TITLE
feat(ui): window-wide history dividers

### DIFF
--- a/GUIDE.org
+++ b/GUIDE.org
@@ -942,14 +942,14 @@ marker manually. Requires the =server-time=, =batch= and =message-tags=
 capabilities, which clatter negotiates by default.
 
 Batched playback - CHATHISTORY, ZNC playback, anything using IRCv3 BATCH -
-renders with full-window divider faces whose labels stay centered when the
-window is resized or the buffer is shown at different widths:
+renders with window-wide divider lines whose labels stay centered as the
+window is resized:
 
 #+begin_example
-                         ── history ──
+────────────────────────────── history ──────────────────────────────
 10:15        <alice> hey everyone
 10:16          <bob> morning!
-                  ── end of history (2 messages) ──
+──────────────────── end of history (2 messages) ────────────────────
 #+end_example
 
 ** Nick Completion

--- a/GUIDE.org
+++ b/GUIDE.org
@@ -942,13 +942,14 @@ marker manually. Requires the =server-time=, =batch= and =message-tags=
 capabilities, which clatter negotiates by default.
 
 Batched playback - CHATHISTORY, ZNC playback, anything using IRCv3 BATCH -
-renders with separators:
+renders with full-window divider faces whose labels stay centered when the
+window is resized or the buffer is shown at different widths:
 
 #+begin_example
- ------------------------------ history ------------------------------
+                         ── history ──
 10:15        <alice> hey everyone
 10:16          <bob> morning!
- -------------------- end of history (2 messages) --------------------
+                  ── end of history (2 messages) ──
 #+end_example
 
 ** Nick Completion

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -38,9 +38,9 @@
   "Face for message timestamps."
   :group 'clatter)
 
-(defface clatter-history-divider
+(defface clatter-divider
   '((t :inherit shadow))
-  "Face for history divider rows."
+  "Face for divider rows."
   :group 'clatter)
 
 (defface clatter-nick
@@ -2693,17 +2693,17 @@ otherwise (the process filter may run in any buffer, so don't rely on
                 (add-text-properties found (1+ found)
                                      (list 'clatter-reactions new-reactions))))))))))
 
-(defun clatter--history-bar (label)
+(defun clatter--divider (label)
   "Return a window-wide divider line with LABEL centered.
 The rule segments are stretch glyphs drawn with `:strike-through', so
 redisplay recenters and resizes the bar with each window - same
 mechanism as `clatter-read-marker-line', no overlays or size hooks."
-  (let ((rule '(:inherit clatter-history-divider :strike-through t))
+  (let ((rule '(:inherit clatter-divider :strike-through t))
         (label (concat " " label " ")))
     (concat
      (propertize " " 'face rule
                  'display `(space :align-to (- center ,(/ (string-width label) 2))))
-     (propertize label 'face 'clatter-history-divider)
+     (propertize label 'face 'clatter-divider)
      (propertize " " 'face rule 'display '(space :align-to right)))))
 
 (defun clatter-ui--on-batch-complete (conn _batch-type target messages)
@@ -2726,8 +2726,8 @@ on screen, so it renders at the buffer's oldest end, in the direction
              ;; end separator, then messages newest-first, then the start
              ;; separator.
              (messages (if backlog (reverse messages) messages))
-             (sep-text (clatter--history-bar "history"))
-             (end-sep-text (clatter--history-bar
+             (sep-text (clatter--divider "history"))
+             (end-sep-text (clatter--divider
                             (format "end of history (%d messages)" count))))
         (clatter--insert-message buf (if backlog end-sep-text sep-text) t)
         ;; Insert each message with dimmed style.  Suppress inline image

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -2693,69 +2693,18 @@ otherwise (the process filter may run in any buffer, so don't rely on
                 (add-text-properties found (1+ found)
                                      (list 'clatter-reactions new-reactions))))))))))
 
-(defun clatter--history-bar-rule-char (&optional window)
-  "Return a one-column rule character for WINDOW's frame.
-TTY fonts often draw ─ two cells wide; ASCII - stays one column."
-  (if (display-graphic-p (and window (window-frame window)))
-      ?─
-    ?-))
-
-(defun clatter--history-bar-window-width (window)
-  "Return the max columns a history bar can occupy in WINDOW."
-  (max 20
-       (cond
-        ((not (window-live-p window)) 72)
-        ((fboundp 'window-max-chars-per-line)
-         (window-max-chars-per-line window))
-        (t (window-body-width window)))))
-
-(defun clatter--history-bar-string (label width &optional rule-char)
-  "Return a WIDTH-wide rule with LABEL centered."
-  (let* ((rule-char (or rule-char (clatter--history-bar-rule-char)))
-         (label (concat " " label " "))
-         (width (max 20 width))
-         (room (max 0 (- width (string-width label))))
-         (left (/ room 2))
-         (right (- room left)))
-    (propertize (concat (make-string left rule-char)
-                        label
-                        (make-string right rule-char))
-                'face 'clatter-history-divider)))
-
 (defun clatter--history-bar (label)
-  "Return a placeholder line for a history bar labeled LABEL."
-  (propertize label 'clatter-history-bar-label label))
-
-(defun clatter--history-bar-refresh (buffer)
-  "Rebuild history-bar overlays in BUFFER for each window showing it."
-  (when (buffer-live-p buffer)
-    (with-current-buffer buffer
-      (remove-overlays (point-min) (point-max) 'clatter-history-bar t)
-      (let ((windows (or (get-buffer-window-list buffer nil t) (list nil))))
-        (save-excursion
-          (goto-char (point-min))
-          (while (not (eobp))
-            (when-let* ((label (get-text-property (point) 'clatter-history-bar-label))
-                        (eol (line-end-position)))
-              (dolist (win windows)
-                (let ((ov (make-overlay (point) eol))
-                      (width (clatter--history-bar-window-width win)))
-                  (overlay-put ov 'clatter-history-bar t)
-                  (overlay-put ov 'evaporate t)
-                  (when win (overlay-put ov 'window win))
-                  (overlay-put ov 'display
-                               (clatter--history-bar-string
-                                label width
-                                (clatter--history-bar-rule-char win))))))
-            (forward-line 1)))))))
-
-(defun clatter--history-bar-on-size (frame)
-  "Refresh history bars after FRAME's windows change size."
-  (dolist (win (window-list frame 'no-minibuffer))
-    (let ((buf (window-buffer win)))
-      (when (and (buffer-live-p buf)
-                 (with-current-buffer buf (derived-mode-p 'clatter-mode)))
-        (clatter--history-bar-refresh buf)))))
+  "Return a window-wide divider line with LABEL centered.
+The rule segments are stretch glyphs drawn with `:strike-through', so
+redisplay recenters and resizes the bar with each window - same
+mechanism as `clatter-read-marker-line', no overlays or size hooks."
+  (let ((rule '(:inherit clatter-history-divider :strike-through t))
+        (label (concat " " label " ")))
+    (concat
+     (propertize " " 'face rule
+                 'display `(space :align-to (- center ,(/ (string-width label) 2))))
+     (propertize label 'face 'clatter-history-divider)
+     (propertize " " 'face rule 'display '(space :align-to right)))))
 
 (defun clatter-ui--on-batch-complete (conn _batch-type target messages)
   "Handle completed batch: render MESSAGES for TARGET on CONN.
@@ -2806,10 +2755,7 @@ on screen, so it renders at the buffer's oldest end, in the direction
                 ('action (clatter-insert-action buf sender text conn time invisible))
                 (_ (clatter-insert-privmsg buf sender text conn time invisible))))))
         ;; Insert end separator
-        (clatter--insert-message buf (if backlog sep-text end-sep-text) t)
-        (clatter--history-bar-refresh buf)
-        (add-hook 'window-size-change-functions
-                  #'clatter--history-bar-on-size)))))
+        (clatter--insert-message buf (if backlog sep-text end-sep-text) t)))))
 
 ;; --- CTCP replies ---
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -38,6 +38,11 @@
   "Face for message timestamps."
   :group 'clatter)
 
+(defface clatter-history-divider
+  '((t :inherit shadow))
+  "Face for history divider rows."
+  :group 'clatter)
+
 (defface clatter-nick
   '((t :weight bold))
   "Default face for nicks."
@@ -2688,6 +2693,70 @@ otherwise (the process filter may run in any buffer, so don't rely on
                 (add-text-properties found (1+ found)
                                      (list 'clatter-reactions new-reactions))))))))))
 
+(defun clatter--history-bar-rule-char (&optional window)
+  "Return a one-column rule character for WINDOW's frame.
+TTY fonts often draw ─ two cells wide; ASCII - stays one column."
+  (if (display-graphic-p (and window (window-frame window)))
+      ?─
+    ?-))
+
+(defun clatter--history-bar-window-width (window)
+  "Return the max columns a history bar can occupy in WINDOW."
+  (max 20
+       (cond
+        ((not (window-live-p window)) 72)
+        ((fboundp 'window-max-chars-per-line)
+         (window-max-chars-per-line window))
+        (t (window-body-width window)))))
+
+(defun clatter--history-bar-string (label width &optional rule-char)
+  "Return a WIDTH-wide rule with LABEL centered."
+  (let* ((rule-char (or rule-char (clatter--history-bar-rule-char)))
+         (label (concat " " label " "))
+         (width (max 20 width))
+         (room (max 0 (- width (string-width label))))
+         (left (/ room 2))
+         (right (- room left)))
+    (propertize (concat (make-string left rule-char)
+                        label
+                        (make-string right rule-char))
+                'face 'clatter-history-divider)))
+
+(defun clatter--history-bar (label)
+  "Return a placeholder line for a history bar labeled LABEL."
+  (propertize label 'clatter-history-bar-label label))
+
+(defun clatter--history-bar-refresh (buffer)
+  "Rebuild history-bar overlays in BUFFER for each window showing it."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (remove-overlays (point-min) (point-max) 'clatter-history-bar t)
+      (let ((windows (or (get-buffer-window-list buffer nil t) (list nil))))
+        (save-excursion
+          (goto-char (point-min))
+          (while (not (eobp))
+            (when-let* ((label (get-text-property (point) 'clatter-history-bar-label))
+                        (eol (line-end-position)))
+              (dolist (win windows)
+                (let ((ov (make-overlay (point) eol))
+                      (width (clatter--history-bar-window-width win)))
+                  (overlay-put ov 'clatter-history-bar t)
+                  (overlay-put ov 'evaporate t)
+                  (when win (overlay-put ov 'window win))
+                  (overlay-put ov 'display
+                               (clatter--history-bar-string
+                                label width
+                                (clatter--history-bar-rule-char win))))))
+            (forward-line 1)))))))
+
+(defun clatter--history-bar-on-size (frame)
+  "Refresh history bars after FRAME's windows change size."
+  (dolist (win (window-list frame 'no-minibuffer))
+    (let ((buf (window-buffer win)))
+      (when (and (buffer-live-p buf)
+                 (with-current-buffer buf (derived-mode-p 'clatter-mode)))
+        (clatter--history-bar-refresh buf)))))
+
 (defun clatter-ui--on-batch-complete (conn _batch-type target messages)
   "Handle completed batch: render MESSAGES for TARGET on CONN.
 Renders a visual separator before and after history playback.
@@ -2708,15 +2777,9 @@ on screen, so it renders at the buffer's oldest end, in the direction
              ;; end separator, then messages newest-first, then the start
              ;; separator.
              (messages (if backlog (reverse messages) messages))
-             (sep-text (propertize
-                        (concat " " (make-string 30 ?-) " history "
-                                (make-string 30 ?-) " ")
-                        'face 'font-lock-doc-face))
-             (end-sep-text (propertize (format " %s end of history (%d messages) %s "
-                                               (make-string 20 ?-)
-                                               count
-                                               (make-string 20 ?-))
-                                       'face 'font-lock-doc-face)))
+             (sep-text (clatter--history-bar "history"))
+             (end-sep-text (clatter--history-bar
+                            (format "end of history (%d messages)" count))))
         (clatter--insert-message buf (if backlog end-sep-text sep-text) t)
         ;; Insert each message with dimmed style.  Suppress inline image
         ;; scanning/fetching for history playback: a large backlog would
@@ -2743,7 +2806,10 @@ on screen, so it renders at the buffer's oldest end, in the direction
                 ('action (clatter-insert-action buf sender text conn time invisible))
                 (_ (clatter-insert-privmsg buf sender text conn time invisible))))))
         ;; Insert end separator
-        (clatter--insert-message buf (if backlog sep-text end-sep-text) t)))))
+        (clatter--insert-message buf (if backlog sep-text end-sep-text) t)
+        (clatter--history-bar-refresh buf)
+        (add-hook 'window-size-change-functions
+                  #'clatter--history-bar-on-size)))))
 
 ;; --- CTCP replies ---
 

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -2545,10 +2545,10 @@ server buffer otherwise (e.g. the connect-time MOTD)."
                   (clatter-get-server-buffer network)
                   (clatter-get-or-create-buffer network "*server*" 'server))))
     (clatter-ui-setup-buffer-if-needed buf)
-    (clatter-insert-system buf "--- MOTD ---")
+    (clatter--insert-message buf (clatter--divider "MOTD") t)
     (dolist (line lines)
       (clatter-insert-system buf (clatter-hl-urls-in-string (clatter-format-parse line)) nil))
-    (clatter-insert-system buf "--- End of MOTD ---")))
+    (clatter--insert-message buf (clatter--divider "End of MOTD") t)))
 
 (defun clatter-ui--on-whois (conn nick data)
   "Handle WHOIS reply for UI: display NICK info from DATA.

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -1648,6 +1648,12 @@ Both message orders keep the page's own messages in display order."
         (when (buffer-live-p buf)
           (kill-buffer buf))))))
 
+(ert-deftest clatter-test-history-bar-string-matches-width ()
+  "The painted rule is exactly WIDTH columns, label included."
+  (let ((bar (clatter--history-bar-string "history" 40)))
+    (should (= 40 (string-width bar)))
+    (should (string-match-p "history" bar))))
+
 ;; --- Typing indicators ---
 
 (ert-deftest clatter-test-typing-location-default-keeps-mode-line-layout ()

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -1648,11 +1648,14 @@ Both message orders keep the page's own messages in display order."
         (when (buffer-live-p buf)
           (kill-buffer buf))))))
 
-(ert-deftest clatter-test-history-bar-string-matches-width ()
-  "The painted rule is exactly WIDTH columns, label included."
-  (let ((bar (clatter--history-bar-string "history" 40)))
-    (should (= 40 (string-width bar)))
-    (should (string-match-p "history" bar))))
+(ert-deftest clatter-test-history-bar-stretches-to-window ()
+  "The bar centers its label and fills the window via display specs."
+  (let ((bar (clatter--history-bar "history")))
+    (should (string-match-p "history" bar))
+    (should (equal '(space :align-to right)
+                   (get-text-property (1- (length bar)) 'display bar)))
+    (should (pcase (get-text-property 0 'display bar)
+              (`(space :align-to (- center ,(pred integerp))) t)))))
 
 ;; --- Typing indicators ---
 

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -1648,9 +1648,9 @@ Both message orders keep the page's own messages in display order."
         (when (buffer-live-p buf)
           (kill-buffer buf))))))
 
-(ert-deftest clatter-test-history-bar-stretches-to-window ()
+(ert-deftest clatter-test-divider-stretches-to-window ()
   "The bar centers its label and fills the window via display specs."
-  (let ((bar (clatter--history-bar "history")))
+  (let ((bar (clatter--divider "history")))
     (should (string-match-p "history" bar))
     (should (equal '(space :align-to right)
                    (get-text-property (1- (length bar)) 'display bar)))

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -1657,6 +1657,17 @@ Both message orders keep the page's own messages in display order."
     (should (pcase (get-text-property 0 'display bar)
               (`(space :align-to (- center ,(pred integerp))) t)))))
 
+(ert-deftest clatter-test-motd-uses-window-dividers ()
+  "MOTD boundaries use window-wide dividers."
+  (clatter-test-with-ui-connection conn
+    (let (labels)
+      (cl-letf (((symbol-function 'clatter--divider)
+                 (lambda (label)
+                   (push label labels)
+                   label)))
+        (clatter-ui--on-motd conn '("Welcome")))
+      (should (equal (nreverse labels) '("MOTD" "End of MOTD"))))))
+
 ;; --- Typing indicators ---
 
 (ert-deftest clatter-test-typing-location-default-keeps-mode-line-layout ()


### PR DESCRIPTION
<img width="1440" height="538" alt="20260827T070101--screenshot-shared__" src="https://github.com/user-attachments/assets/c02a316e-016d-4ef3-9704-d132db035030" />

I'm glad you asked @trev; Smooth overlay bars that has dynamic width (instead of dashes): 

CHATHISTORY/batch playback separators are now window-wide divider lines with the label centered, replacing the fixed-width `----- history -----` strings.

The divider is built from stretch glyphs (`:align-to` display specs) with `:strike-through`, the same mechanism as `clatter-read-marker-line`, so redisplay recenters and resizes it per window — no overlays, width math, or resize hooks. The helper is generic (`clatter--divider`, face `clatter-divider`); history playback is just its first caller.

- New face `clatter-divider` (inherits `shadow`)
- GUIDE example updated to match the rendered output
- Test asserts the display specs that center and fill the line

On terminals without strike-through support the rule degrades to a centered dim label, same trade-off as the read-marker line.