### PR TITLE
feat(ui): inline and divider timestamp sides

### DIFF
--- a/GUIDE.org
+++ b/GUIDE.org
@@ -662,7 +662,7 @@ legitimate second client.
 | =clatter-message-order=              | ='newest-first= | Input at top with messages below, or =oldest-first=              |
 | =clatter-timestamp-format=           | ="%H:%M"=       | Timestamp format string                                          |
 | =clatter-timestamp-side=             | ='right=        | =left=/=right= margin, =inline= overlay, =divider= row, or =nil= |
-| =clatter-timestamp-divider-interval= | =1=             | Minutes between =divider= rows                                   |
+| =clatter-timestamp-interval=         | =1=             | Minutes between time marks, all sides                            |
 | =clatter-timestamp-only-if-changed=  | =nil=           | Show a timestamp only when it differs from the previous          |
 | =clatter-fill-column=                | =80=            | Wrap column; =auto= derives it from the window, =nil= disables   |
 | =clatter-sender-format=              | ="<%nick>"=     | Sender prefix; =%nick= is the nickname                           |

--- a/GUIDE.org
+++ b/GUIDE.org
@@ -661,7 +661,8 @@ legitimate second client.
 |--------------------------------+----------------+------------------------------------------------------------|
 | =clatter-message-order=          | ='newest-first= | Input at top with messages below, or =oldest-first=          |
 | =clatter-timestamp-format=       | ="%H:%M"=        | Timestamp format string                                    |
-| =clatter-timestamp-side=         | ='right=        | Margin for timestamps: =left=, =right=, or =nil= to disable      |
+| =clatter-timestamp-side=         | ='right=        | =left=/=right= margin, =divider= minute row, or =nil=            |
+| =clatter-timestamp-divider-interval= | =1=        | Minutes between =divider= rows                               |
 | =clatter-timestamp-only-if-changed= | =nil=       | Show a timestamp only when it differs from the previous    |
 | =clatter-fill-column=            | =80=             | Wrap column; =auto= derives it from the window, =nil= disables |
 | =clatter-sender-format=          | ="<%nick>"=      | Sender prefix; =%nick= is the nickname                       |

--- a/GUIDE.org
+++ b/GUIDE.org
@@ -657,27 +657,27 @@ legitimate second client.
 
 ** Display
 
-| Variable                       | Default        | Description                                                |
-|--------------------------------+----------------+------------------------------------------------------------|
-| =clatter-message-order=          | ='newest-first= | Input at top with messages below, or =oldest-first=          |
-| =clatter-timestamp-format=       | ="%H:%M"=        | Timestamp format string                                    |
-| =clatter-timestamp-side=         | ='right=        | =left=/=right= margin, =divider= minute row, or =nil=            |
-| =clatter-timestamp-divider-interval= | =1=        | Minutes between =divider= rows                               |
-| =clatter-timestamp-only-if-changed= | =nil=       | Show a timestamp only when it differs from the previous    |
-| =clatter-fill-column=            | =80=             | Wrap column; =auto= derives it from the window, =nil= disables |
-| =clatter-sender-format=          | ="<%nick>"=      | Sender prefix; =%nick= is the nickname                       |
-| =clatter-nick-column-width=      | =20=             | Width of the right-aligned nick column                     |
-| =clatter-nick-column-truncate=   | =nil=            | When =t=, clip nicks longer than the column to =<nick…>=  |
-| =clatter-buffer-max-lines=       | =10000=          | Truncate a buffer past this many lines                     |
-| =clatter-buffer-name-style=      | ='full=         | =full=, =network= or =channel= buffer naming                     |
-| =clatter-header-line-preset=     | =nil=            | =topic= or =context= moves channel info to the header line     |
-| =clatter-prompt-format=          | ="%t> "=         | =%t= target, =%n= nick, =%N= network; or a function              |
-| =clatter-prompt-alignment=       | =nil=            | =right= aligns the prompt with the nick column               |
-| =clatter-away-indicator=         | ="@"=            | Marker appended to your nick while away                    |
-| =clatter-bot-label=              | ="[bot]"=        | Label on messages from nicks with bot mode                 |
-| =clatter-display-on-join=        | =t=              | Show the channel buffer when you join                      |
-| =clatter-display-on-welcome=     | =t=              | Show the server buffer after the welcome numeric           |
-| =clatter-receive-query-display=  | ='bury=         | Incoming DM buffers: =bury=, =buffer= or =pop=                   |
+| Variable                             | Default         | Description                                                      |
+|--------------------------------------+-----------------+------------------------------------------------------------------|
+| =clatter-message-order=              | ='newest-first= | Input at top with messages below, or =oldest-first=              |
+| =clatter-timestamp-format=           | ="%H:%M"=       | Timestamp format string                                          |
+| =clatter-timestamp-side=             | ='right=        | =left=/=right= margin, =inline= overlay, =divider= row, or =nil= |
+| =clatter-timestamp-divider-interval= | =1=             | Minutes between =divider= rows                                   |
+| =clatter-timestamp-only-if-changed=  | =nil=           | Show a timestamp only when it differs from the previous          |
+| =clatter-fill-column=                | =80=            | Wrap column; =auto= derives it from the window, =nil= disables   |
+| =clatter-sender-format=              | ="<%nick>"=     | Sender prefix; =%nick= is the nickname                           |
+| =clatter-nick-column-width=          | =20=            | Width of the right-aligned nick column                           |
+| =clatter-nick-column-truncate=       | =nil=           | When =t=, clip nicks longer than the column to =<nick…>=         |
+| =clatter-buffer-max-lines=           | =10000=         | Truncate a buffer past this many lines                           |
+| =clatter-buffer-name-style=          | ='full=         | =full=, =network= or =channel= buffer naming                     |
+| =clatter-header-line-preset=         | =nil=           | =topic= or =context= moves channel info to the header line       |
+| =clatter-prompt-format=              | ="%t> "=        | =%t= target, =%n= nick, =%N= network; or a function              |
+| =clatter-prompt-alignment=           | =nil=           | =right= aligns the prompt with the nick column                   |
+| =clatter-away-indicator=             | ="@"=           | Marker appended to your nick while away                          |
+| =clatter-bot-label=                  | ="[bot]"=       | Label on messages from nicks with bot mode                       |
+| =clatter-display-on-join=            | =t=             | Show the channel buffer when you join                            |
+| =clatter-display-on-welcome=         | =t=             | Show the server buffer after the welcome numeric                 |
+| =clatter-receive-query-display=      | ='bury=         | Incoming DM buffers: =bury=, =buffer= or =pop=                   |
 
 *** Compact system messages
 

--- a/GUIDE.org
+++ b/GUIDE.org
@@ -684,12 +684,12 @@ legitimate second client.
 Presence and moderation events can be collapsed into terse glyph runs instead
 of one line each:
 
-| Variable                             | Default | Description                                           |
-|--------------------------------------+---------+-------------------------------------------------------|
-| =clatter-compact-system-messages=      | =nil=     | =nil=, =compact=, =essential=, =reasons= or =full=              |
-| =clatter-compact-system-group-window=  | =180=     | Seconds within which events group together            |
-| =clatter-compact-system-separator=     | =" · "=   | Separator between grouped events                      |
-| =clatter-compact-system-symbols=       | (glyphs) | Per-event glyphs: join =→=, part =←=, quit =×=, nick =»=, ... |
+| Variable                              | Default  | Description                                                   |
+|---------------------------------------+----------+---------------------------------------------------------------|
+| =clatter-compact-system-messages=     | =nil=    | =nil=, =compact=, =essential=, =reasons= or =full=            |
+| =clatter-compact-system-group-window= | =180=    | Seconds within which events group together                    |
+| =clatter-compact-system-separator=    | =" · "=  | Separator between grouped events                              |
+| =clatter-compact-system-symbols=      | (glyphs) | Per-event glyphs: join =→=, part =←=, quit =×=, nick =»=, ... |
 
 *** Sender prefix format
 
@@ -710,11 +710,11 @@ format supplies, so a long nick becomes =[longnic…]= or =longnic…:=.
 Consecutive PRIVMSGs from the same nick can share a single nick prefix
 instead of repeating it on every line:
 
-| Variable                        | Default | Description                                                |
-|---------------------------------+---------+------------------------------------------------------------|
-| =clatter-group-messages-by-nick=  | =nil=     | Collapse the nick column on same-nick bursts               |
-| =clatter-group-messages-window=   | =300=     | Seconds within which same-nick lines group; =nil= for adjacency only |
-| =clatter-group-messages-gap=      | =nil=     | Extra spacing between groups: pixels (integer) or line-height multiple (float) |
+| Variable                         | Default | Description                                                                    |
+|----------------------------------+---------+--------------------------------------------------------------------------------|
+| =clatter-group-messages-by-nick= | =nil=   | Collapse the nick column on same-nick bursts                                   |
+| =clatter-group-messages-window=  | =300=   | Seconds within which same-nick lines group; =nil= for adjacency only           |
+| =clatter-group-messages-gap=     | =nil=   | Extra spacing between groups: pixels (integer) or line-height multiple (float) |
 
 Only the chronologically-first message of a burst shows the nick; later
 same-nick PRIVMSGs within the window render a blank column that still
@@ -762,14 +762,14 @@ notifications, and =clatter-typing-timeout= still controls incoming expiry.
 
 ** Message Suppression and Filtering
 
-| Variable                  | Default   | Description                                                     |
-|---------------------------+-----------+-----------------------------------------------------------------|
-| =clatter-suppress-messages= | =(muted)=   | Types hidden in new buffers: join part quit nick mode away kick topic |
-| =clatter-ignore-list=       | =nil=       | Ignored nick or hostmask patterns; glob =*= and =?=                 |
-| =clatter-pals=              | =nil=       | Nicks highlighted as pals                                       |
-| =clatter-fools=             | =nil=       | Nicks dimmed and hidden                                         |
-| =clatter-fools-visible=     | =nil=       | Show fool messages dimmed instead of hidden                     |
-| =clatter-mention-p-function= | =clatter-nick-match-p= | Whole-word or substring mention matching             |
+| Variable                     | Default                | Description                                                           |
+|------------------------------+------------------------+-----------------------------------------------------------------------|
+| =clatter-suppress-messages=  | =(muted)=              | Types hidden in new buffers: join part quit nick mode away kick topic |
+| =clatter-ignore-list=        | =nil=                  | Ignored nick or hostmask patterns; glob =*= and =?=                   |
+| =clatter-pals=               | =nil=                  | Nicks highlighted as pals                                             |
+| =clatter-fools=              | =nil=                  | Nicks dimmed and hidden                                               |
+| =clatter-fools-visible=      | =nil=                  | Show fool messages dimmed instead of hidden                           |
+| =clatter-mention-p-function= | =clatter-nick-match-p= | Whole-word or substring mention matching                              |
 
 Suppression is non-destructive: matching messages are still inserted, just
 hidden, so =/unsuppress= reveals the history you missed.
@@ -780,15 +780,15 @@ hidden, so =/unsuppress= reveals the history you missed.
 
 ** Nick Highlighting
 
-| Variable                        | Default   | Description                              |
-|---------------------------------+-----------+------------------------------------------|
-| =clatter-hl-nicks-enabled=        | =t=         | Colorize nicks in message text           |
-| =clatter-hl-nicks-minimum-length= | =3=         | Shortest nick eligible for colorization  |
-| =clatter-hl-nicks-skip-nicks=     | =nil=       | Nicks never colorized                    |
+| Variable                          | Default   | Description                              |
+|-----------------------------------+-----------+------------------------------------------|
+| =clatter-hl-nicks-enabled=        | =t=       | Colorize nicks in message text           |
+| =clatter-hl-nicks-minimum-length= | =3=       | Shortest nick eligible for colorization  |
+| =clatter-hl-nicks-skip-nicks=     | =nil=     | Nicks never colorized                    |
 | =clatter-hl-nicks-skip-faces=     | (3 faces) | Faces exempt from in-text highlighting   |
-| =clatter-hl-nicks-alias-alist=    | =nil=       | Map alternate nicks to a canonical color |
+| =clatter-hl-nicks-alias-alist=    | =nil=     | Map alternate nicks to a canonical color |
 | =clatter-hl-nick-base-faces=      | 12 faces  | Palette nicks inherit from               |
-| =clatter-hl-keywords=             | =nil=       | Extra words highlighted in message text  |
+| =clatter-hl-keywords=             | =nil=     | Extra words highlighted in message text  |
 
 Nick colors are derived from the active theme rather than hardcoded: each nick
 hashes deterministically onto one of the =font-lock-*= faces in
@@ -799,20 +799,20 @@ argument to refresh faces already in use).
 
 ** Activity Tracking
 
-| Variable                       | Default        | Description                                    |
-|--------------------------------+----------------+------------------------------------------------|
-| =clatter-track-enabled=          | =t=              | Show activity in the global mode line          |
-| =clatter-track-position=         | ='after-modes=  | Placement within the mode line                 |
-| =clatter-track-muted-channels=   | =nil=            | Targets dimmed but still tracked               |
-| =clatter-track-exclude-targets=  | =nil=            | Targets hidden from every tracker surface      |
-| =clatter-track-shorten=          | =nil=            | =nil=, an integer N, =drop-vowels= or =syllable= channel shortening |
-| =clatter-track-show-counts=      | =t=              | Show unread counts                             |
-| =clatter-track-count-style=      | ='suffix=       | =suffix=, =superscript=, =subscript=, =glyph=, =none=    |
-| =clatter-track-indicators=       | =@= / =*= / (none) | Prefix glyph for mention / DM / activity       |
-| =clatter-track-faces-alist=      | (4 faces)      | Face per activity type                         |
-| =clatter-track-show-in-clatter-buffers= | =nil=       | Also show crumbs in each clatter buffer        |
-| =clatter-track-global-mode-line= | =t=          | Append crumbs to the global mode line (set =nil= with a custom modeline) |
-| =clatter-track-switch-return-to-origin= | =t=    | =clatter-track-switch= returns to the start buffer when exhausted |
+| Variable                                | Default            | Description                                                              |
+|-----------------------------------------+--------------------+--------------------------------------------------------------------------|
+| =clatter-track-enabled=                 | =t=                | Show activity in the global mode line                                    |
+| =clatter-track-position=                | ='after-modes=     | Placement within the mode line                                           |
+| =clatter-track-muted-channels=          | =nil=              | Targets dimmed but still tracked                                         |
+| =clatter-track-exclude-targets=         | =nil=              | Targets hidden from every tracker surface                                |
+| =clatter-track-shorten=                 | =nil=              | =nil=, an integer N, =drop-vowels= or =syllable= channel shortening      |
+| =clatter-track-show-counts=             | =t=                | Show unread counts                                                       |
+| =clatter-track-count-style=             | ='suffix=          | =suffix=, =superscript=, =subscript=, =glyph=, =none=                    |
+| =clatter-track-indicators=              | =@= / =*= / (none) | Prefix glyph for mention / DM / activity                                 |
+| =clatter-track-faces-alist=             | (4 faces)          | Face per activity type                                                   |
+| =clatter-track-show-in-clatter-buffers= | =nil=              | Also show crumbs in each clatter buffer                                  |
+| =clatter-track-global-mode-line=        | =t=                | Append crumbs to the global mode line (set =nil= with a custom modeline) |
+| =clatter-track-switch-return-to-origin= | =t=                | =clatter-track-switch= returns to the start buffer when exhausted        |
 
 To embed the indicator in a custom mode line (for example a
 =doom-modeline= segment), set =clatter-track-global-mode-line= to =nil= so
@@ -844,26 +844,26 @@ switching from.
 
 ** Notifications
 
-| Variable                      | Default   | Description                          |
-|-------------------------------+-----------+--------------------------------------|
-| =clatter-notify-enabled=        | =t=         | Enable desktop notifications         |
-| =clatter-notify-on-mention=     | =t=         | Notify on nick mentions              |
-| =clatter-notify-on-dm=          | =t=         | Notify on direct messages            |
-| =clatter-notify-on-invite=      | =t=         | Notify on channel invitations        |
-| =clatter-notify-on-keyword=     | =t=         | Notify on keyword matches            |
-| =clatter-notify-keywords=       | =nil=       | Extra keywords to notify on          |
-| =clatter-notify-muted-channels= | =nil=       | Channels that never notify           |
-| =clatter-notify-muted-nicks=    | =nil=       | Nick patterns that never notify      |
-| =clatter-notify-current-buffer= | =nil=       | Notify even for the visible buffer   |
-| =clatter-notify-echo-area=      | =nil=       | Echo-area fallback when native delivery fails |
-| =clatter-notify-timeout=        | =5000=      | Notification timeout (ms)            |
-| =clatter-notify-icon=           | =nil=       | Path to a notification icon          |
-| =clatter-notify-urgency=        | ='normal=  | =low=, =normal= or =critical=              |
-| =clatter-notify-sound=          | =nil=       | Sound file                           |
-| =clatter-notify-max-length=     | =80=        | Max message length in a notification |
-| =clatter-notify-cooldown=       | =3=         | Min seconds between notifications per source |
-| =clatter-notify-dm-priority=    | ='always=  | =always=, =rules= or =never=               |
-| =clatter-notify-rules=          | =nil=       | Per-target rules (see below)         |
+| Variable                        | Default   | Description                                   |
+|---------------------------------+-----------+-----------------------------------------------|
+| =clatter-notify-enabled=        | =t=       | Enable desktop notifications                  |
+| =clatter-notify-on-mention=     | =t=       | Notify on nick mentions                       |
+| =clatter-notify-on-dm=          | =t=       | Notify on direct messages                     |
+| =clatter-notify-on-invite=      | =t=       | Notify on channel invitations                 |
+| =clatter-notify-on-keyword=     | =t=       | Notify on keyword matches                     |
+| =clatter-notify-keywords=       | =nil=     | Extra keywords to notify on                   |
+| =clatter-notify-muted-channels= | =nil=     | Channels that never notify                    |
+| =clatter-notify-muted-nicks=    | =nil=     | Nick patterns that never notify               |
+| =clatter-notify-current-buffer= | =nil=     | Notify even for the visible buffer            |
+| =clatter-notify-echo-area=      | =nil=     | Echo-area fallback when native delivery fails |
+| =clatter-notify-timeout=        | =5000=    | Notification timeout (ms)                     |
+| =clatter-notify-icon=           | =nil=     | Path to a notification icon                   |
+| =clatter-notify-urgency=        | ='normal= | =low=, =normal= or =critical=                 |
+| =clatter-notify-sound=          | =nil=     | Sound file                                    |
+| =clatter-notify-max-length=     | =80=      | Max message length in a notification          |
+| =clatter-notify-cooldown=       | =3=       | Min seconds between notifications per source  |
+| =clatter-notify-dm-priority=    | ='always= | =always=, =rules= or =never=                  |
+| =clatter-notify-rules=          | =nil=     | Per-target rules (see below)                  |
 
 Delivery uses Emacs-native notifications (D-Bus, Android, Haiku or Windows),
 falling back to =terminal-notifier= on macOS. Failure is silent unless
@@ -891,8 +891,8 @@ default) means DMs notify regardless, =rules= makes them follow per-target rules
 
 ** Logging
 
-| Variable                     | Default                  | Description                  |
-|------------------------------+--------------------------+------------------------------|
+| Variable                       | Default                    | Description                  |
+|--------------------------------+----------------------------+------------------------------|
 | =clatter-log-enable=           | =nil=                      | Enable channel logging       |
 | =clatter-log-directory=        | =~/.emacs.d/clatter/logs/= | Log file directory           |
 | =clatter-log-rotate-daily=     | =t=                        | Daily log rotation           |
@@ -918,24 +918,24 @@ these files existing.
 
 ** Search
 
-| Variable                     | Default | Description                  |
-|------------------------------+---------+------------------------------|
-| =clatter-search-max-results=   | =500=     | Max search results           |
-| =clatter-search-context-lines= | =0=       | Context lines around matches |
+| Variable                       | Default | Description                  |
+|--------------------------------+---------+------------------------------|
+| =clatter-search-max-results=   | =500=   | Max search results           |
+| =clatter-search-context-lines= | =0=     | Context lines around matches |
 
 ** Chat History and Read Markers
 
-| Variable                         | Default | Description                                |
-|----------------------------------+---------+--------------------------------------------|
-| =clatter-chathistory-enabled=      | =t=       | Enable IRCv3 CHATHISTORY                   |
-| =clatter-chathistory-limit=        | =50=      | Messages fetched per request               |
-| =clatter-chathistory-on-join=      | =t=       | Fetch on channel join                      |
-| =clatter-chathistory-on-reconnect= | =t=       | Fetch the gap on reconnect                 |
-| =clatter-read-marker-enabled=      | =t=       | Sync read position with the server         |
-| =clatter-read-marker-auto-send=    | =t=       | Send MARKREAD when switching to a buffer   |
-| =clatter-read-state-enabled=       | =t=       | Local last-read fallback for bouncers      |
-| =clatter-read-state-file=          | =~/.emacs.d/clatter/read-state.el= | Where local read state lives |
-| =clatter-read-state-save-delay=    | =2=       | Debounce seconds for read-state writes     |
+| Variable                           | Default                            | Description                              |
+|------------------------------------+------------------------------------+------------------------------------------|
+| =clatter-chathistory-enabled=      | =t=                                | Enable IRCv3 CHATHISTORY                 |
+| =clatter-chathistory-limit=        | =50=                               | Messages fetched per request             |
+| =clatter-chathistory-on-join=      | =t=                                | Fetch on channel join                    |
+| =clatter-chathistory-on-reconnect= | =t=                                | Fetch the gap on reconnect               |
+| =clatter-read-marker-enabled=      | =t=                                | Sync read position with the server       |
+| =clatter-read-marker-auto-send=    | =t=                                | Send MARKREAD when switching to a buffer |
+| =clatter-read-state-enabled=       | =t=                                | Local last-read fallback for bouncers    |
+| =clatter-read-state-file=          | =~/.emacs.d/clatter/read-state.el= | Where local read state lives             |
+| =clatter-read-state-save-delay=    | =2=                                | Debounce seconds for read-state writes   |
 
 =M-x clatter-chathistory-more= fetches older messages;
 =M-x clatter-read-marker-mark= and =M-x clatter-read-marker-query= drive the
@@ -954,9 +954,9 @@ renders with separators:
 
 ** Nick Completion
 
-| Variable                     | Default | Description                            |
-|------------------------------+---------+----------------------------------------|
-| =clatter-completion-add-colon= | =t=       | Append =:= after a nick at start of line |
+| Variable                       | Default | Description                              |
+|--------------------------------+---------+------------------------------------------|
+| =clatter-completion-add-colon= | =t=     | Append =:= after a nick at start of line |
 
 Completion is a standard CAPF, so it works with corfu, vertico and orderless.
 It completes nicks, =/commands= and =#channels=; annotations show channel prefix
@@ -964,27 +964,27 @@ for nicks and a description for commands.
 
 ** Nick List Sidebar
 
-| Variable               | Default  | Description                |
-|------------------------+----------+----------------------------|
-| =clatter-nicklist-width= | =20=       | Sidebar width              |
-| =clatter-nicklist-side=  | ='right=  | Which side (left or right) |
+| Variable                 | Default  | Description                |
+|--------------------------+----------+----------------------------|
+| =clatter-nicklist-width= | =20=     | Sidebar width              |
+| =clatter-nicklist-side=  | ='right= | Which side (left or right) |
 
 Toggle per buffer with =M-x clatter-nicklist-toggle=.
 
 ** mIRC Formatting
 
-| Variable                  | Default | Description                       |
-|---------------------------+---------+-----------------------------------|
-| =clatter-format-enable=     | =t=       | Parse mIRC color/formatting codes |
-| =clatter-format-strip-only= | =nil=     | Strip codes without rendering     |
+| Variable                    | Default | Description                       |
+|-----------------------------+---------+-----------------------------------|
+| =clatter-format-enable=     | =t=     | Parse mIRC color/formatting codes |
+| =clatter-format-strip-only= | =nil=   | Strip codes without rendering     |
 
 ** URL Preview
 
-| Variable                             | Default    | Description                  |
-|--------------------------------------+------------+------------------------------|
-| =clatter-url-preview-enable=           | =nil=        | Fetch and display URL titles |
-| =clatter-url-preview-max-length=       | =200=        | Max title length             |
-| =clatter-url-preview-timeout=          | =10=         | Fetch timeout (seconds)      |
+| Variable                               | Default    | Description                  |
+|----------------------------------------+------------+------------------------------|
+| =clatter-url-preview-enable=           | =nil=      | Fetch and display URL titles |
+| =clatter-url-preview-max-length=       | =200=      | Max title length             |
+| =clatter-url-preview-timeout=          | =10=       | Fetch timeout (seconds)      |
 | =clatter-url-preview-exclude-patterns= | 15 regexps | Binary/media URLs to skip    |
 
 Titles are cached, so a repeated link is not re-fetched. Requires =curl=.
@@ -994,13 +994,13 @@ internal-network hosts.
 
 ** Inline Images
 
-| Variable                 | Default         | Description                  |
-|--------------------------+-----------------+------------------------------|
-| =clatter-image-enable=     | =nil=             | Enable inline image previews |
-| =clatter-image-max-width=  | =400=             | Max image width (pixels)     |
-| =clatter-image-max-height= | =300=             | Max image height (pixels)    |
-| =clatter-image-max-size=   | =5242880= (5 MB)  | Max download size            |
-| =clatter-image-extensions= | =(png jpg ...)=   | Recognized image extensions  |
+| Variable                   | Default          | Description                  |
+|----------------------------+------------------+------------------------------|
+| =clatter-image-enable=     | =nil=            | Enable inline image previews |
+| =clatter-image-max-width=  | =400=            | Max image width (pixels)     |
+| =clatter-image-max-height= | =300=            | Max image height (pixels)    |
+| =clatter-image-max-size=   | =5242880= (5 MB) | Max download size            |
+| =clatter-image-extensions= | =(png jpg ...)=  | Recognized image extensions  |
 
 GUI frames only; a no-op in a terminal. Fetching is an async =curl= subprocess
 with the same scheme and redirect restrictions as URL preview, plus a magic-byte
@@ -1008,21 +1008,21 @@ check on the downloaded data.
 
 ** Raw Protocol Log
 
-| Variable                   | Default | Description                       |
-|----------------------------+---------+-----------------------------------|
-| =clatter-rawlog-enabled=     | =nil=     | Enable rawlog buffers             |
-| =clatter-rawlog-max-lines=   | =5000=    | Max lines per rawlog buffer       |
-| =clatter-rawlog-show-parsed= | =t=       | Show the parsed message breakdown |
-| =clatter-log-raw-protocol=   | =nil=     | Log raw lines to =*clatter-debug*=  |
+| Variable                     | Default | Description                        |
+|------------------------------+---------+------------------------------------|
+| =clatter-rawlog-enabled=     | =nil=   | Enable rawlog buffers              |
+| =clatter-rawlog-max-lines=   | =5000=  | Max lines per rawlog buffer        |
+| =clatter-rawlog-show-parsed= | =t=     | Show the parsed message breakdown  |
+| =clatter-log-raw-protocol=   | =nil=   | Log raw lines to =*clatter-debug*= |
 
 ** DCC File Transfer
 
-| Variable                       | Default        | Description                               |
-|--------------------------------+----------------+-------------------------------------------|
-| =clatter-dcc-download-directory= | =~/Downloads/=   | Where received files are saved            |
-| =clatter-dcc-auto-accept=        | =nil=            | Auto-accept incoming offers               |
-| =clatter-dcc-max-file-size=      | =0=              | Max accepted size in bytes; =0= = unlimited |
-| =clatter-dcc-progress-interval=  | =2=              | Seconds between progress updates          |
+| Variable                         | Default        | Description                                 |
+|----------------------------------+----------------+---------------------------------------------|
+| =clatter-dcc-download-directory= | =~/Downloads/= | Where received files are saved              |
+| =clatter-dcc-auto-accept=        | =nil=          | Auto-accept incoming offers                 |
+| =clatter-dcc-max-file-size=      | =0=            | Max accepted size in bytes; =0= = unlimited |
+| =clatter-dcc-progress-interval=  | =2=            | Seconds between progress updates            |
 
 These live in their own customize group, =clatter-dcc=.
 
@@ -1041,40 +1041,40 @@ The *Enabled by* column distinguishes three cases - loaded and always active,
 loaded but gated by an option that =clatter-setup= consults, and needing an
 explicit call from your configuration.
 
-| Module                   | What it does                                  | Enabled by                          |
-|--------------------------+-----------------------------------------------+-------------------------------------|
-| =clatter.el=               | Entry points, autoloads, =clatter-setup=        | always                              |
-| =clatter-config.el=        | User options, auth-source lookup              | always                              |
-| =clatter-protocol.el=      | IRC message parsing and formatting            | always                              |
-| =clatter-connection.el=    | TCP/TLS, reconnect, health pings              | always                              |
-| =clatter-socks.el=         | SOCKS5 / Tor proxy                            | =:proxy= / =:tor= per network           |
-| =clatter-cap.el=           | CAP negotiation and SASL                      | always                              |
-| =clatter-sasl-scram.el=    | SASL SCRAM-SHA-256 (RFC 5802)                 | =:sasl scram-sha-256=                 |
-| =clatter-sts.el=           | IRCv3 Strict Transport Security               | =clatter-sts-enable= (on)             |
-| =clatter-handlers.el=      | Message dispatch and hooks                    | always                              |
-| =clatter-model.el=         | Buffer registry, channel and nick state       | always                              |
-| =clatter-ui.el=            | Rendering, faces, mode line, input            | always                              |
-| =clatter-commands.el=      | Slash commands                                | always                              |
-| =clatter-completion.el=    | Completion at point                           | always                              |
-| =clatter-actions.el=       | Message action menu                           | always                              |
-| =clatter-hl-nicks.el=      | Nick colorization, keywords, URL links        | =clatter-hl-nicks-enabled= (on)       |
-| =clatter-format.el=        | mIRC color and formatting codes               | =clatter-format-enable= (on)          |
-| =clatter-smart.el=         | Adaptive noise filtering                      | =clatter-smart-enabled= (on)          |
-| =clatter-pals.el=          | Pals, fools and visibility                    | =clatter-pals= / =clatter-fools=        |
-| =clatter-nicklist.el=      | Channel member sidebar                        | =clatter-nicklist-toggle=             |
-| =clatter-list.el=          | Channel list browser                          | =/list=                               |
-| =clatter-track.el=         | Mode-line activity tracking                   | =clatter-track-enabled= (on)          |
-| =clatter-notify.el=        | Desktop notifications                         | =clatter-notify-enabled= (on)         |
-| =clatter-chathistory.el=   | IRCv3 CHATHISTORY backlog                     | =clatter-chathistory-enabled= (on)    |
-| =clatter-read-marker.el=   | IRCv3 read markers                            | =clatter-read-marker-enabled= (on)    |
-| =clatter-soju.el=          | soju bouncer network fan-out                  | =clatter-soju-enabled= (on) + =:bouncer= |
-| =clatter-log.el=           | Channel logging with daily rotation           | =clatter-log-enable= (off)            |
-| =clatter-url-preview.el=   | Async URL title preview                       | =clatter-url-preview-enable= (off)    |
-| =clatter-rawlog.el=        | Raw protocol inspector                        | =clatter-rawlog-enabled= (off)        |
-| =clatter-search.el=        | Full-text search across logs                  | =/search= (loaded on demand)          |
-| =clatter-image.el=         | Inline image preview (GUI only)               | =(require 'clatter-image)= + =clatter-image-enable= |
-| =clatter-dcc.el=           | DCC file transfer                             | =(clatter-dcc-setup)=                 |
-| =clatter-org.el=           | Org links, capture, log export                | =(clatter-org-setup)=                 |
+| Module                   | What it does                             | Enabled by                                          |
+|--------------------------+------------------------------------------+-----------------------------------------------------|
+| =clatter.el=             | Entry points, autoloads, =clatter-setup= | always                                              |
+| =clatter-config.el=      | User options, auth-source lookup         | always                                              |
+| =clatter-protocol.el=    | IRC message parsing and formatting       | always                                              |
+| =clatter-connection.el=  | TCP/TLS, reconnect, health pings         | always                                              |
+| =clatter-socks.el=       | SOCKS5 / Tor proxy                       | =:proxy= / =:tor= per network                       |
+| =clatter-cap.el=         | CAP negotiation and SASL                 | always                                              |
+| =clatter-sasl-scram.el=  | SASL SCRAM-SHA-256 (RFC 5802)            | =:sasl scram-sha-256=                               |
+| =clatter-sts.el=         | IRCv3 Strict Transport Security          | =clatter-sts-enable= (on)                           |
+| =clatter-handlers.el=    | Message dispatch and hooks               | always                                              |
+| =clatter-model.el=       | Buffer registry, channel and nick state  | always                                              |
+| =clatter-ui.el=          | Rendering, faces, mode line, input       | always                                              |
+| =clatter-commands.el=    | Slash commands                           | always                                              |
+| =clatter-completion.el=  | Completion at point                      | always                                              |
+| =clatter-actions.el=     | Message action menu                      | always                                              |
+| =clatter-hl-nicks.el=    | Nick colorization, keywords, URL links   | =clatter-hl-nicks-enabled= (on)                     |
+| =clatter-format.el=      | mIRC color and formatting codes          | =clatter-format-enable= (on)                        |
+| =clatter-smart.el=       | Adaptive noise filtering                 | =clatter-smart-enabled= (on)                        |
+| =clatter-pals.el=        | Pals, fools and visibility               | =clatter-pals= / =clatter-fools=                    |
+| =clatter-nicklist.el=    | Channel member sidebar                   | =clatter-nicklist-toggle=                           |
+| =clatter-list.el=        | Channel list browser                     | =/list=                                             |
+| =clatter-track.el=       | Mode-line activity tracking              | =clatter-track-enabled= (on)                        |
+| =clatter-notify.el=      | Desktop notifications                    | =clatter-notify-enabled= (on)                       |
+| =clatter-chathistory.el= | IRCv3 CHATHISTORY backlog                | =clatter-chathistory-enabled= (on)                  |
+| =clatter-read-marker.el= | IRCv3 read markers                       | =clatter-read-marker-enabled= (on)                  |
+| =clatter-soju.el=        | soju bouncer network fan-out             | =clatter-soju-enabled= (on) + =:bouncer=            |
+| =clatter-log.el=         | Channel logging with daily rotation      | =clatter-log-enable= (off)                          |
+| =clatter-url-preview.el= | Async URL title preview                  | =clatter-url-preview-enable= (off)                  |
+| =clatter-rawlog.el=      | Raw protocol inspector                   | =clatter-rawlog-enabled= (off)                      |
+| =clatter-search.el=      | Full-text search across logs             | =/search= (loaded on demand)                        |
+| =clatter-image.el=       | Inline image preview (GUI only)          | =(require 'clatter-image)= + =clatter-image-enable= |
+| =clatter-dcc.el=         | DCC file transfer                        | =(clatter-dcc-setup)=                               |
+| =clatter-org.el=         | Org links, capture, log export           | =(clatter-org-setup)=                               |
 
 The on-by-default extras can also be toggled at runtime with their
 =clatter-FEATURE-enable= / =clatter-FEATURE-disable= commands.

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -198,9 +198,9 @@ can notify you without disrupting the current window.  `buffer' uses
   "Where message timestamps are displayed.
 `left' and `right' use a window margin.  `inline' right-aligns an overlay
 at the end of the message line with no reserved margin.  `divider'
-inserts a minute row before spoken messages (PRIVMSG/action) when the
-formatted time changes; system lines never create a row, and two rows
-are never adjacent.  A new buffer opens with a divider at its creation
+inserts a minute row before any line a margin would stamp when the
+clock bucket changes; the row hides and shows with the line that
+opened it, and two rows are never adjacent.  A new buffer opens with a divider at its creation
 time, so a quiet buffer still shows when it started.  nil disables
 timestamps."
   :type '(choice (const :tag "Left margin" left)
@@ -212,7 +212,7 @@ timestamps."
 
 (defcustom clatter-timestamp-divider-interval 1
   "Minutes between `divider' timestamp rows.
-A spoken message opens a new row only when this many minutes have
+A message opens a new row only when this many minutes have
 ticked on the clock since the last row in that buffer.  Values below
 1 are treated as 1.  Unused unless `clatter-timestamp-side' is `divider'."
   :type 'integer

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -200,7 +200,9 @@ can notify you without disrupting the current window.  `buffer' uses
 at the end of the message line with no reserved margin.  `divider'
 inserts a minute row before spoken messages (PRIVMSG/action) when the
 formatted time changes; system lines never create a row, and two rows
-are never adjacent.  nil disables timestamps."
+are never adjacent.  A new buffer opens with a divider at its creation
+time, so a quiet buffer still shows when it started.  nil disables
+timestamps."
   :type '(choice (const :tag "Left margin" left)
                  (const :tag "Right margin" right)
                  (const :tag "Right-aligned overlay" inline)
@@ -208,9 +210,6 @@ are never adjacent.  nil disables timestamps."
                  (const :tag "Disabled" nil))
   :group 'clatter)
 
-;; TODO: when divider-interval is set, always start with a divider at
-;; the current time so a quiet buffer is not timestamp-less until the
-;; next bucket.
 (defcustom clatter-timestamp-divider-interval 1
   "Minutes between `divider' timestamp rows.
 A spoken message opens a new row only when this many minutes have

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -200,9 +200,9 @@ can notify you without disrupting the current window.  `buffer' uses
 at the end of the message line with no reserved margin.  `divider'
 inserts a minute row before any line a margin would stamp when the
 clock bucket changes; the row hides and shows with the line that
-opened it, and two rows are never adjacent.  A new buffer opens with a divider at its creation
-time, so a quiet buffer still shows when it started.  nil disables
-timestamps."
+opened it, and two rows are never adjacent.  A new buffer opens with a
+divider at its creation time, so a quiet buffer still shows when it
+started.  nil disables timestamps."
   :type '(choice (const :tag "Left margin" left)
                  (const :tag "Right margin" right)
                  (const :tag "Right-aligned overlay" inline)
@@ -210,11 +210,14 @@ timestamps."
                  (const :tag "Disabled" nil))
   :group 'clatter)
 
-(defcustom clatter-timestamp-divider-interval 1
-  "Minutes between `divider' timestamp rows.
-A message opens a new row only when this many minutes have
-ticked on the clock since the last row in that buffer.  Values below
-1 are treated as 1.  Unused unless `clatter-timestamp-side' is `divider'."
+(defcustom clatter-timestamp-interval 1
+  "Minutes between time marks, for every `clatter-timestamp-side'.
+A new mark appears only when this many minutes have ticked on the
+clock since the last one in that buffer: `divider' opens rows this
+often, and the margin and `inline' sides coalesce their stamps to the
+same buckets when `clatter-timestamp-only-if-changed' is non-nil.
+At 1, marks follow the formatted timestamp value.  Values below 1 are
+treated as 1."
   :type 'integer
   :group 'clatter)
 

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -196,16 +196,21 @@ can notify you without disrupting the current window.  `buffer' uses
 
 (defcustom clatter-timestamp-side 'right
   "Where message timestamps are displayed.
-`left' and `right' use a window margin.  `divider' inserts a minute
-row before spoken messages (PRIVMSG/action) when the formatted time
-changes; system lines never create a row, and two rows are never
-adjacent.  nil disables timestamps."
+`left' and `right' use a window margin.  `inline' right-aligns an overlay
+at the end of the message line with no reserved margin.  `divider'
+inserts a minute row before spoken messages (PRIVMSG/action) when the
+formatted time changes; system lines never create a row, and two rows
+are never adjacent.  nil disables timestamps."
   :type '(choice (const :tag "Left margin" left)
                  (const :tag "Right margin" right)
+                 (const :tag "Right-aligned overlay" inline)
                  (const :tag "Minute divider row" divider)
                  (const :tag "Disabled" nil))
   :group 'clatter)
 
+;; TODO: when divider-interval is set, always start with a divider at
+;; the current time so a quiet buffer is not timestamp-less until the
+;; next bucket.
 (defcustom clatter-timestamp-divider-interval 1
   "Minutes between `divider' timestamp rows.
 A spoken message opens a new row only when this many minutes have

--- a/clatter-config.el
+++ b/clatter-config.el
@@ -195,12 +195,23 @@ can notify you without disrupting the current window.  `buffer' uses
   :group 'clatter)
 
 (defcustom clatter-timestamp-side 'right
-  "Side of the window where message timestamps are displayed.
-The value `left' uses the left margin, `right' uses the right margin,
-and nil disables margin timestamps."
+  "Where message timestamps are displayed.
+`left' and `right' use a window margin.  `divider' inserts a minute
+row before spoken messages (PRIVMSG/action) when the formatted time
+changes; system lines never create a row, and two rows are never
+adjacent.  nil disables timestamps."
   :type '(choice (const :tag "Left margin" left)
                  (const :tag "Right margin" right)
+                 (const :tag "Minute divider row" divider)
                  (const :tag "Disabled" nil))
+  :group 'clatter)
+
+(defcustom clatter-timestamp-divider-interval 1
+  "Minutes between `divider' timestamp rows.
+A spoken message opens a new row only when this many minutes have
+ticked on the clock since the last row in that buffer.  Values below
+1 are treated as 1.  Unused unless `clatter-timestamp-side' is `divider'."
+  :type 'integer
   :group 'clatter)
 
 (defcustom clatter-self-echo-mode 'server

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -614,6 +614,14 @@ approach in `erc-update-undo-list'."
             (setcdr cons (+ (cdr cons) shift)))))
         (setq list (cdr list))))))
 
+(defun clatter--body-width (&optional buffer)
+  "Return the body width of a window showing BUFFER, else the frame width.
+The frame fallback keeps headless and temp-buffer contexts working."
+  (if-let* ((win (car (get-buffer-window-list (or buffer (current-buffer))
+                                              nil 'visible))))
+      (window-body-width win)
+    (frame-width)))
+
 (defun clatter--effective-fill-column (&optional buffer)
   "Return the column at which to hard-wrap inserted message text.
 When `clatter-fill-column' is an integer, return it.  When it is the
@@ -629,10 +637,8 @@ column is too narrow to wrap past the nick indent."
     (pcase clatter-fill-column
       ('nil nil)
       ('auto
-       (let* ((buf (or buffer (current-buffer)))
-              (win (car (get-buffer-window-list buf nil 'visible)))
-              (raw (if win (window-body-width win) (frame-width)))
-              (col (min raw (or clatter-max-line-length 400))))
+       (let ((col (min (clatter--body-width buffer)
+                       (or clatter-max-line-length 400))))
          (when (> col floor-col) col)))
       (col (when (and (integerp col) (> col floor-col)) col)))))
 
@@ -640,11 +646,57 @@ column is too narrow to wrap past the nick indent."
   "Return non-nil when timestamps use a window margin."
   (memq clatter-timestamp-side '(left right)))
 
+(defun clatter--timestamp-overlay-p ()
+  "Return non-nil when timestamps use a per-message overlay."
+  (memq clatter-timestamp-side '(left right inline)))
+
+(defun clatter--timestamp-spoken-p (msg-props invisible)
+  "Return non-nil when this insert is a visible PRIVMSG or action."
+  (and (not invisible)
+       (memq (plist-get msg-props 'clatter-msg-type) '(privmsg action))))
+
+;; `:align-to' runs before word-wrap, so leftover space on the last
+;; visual row can't be used.  Decided at insert time — stale after a
+;; window resize until the line is rewritten.
+(defun clatter--timestamp-inline-break-p (eol ts-str)
+  "Return non-nil when the line ending at EOL leaves no room for TS-STR."
+  (save-excursion
+    (goto-char eol)
+    (> (current-column)
+       (- (clatter--body-width) (string-width ts-str) 1))))
+
+(defun clatter--timestamp-overlay-apply (ov ts-str &optional tooltip)
+  "Attach the timestamp string for TS-STR to OV for the current side.
+TOOLTIP, when non-nil, becomes the stamp's `help-echo'."
+  (let ((stamp (propertize ts-str
+                           'face '(clatter-timestamp default)
+                           'help-echo tooltip)))
+    (if (eq clatter-timestamp-side 'inline)
+        ;; Stamp sits on the message's last row; one that doesn't fit is
+        ;; dropped.  No fresh-row fallback: an overlay-string row has no
+        ;; buffer position of its own, so point can't land on it and
+        ;; vertical motion gets trapped.
+        (overlay-put ov 'before-string
+                     (unless (clatter--timestamp-inline-break-p
+                              (overlay-start ov) ts-str)
+                       (concat (propertize
+                                " " 'display
+                                `(space :align-to
+                                        (- right ,(string-width ts-str))))
+                               stamp)))
+      ;; Apply 'default face after 'clatter-timestamp so no unwanted face
+      ;; properties are inherited from text which might be at point.
+      (overlay-put ov 'before-string
+                   (propertize " " 'display
+                               `((margin ,(if (eq clatter-timestamp-side 'left)
+                                              'left-margin
+                                            'right-margin))
+                                 ,stamp))))))
+
 (defun clatter--timestamp-divider-spoken-p (msg-props invisible)
   "Return non-nil when this insert can own a minute-divider row."
   (and (eq clatter-timestamp-side 'divider)
-       (not invisible)
-       (memq (plist-get msg-props 'clatter-msg-type) '(privmsg action))))
+       (clatter--timestamp-spoken-p msg-props invisible)))
 
 (defun clatter--timestamp-divider-key (time)
   "Return the divider bucket key for TIME.
@@ -684,11 +736,9 @@ append at the bottom like a traditional IRC client."
                       (format-time-string clatter-timestamp-format time)))
                    (spoken-div-p
                     (clatter--timestamp-divider-spoken-p msg-props invisible))
-                   ;; Coalescing key: the formatted value rather than the raw
-                   ;; time, so formats without seconds coalesce correctly and
-                   ;; each buffer keeps its own timestamp run.  Divider mode
-                   ;; only keys spoken lines, so joins/parts cannot open a
-                   ;; new minute row.
+                   ;; Key on the formatted value so formats without seconds
+                   ;; coalesce.  Divider mode keys only spoken lines, so
+                   ;; joins/parts cannot open a minute row.
                    (ts-key (and formatted-timestamp
                                 (if (eq clatter-timestamp-side 'divider)
                                     (and spoken-div-p
@@ -697,14 +747,18 @@ append at the bottom like a traditional IRC client."
                    (ts-changed-p
                     (not (equal ts-key clatter--last-timestamp-key)))
                    (ts-str (and formatted-timestamp
-                                (clatter--timestamp-margin-p)
+                                ;; Margin modes stamp every line; inline
+                                ;; stamps only spoken ones.
+                                (if (eq clatter-timestamp-side 'inline)
+                                    (clatter--timestamp-spoken-p msg-props invisible)
+                                  (clatter--timestamp-margin-p))
                                 (or (not clatter-timestamp-only-if-changed)
                                     ts-changed-p)
                                 formatted-timestamp))
                    (ts-tooltip-str
-                    (unless no-timestamp
-                      (when clatter-timestamp-tooltip-format
-                        (format-time-string clatter-timestamp-tooltip-format time))))
+                    (and (not no-timestamp)
+                         clatter-timestamp-tooltip-format
+                         (format-time-string clatter-timestamp-tooltip-format time)))
                    (wrap-col (1+ clatter-nick-column-width))
                    (wrap-prefix (make-string wrap-col ?\s))
                    (line-props (list 'read-only t
@@ -734,18 +788,12 @@ append at the bottom like a traditional IRC client."
                         (adaptive-fill-mode nil))
                     (fill-region start (1- (point))))))
               (when ts-str
-                (let ((ov (make-overlay start (1+ start) nil t)))
-                  (overlay-put ov 'before-string
-                               ;; Apply 'default face after 'clatter-timestamp to ensure that no
-                               ;; unwanted face properties are inherited from text which might be
-                               ;; at point.
-                               (propertize " " 'display
-                                           `((margin ,(if (eq clatter-timestamp-side 'left)
-                                                          'left-margin
-                                                        'right-margin))
-                                             ,(propertize ts-str
-                                                          'face '(clatter-timestamp default)
-                                                          'help-echo ts-tooltip-str))))
+                (let ((ov (if (eq clatter-timestamp-side 'inline)
+                              ;; Covers the final newline; rear stays put so
+                              ;; a message inserted below can't extend it.
+                              (make-overlay (1- (point)) (point) nil t)
+                            (make-overlay start (1+ start) nil t))))
+                  (clatter--timestamp-overlay-apply ov ts-str ts-tooltip-str)
                   (overlay-put ov 'clatter-timestamp t)
                   (overlay-put ov 'invisible invisible)))
               (add-text-properties start (point) line-props)
@@ -1128,17 +1176,13 @@ identical messages sent close together each reconcile only one local line."
                                            'clatter-text text))
                 (when msgid
                   (put-text-property start end 'clatter-msgid msgid))
-                (when (and server-time (clatter--timestamp-margin-p))
-                  (dolist (overlay (overlays-at start))
+                (when (and server-time (clatter--timestamp-overlay-p))
+                  (dolist (overlay (overlays-in start end))
                     (when (overlay-get overlay 'clatter-timestamp)
-                      (overlay-put overlay 'before-string
-                                   (propertize " " 'display
-                                               `((margin ,(if (eq clatter-timestamp-side 'left)
-                                                              'left-margin
-                                                            'right-margin))
-                                                 ,(propertize
-                                                   (format-time-string clatter-timestamp-format server-time)
-                                                   'face '(clatter-timestamp default))))))))
+                      (clatter--timestamp-overlay-apply
+                       overlay
+                       (format-time-string clatter-timestamp-format
+                                           server-time)))))
                 ;; Do not consume a pending record unless its tentative line
                 ;; still exists.  Buffer truncation may have removed it, in
                 ;; which case the caller must insert the server echo normally.

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -650,11 +650,6 @@ column is too narrow to wrap past the nick indent."
   "Return non-nil when timestamps use a per-message overlay."
   (memq clatter-timestamp-side '(left right inline)))
 
-(defun clatter--timestamp-spoken-p (msg-props invisible)
-  "Return non-nil when this insert is a visible PRIVMSG or action."
-  (and (not invisible)
-       (memq (plist-get msg-props 'clatter-msg-type) '(privmsg action))))
-
 ;; `:align-to' runs before word-wrap, so leftover space on the last
 ;; visual row can't be used.  Decided at insert time — stale after a
 ;; window resize until the line is rewritten.
@@ -710,11 +705,6 @@ rule as at insert time."
           (clatter--timestamp-overlay-apply
            ov ts-str (overlay-get ov 'clatter-timestamp-tooltip)))))))
 
-(defun clatter--timestamp-divider-spoken-p (msg-props invisible)
-  "Return non-nil when this insert can own a minute-divider row."
-  (and (eq clatter-timestamp-side 'divider)
-       (clatter--timestamp-spoken-p msg-props invisible)))
-
 (defun clatter--timestamp-divider-key (time)
   "Return the divider bucket key for TIME.
 Minutes are floored to `clatter-timestamp-divider-interval' so a value
@@ -726,16 +716,20 @@ of 10 yields one row per ten-minute clock mark."
           (* interval (/ (decoded-time-minute dec) interval)))
     (format-time-string clatter-timestamp-format (encode-time dec))))
 
-(defun clatter--timestamp-divider-insert-row (formatted tooltip line-props)
+(defun clatter--timestamp-divider-insert-row (formatted tooltip line-props
+                                                        &optional invisible)
   "Insert a minute-divider row for FORMATTED time at point.
-TOOLTIP becomes the row's help-echo; LINE-PROPS cover the whole row."
+TOOLTIP becomes the row's help-echo; LINE-PROPS cover the whole row.
+INVISIBLE carries the opening line's categories, so the row hides and
+shows with the line that opened it, like a margin stamp would."
   (let ((start (point)))
     (insert (propertize (format "— %s —" formatted)
                         'face 'clatter-timestamp
                         'clatter-timestamp-divider t
                         'help-echo tooltip)
             "\n")
-    (add-text-properties start (point) line-props)))
+    (add-text-properties start (point) line-props)
+    (put-text-property start (point) 'invisible invisible)))
 
 (defun clatter--timestamp-divider-seed (buffer)
   "Insert an opening minute-divider row in BUFFER at the current time.
@@ -788,15 +782,11 @@ append at the bottom like a traditional IRC client."
             (let* ((formatted-timestamp
                     (unless no-timestamp
                       (format-time-string clatter-timestamp-format time)))
-                   (spoken-div-p
-                    (clatter--timestamp-divider-spoken-p msg-props invisible))
                    ;; Key on the formatted value so formats without seconds
-                   ;; coalesce.  Divider mode keys only spoken lines, so
-                   ;; joins/parts cannot open a minute row.
+                   ;; coalesce.
                    (ts-key (and formatted-timestamp
                                 (if (eq clatter-timestamp-side 'divider)
-                                    (and spoken-div-p
-                                         (clatter--timestamp-divider-key time))
+                                    (clatter--timestamp-divider-key time)
                                   formatted-timestamp)))
                    (ts-changed-p
                     (not (equal ts-key clatter--last-timestamp-key)))
@@ -818,9 +808,10 @@ append at the bottom like a traditional IRC client."
                    start)
               (when ts-key
                 (setq clatter--last-timestamp-key ts-key))
-              (when (and spoken-div-p ts-key ts-changed-p)
+              (when (and (eq clatter-timestamp-side 'divider)
+                         ts-key ts-changed-p)
                 (clatter--timestamp-divider-insert-row
-                 formatted-timestamp ts-tooltip-str line-props))
+                 formatted-timestamp ts-tooltip-str line-props invisible))
               (setq start (point))
               (insert text "\n")
               (when message-line-spacing

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -709,6 +709,43 @@ of 10 yields one row per ten-minute clock mark."
           (* interval (/ (decoded-time-minute dec) interval)))
     (format-time-string clatter-timestamp-format (encode-time dec))))
 
+(defun clatter--timestamp-divider-insert-row (formatted tooltip line-props)
+  "Insert a minute-divider row for FORMATTED time at point.
+TOOLTIP becomes the row's help-echo; LINE-PROPS cover the whole row."
+  (let ((start (point)))
+    (insert (propertize (format "— %s —" formatted)
+                        'face 'clatter-timestamp
+                        'clatter-timestamp-divider t
+                        'help-echo tooltip)
+            "\n")
+    (add-text-properties start (point) line-props)))
+
+(defun clatter--timestamp-divider-seed (buffer)
+  "Insert an opening minute-divider row in BUFFER at the current time.
+Without it a quiet buffer shows no time at all until the first spoken
+message.  Seeds `clatter--last-timestamp-key' so a message arriving in
+the same bucket does not open a second, adjacent row."
+  (when (and (eq clatter-timestamp-side 'divider)
+             clatter-timestamp-format)
+    (with-current-buffer buffer
+      (let* ((inhibit-read-only t)
+             (buffer-undo-list t)
+             (time (current-time))
+             (formatted (format-time-string clatter-timestamp-format time))
+             (tooltip (and clatter-timestamp-tooltip-format
+                           (format-time-string
+                            clatter-timestamp-tooltip-format time))))
+        (save-excursion
+          (goto-char (clatter--message-insert-position))
+          (clatter--timestamp-divider-insert-row
+           formatted tooltip
+           (list 'read-only t
+                 'front-sticky t
+                 'wrap-prefix (make-string (1+ clatter-nick-column-width) ?\s)
+                 'line-prefix "")))
+        (setq clatter--last-timestamp-key
+              (clatter--timestamp-divider-key time))))))
+
 (defun clatter--insert-message (buffer text &optional no-timestamp msg-props time invisible message-line-spacing)
   "Insert formatted TEXT into BUFFER.
 Adds timestamp unless NO-TIMESTAMP is non-nil.
@@ -769,13 +806,8 @@ append at the bottom like a traditional IRC client."
               (when ts-key
                 (setq clatter--last-timestamp-key ts-key))
               (when (and spoken-div-p ts-key ts-changed-p)
-                (let ((div-start (point)))
-                  (insert (propertize (format "— %s —" formatted-timestamp)
-                                      'face 'clatter-timestamp
-                                      'clatter-timestamp-divider t
-                                      'help-echo ts-tooltip-str)
-                          "\n")
-                  (add-text-properties div-start (point) line-props)))
+                (clatter--timestamp-divider-insert-row
+                 formatted-timestamp ts-tooltip-str line-props))
               (setq start (point))
               (insert text "\n")
               (when message-line-spacing
@@ -2076,6 +2108,7 @@ connected (the common case) or absent."
     (add-hook 'visible-mode-hook
               #'clatter--refresh-compact-system-layout nil t)
     (clatter--setup-prompt buffer)
+    (clatter--timestamp-divider-seed buffer)
     ;; Add mode-line.  Optionally include the activity crumbs (see
     ;; `clatter-track-show-in-clatter-buffers') so they are visible while
     ;; inside a clatter buffer, not just in the global mode line.

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -28,9 +28,8 @@
 
 (defvar-local clatter--last-timestamp-key nil
   "Coalescing key of the last timestamped message in this buffer.
-The formatted timestamp in margin mode, or the divider bucket from
-`clatter--timestamp-divider-key' when `clatter-timestamp-side' is
-`divider'.")
+The bucket key from `clatter--timestamp-bucket-key', shared by every
+timestamp side.")
 
 ;; Clatter faces inherit from standard theme faces (font-lock-*,
 ;; error, success) rather than hardcoding hex colors, so they stay legible
@@ -705,16 +704,19 @@ rule as at insert time."
           (clatter--timestamp-overlay-apply
            ov ts-str (overlay-get ov 'clatter-timestamp-tooltip)))))))
 
-(defun clatter--timestamp-divider-key (time)
-  "Return the divider bucket key for TIME.
-Minutes are floored to `clatter-timestamp-divider-interval' so a value
-of 10 yields one row per ten-minute clock mark."
-  (let ((interval (max 1 clatter-timestamp-divider-interval))
-        (dec (decode-time time)))
-    (setf (decoded-time-second dec) 0
-          (decoded-time-minute dec)
-          (* interval (/ (decoded-time-minute dec) interval)))
-    (format-time-string clatter-timestamp-format (encode-time dec))))
+(defun clatter--timestamp-bucket-key (time)
+  "Return the coalescing key for TIME, shared by every timestamp side.
+At `clatter-timestamp-interval' 1 this is the formatted timestamp, so
+marks follow the displayed value.  Above 1, minutes are floored to the
+interval: a value of 10 yields one mark per ten-minute clock bucket."
+  (if (<= clatter-timestamp-interval 1)
+      (format-time-string clatter-timestamp-format time)
+    (let ((dec (decode-time time)))
+      (setf (decoded-time-second dec) 0
+            (decoded-time-minute dec)
+            (* clatter-timestamp-interval
+               (/ (decoded-time-minute dec) clatter-timestamp-interval)))
+      (format-time-string clatter-timestamp-format (encode-time dec)))))
 
 (defun clatter--timestamp-divider-insert-row (formatted tooltip line-props
                                                         &optional invisible)
@@ -755,7 +757,7 @@ the same bucket does not open a second, adjacent row."
                  'wrap-prefix (make-string (1+ clatter-nick-column-width) ?\s)
                  'line-prefix "")))
         (setq clatter--last-timestamp-key
-              (clatter--timestamp-divider-key time))))))
+              (clatter--timestamp-bucket-key time))))))
 
 (defun clatter--insert-message (buffer text &optional no-timestamp msg-props time invisible message-line-spacing)
   "Insert formatted TEXT into BUFFER.
@@ -782,12 +784,8 @@ append at the bottom like a traditional IRC client."
             (let* ((formatted-timestamp
                     (unless no-timestamp
                       (format-time-string clatter-timestamp-format time)))
-                   ;; Key on the formatted value so formats without seconds
-                   ;; coalesce.
                    (ts-key (and formatted-timestamp
-                                (if (eq clatter-timestamp-side 'divider)
-                                    (clatter--timestamp-divider-key time)
-                                  formatted-timestamp)))
+                                (clatter--timestamp-bucket-key time)))
                    (ts-changed-p
                     (not (equal ts-key clatter--last-timestamp-key)))
                    (ts-str (and formatted-timestamp

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -26,8 +26,11 @@
 
 ;; --- Faces ---
 
-(defvar-local clatter--last-formatted-timestamp nil
-  "Last formatted message timestamp in the current Clatter buffer.")
+(defvar-local clatter--last-timestamp-key nil
+  "Coalescing key of the last timestamped message in this buffer.
+The formatted timestamp in margin mode, or the divider bucket from
+`clatter--timestamp-divider-key' when `clatter-timestamp-side' is
+`divider'.")
 
 ;; Clatter faces inherit from standard theme faces (font-lock-*,
 ;; error, success) rather than hardcoding hex colors, so they stay legible
@@ -633,6 +636,27 @@ column is too narrow to wrap past the nick indent."
          (when (> col floor-col) col)))
       (col (when (and (integerp col) (> col floor-col)) col)))))
 
+(defun clatter--timestamp-margin-p ()
+  "Return non-nil when timestamps use a window margin."
+  (memq clatter-timestamp-side '(left right)))
+
+(defun clatter--timestamp-divider-spoken-p (msg-props invisible)
+  "Return non-nil when this insert can own a minute-divider row."
+  (and (eq clatter-timestamp-side 'divider)
+       (not invisible)
+       (memq (plist-get msg-props 'clatter-msg-type) '(privmsg action))))
+
+(defun clatter--timestamp-divider-key (time)
+  "Return the divider bucket key for TIME.
+Minutes are floored to `clatter-timestamp-divider-interval' so a value
+of 10 yields one row per ten-minute clock mark."
+  (let ((interval (max 1 clatter-timestamp-divider-interval))
+        (dec (decode-time time)))
+    (setf (decoded-time-second dec) 0
+          (decoded-time-minute dec)
+          (* interval (/ (decoded-time-minute dec) interval)))
+    (format-time-string clatter-timestamp-format (encode-time dec))))
+
 (defun clatter--insert-message (buffer text &optional no-timestamp msg-props time invisible message-line-spacing)
   "Insert formatted TEXT into BUFFER.
 Adds timestamp unless NO-TIMESTAMP is non-nil.
@@ -658,10 +682,24 @@ append at the bottom like a traditional IRC client."
             (let* ((formatted-timestamp
                     (unless no-timestamp
                       (format-time-string clatter-timestamp-format time)))
+                   (spoken-div-p
+                    (clatter--timestamp-divider-spoken-p msg-props invisible))
+                   ;; Coalescing key: the formatted value rather than the raw
+                   ;; time, so formats without seconds coalesce correctly and
+                   ;; each buffer keeps its own timestamp run.  Divider mode
+                   ;; only keys spoken lines, so joins/parts cannot open a
+                   ;; new minute row.
+                   (ts-key (and formatted-timestamp
+                                (if (eq clatter-timestamp-side 'divider)
+                                    (and spoken-div-p
+                                         (clatter--timestamp-divider-key time))
+                                  formatted-timestamp)))
+                   (ts-changed-p
+                    (not (equal ts-key clatter--last-timestamp-key)))
                    (ts-str (and formatted-timestamp
+                                (clatter--timestamp-margin-p)
                                 (or (not clatter-timestamp-only-if-changed)
-                                    (not (equal formatted-timestamp
-                                                clatter--last-formatted-timestamp)))
+                                    ts-changed-p)
                                 formatted-timestamp))
                    (ts-tooltip-str
                     (unless no-timestamp
@@ -669,12 +707,22 @@ append at the bottom like a traditional IRC client."
                         (format-time-string clatter-timestamp-tooltip-format time))))
                    (wrap-col (1+ clatter-nick-column-width))
                    (wrap-prefix (make-string wrap-col ?\s))
-                   (start (point)))
-              ;; Remember the formatted value, rather than the raw time, so
-              ;; formats without seconds coalesce correctly and each buffer
-              ;; keeps its own timestamp run.
-              (when formatted-timestamp
-                (setq clatter--last-formatted-timestamp formatted-timestamp))
+                   (line-props (list 'read-only t
+                                     'front-sticky t
+                                     'wrap-prefix wrap-prefix
+                                     'line-prefix ""))
+                   start)
+              (when ts-key
+                (setq clatter--last-timestamp-key ts-key))
+              (when (and spoken-div-p ts-key ts-changed-p)
+                (let ((div-start (point)))
+                  (insert (propertize (format "— %s —" formatted-timestamp)
+                                      'face 'clatter-timestamp
+                                      'clatter-timestamp-divider t
+                                      'help-echo ts-tooltip-str)
+                          "\n")
+                  (add-text-properties div-start (point) line-props)))
+              (setq start (point))
               (insert text "\n")
               (when message-line-spacing
                 (put-text-property (1- (point)) (point)
@@ -687,25 +735,20 @@ append at the bottom like a traditional IRC client."
                     (fill-region start (1- (point))))))
               (when ts-str
                 (let ((ov (make-overlay start (1+ start) nil t)))
-                  (when clatter-timestamp-side
-                    (overlay-put ov 'before-string
-                                 ;; Apply 'default face after 'clatter-timestamp to ensure that no
-                                 ;; unwanted face properties are inherited from text which might be
-                                 ;; at point.
-                                 (propertize " " 'display
-                                             `((margin ,(if (eq clatter-timestamp-side 'left)
-                                                            'left-margin
-                                                          'right-margin))
-                                               ,(propertize ts-str
-                                                            'face '(clatter-timestamp default)
-                                                            'help-echo ts-tooltip-str)))))
+                  (overlay-put ov 'before-string
+                               ;; Apply 'default face after 'clatter-timestamp to ensure that no
+                               ;; unwanted face properties are inherited from text which might be
+                               ;; at point.
+                               (propertize " " 'display
+                                           `((margin ,(if (eq clatter-timestamp-side 'left)
+                                                          'left-margin
+                                                        'right-margin))
+                                             ,(propertize ts-str
+                                                          'face '(clatter-timestamp default)
+                                                          'help-echo ts-tooltip-str))))
                   (overlay-put ov 'clatter-timestamp t)
                   (overlay-put ov 'invisible invisible)))
-              (add-text-properties start (point)
-                                   (list 'read-only t
-                                         'front-sticky t
-                                         'wrap-prefix wrap-prefix
-                                         'line-prefix ""))
+              (add-text-properties start (point) line-props)
               (when msg-props
                 (add-text-properties start (point) msg-props))
               (when (clatter--fool-invisibility-p invisible)
@@ -1085,7 +1128,7 @@ identical messages sent close together each reconcile only one local line."
                                            'clatter-text text))
                 (when msgid
                   (put-text-property start end 'clatter-msgid msgid))
-                (when server-time
+                (when (and server-time (clatter--timestamp-margin-p))
                   (dolist (overlay (overlays-at start))
                     (when (overlay-get overlay 'clatter-timestamp)
                       (overlay-put overlay 'before-string

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -675,15 +675,19 @@ TOOLTIP, when non-nil, becomes the stamp's `help-echo'."
         ;; Stamp sits on the message's last row; one that doesn't fit is
         ;; dropped.  No fresh-row fallback: an overlay-string row has no
         ;; buffer position of its own, so point can't land on it and
-        ;; vertical motion gets trapped.
-        (overlay-put ov 'before-string
-                     (unless (clatter--timestamp-inline-break-p
-                              (overlay-start ov) ts-str)
-                       (concat (propertize
-                                " " 'display
-                                `(space :align-to
-                                        (- right ,(string-width ts-str))))
-                               stamp)))
+        ;; vertical motion gets trapped.  Keep the raw stamp on the
+        ;; overlay so `clatter--timestamp-inline-refresh-at' can re-fit.
+        (progn
+          (overlay-put ov 'clatter-timestamp-str ts-str)
+          (overlay-put ov 'clatter-timestamp-tooltip tooltip)
+          (overlay-put ov 'before-string
+                       (unless (clatter--timestamp-inline-break-p
+                                (overlay-start ov) ts-str)
+                         (concat (propertize
+                                  " " 'display
+                                  `(space :align-to
+                                     (- right ,(string-width ts-str))))
+                                 stamp))))
       ;; Apply 'default face after 'clatter-timestamp so no unwanted face
       ;; properties are inherited from text which might be at point.
       (overlay-put ov 'before-string
@@ -692,6 +696,19 @@ TOOLTIP, when non-nil, becomes the stamp's `help-echo'."
                                               'left-margin
                                             'right-margin))
                                  ,stamp))))))
+
+(defun clatter--timestamp-inline-refresh-at (eol)
+  "Re-fit the inline stamp on the line ending at EOL.
+Compact system groups change a line after its stamp's fit was decided —
+appends lengthen it, visibility toggles change its displayed width — so
+apply the stamp again: the fit check drops or restores it, the same
+rule as at insert time."
+  (when (eq clatter-timestamp-side 'inline)
+    (dolist (ov (overlays-at eol))
+      (when (overlay-get ov 'clatter-timestamp)
+        (when-let* ((ts-str (overlay-get ov 'clatter-timestamp-str)))
+          (clatter--timestamp-overlay-apply
+           ov ts-str (overlay-get ov 'clatter-timestamp-tooltip)))))))
 
 (defun clatter--timestamp-divider-spoken-p (msg-props invisible)
   "Return non-nil when this insert can own a minute-divider row."
@@ -784,11 +801,7 @@ append at the bottom like a traditional IRC client."
                    (ts-changed-p
                     (not (equal ts-key clatter--last-timestamp-key)))
                    (ts-str (and formatted-timestamp
-                                ;; Margin modes stamp every line; inline
-                                ;; stamps only spoken ones.
-                                (if (eq clatter-timestamp-side 'inline)
-                                    (clatter--timestamp-spoken-p msg-props invisible)
-                                  (clatter--timestamp-margin-p))
+                                (clatter--timestamp-overlay-p)
                                 (or (not clatter-timestamp-only-if-changed)
                                     ts-changed-p)
                                 formatted-timestamp))
@@ -1412,7 +1425,9 @@ shared layout coherent when `buffer-invisibility-spec' changes, notably when
             (when any-visible
               (remove-text-properties group-start first-event-start
                                       '(display nil))))
-          (dolist (overlay (overlays-at group-start))
+          (dolist (overlay (append (overlays-at group-start)
+                                   (and newline-position
+                                        (overlays-at newline-position))))
             (when (overlay-get overlay 'clatter-timestamp)
               (overlay-put
                overlay 'invisible
@@ -1429,6 +1444,8 @@ shared layout coherent when `buffer-invisibility-spec' changes, notably when
                newline-position group-end 'invisible
                (and first-event-start
                     (get-text-property first-event-start 'invisible)))))
+          (when newline-position
+            (clatter--timestamp-inline-refresh-at newline-position))
           (setq position group-end)))
       (clatter--refresh-input-spacers (current-buffer)))))
 
@@ -1531,7 +1548,8 @@ INVISIBLE categories so smart-hidden and visible actions can share a group."
                            'wrap-prefix
                            (make-string (1+ clatter-nick-column-width) ?\s)
                            'line-prefix ""))
-                    (set-marker tail (point))))
+                    (set-marker tail (point))
+                    (clatter--timestamp-inline-refresh-at (point))))
                 (when (and pre-input clatter--input-marker)
                   (clatter--update-undo-list
                    (- (marker-position clatter--input-marker) pre-input)))
@@ -1568,7 +1586,8 @@ INVISIBLE categories so smart-hidden and visible actions can share a group."
                 (put-text-property end (min (1+ end) (point-max))
                                    'invisible
                                    (clatter--compact-system-visibility invisible))
-                (dolist (overlay (overlays-at start))
+                (dolist (overlay (append (overlays-at start)
+                                         (overlays-at end)))
                   (when (overlay-get overlay 'clatter-timestamp)
                     (overlay-put overlay 'invisible invisible)
                     (overlay-put overlay 'clatter-compact-system-invisible
@@ -2883,85 +2902,85 @@ COMMAND is the numeric reply code, PARAMS its parameters on CONN."
         (clatter-insert-system
          query-buf (format "[%s] %s" command (string-join (cdr params) " ")))
         (cl-return-from clatter-ui--on-numeric)))
-  (pcase command
-    ;; --- Informational numerics ---
-    ((or "001" "002" "003" "004" "242" "251" "252" "253" "254" "255"
-         "265" "266")
-     (let* ((network (clatter-connection-network-id conn))
-            (buf (clatter-get-server-buffer network)))
-       (when buf
-         (clatter-insert-system buf (string-join (cdr params) " ")))))
-    ((or "305" "306") ;  RPL_UNAWAY, RPL_NOWAWAY
-     (let* ((network (clatter-connection-network-id conn))
-            (buf (clatter-get-server-buffer network))
-            (msg (string-join (cdr params) " ")))
-       (when buf
-         (clatter-insert-system buf msg))
-       (dolist (buf (clatter-channel-buffers network))
-         (clatter-insert-system buf msg)))
-     (when (clatter--prompt-format-needs-away-p)
-       (clatter--refresh-prompt)))
-    ;; --- MODE numerics ---
-    ("221"   ; RPL_UMODEIS
-     (let* ((network (clatter-connection-network-id conn))
-            (buf (clatter-get-server-buffer network))
-            (nick (nth 0 params))
-            (modes (nth 1 params)))
-       (when buf
-         (clatter-insert-system buf (format "%s is %s" nick modes)))))
-    ("324"   ; RPL_CHANNELMODEIS
-     (let* ((network (clatter-connection-network-id conn))
-            (channel (nth 1 params))
-            (buf (clatter-get-buffer network channel))
-            (modes (nth 2 params)))
-       (when buf
-         (clatter-set-channel-modes buf modes)
-         (clatter-insert-system buf (format "%s is %s" channel modes)))))
-    ("329"   ; RPL_CREATIONTIME
-     (let* ((network (clatter-connection-network-id conn))
-            (channel (nth 1 params))
-            (buf (clatter-get-buffer network channel))
-            (ctime (string-to-number (nth 2 params))))
-       (when buf
-         (clatter-insert-system
-          buf (format "%s was created at %s"
-                      channel (format-time-string "%F %T" ctime))))))
-    ((or "401" "403"  ; ERR_NOSUCHNICK, ERR_NOSUCHCHANNEL
-         "404"        ; ERR_CANNOTSENDTOCHAN
-         "475")       ; ERR_BADCHANNELKEY
-     ;; Route to the buffer named by the reply's target param (a query
-     ;; buffer for 401's nick, a channel buffer for the others), falling
-     ;; back to the server buffer.  Do not use (current-buffer): the
-     ;; process filter may run in any buffer.
-     (let* ((network (clatter-connection-network-id conn))
-            (target (nth 1 params))
-            (buf (or (clatter-get-buffer network target)
-                     (clatter-get-server-buffer network))))
-       (when buf
-         (clatter-insert-system buf (string-join (reverse (cdr params)) " ")))))
-    ("421"                            ; ERR_UNKNOWNCOMMAND
-     ;; The server rejected a command we sent.  If it was TAGMSG, the
-     ;; server (or an upstream behind a bouncer/bridge) ACKed message-tags
-     ;; but does not actually accept TAGMSG; remember that so outbound
-     ;; typing/reaction TAGMSGs stop rather than spamming 421s every
-     ;; keystroke.  Still display the error so the user sees it once.
-     (let ((rejected-cmd (nth 1 params)))
-       (when (string-equal (and rejected-cmd (upcase rejected-cmd)) "TAGMSG")
-         (setf (clatter-connection-tagmsg-rejected conn) t)))
-     (let* ((network (clatter-connection-network-id conn))
-            (buf (clatter-get-server-buffer network)))
-       (when buf
-         (clatter-insert-system
-          buf (format "[%s] %s" command (string-join (cdr params) " "))))))
-    ;; Catch-all: show any unhandled numeric (e.g. 421 ERR_UNKNOWNCOMMAND,
-    ;; 411/412/432/433/461/471-477 ...) in the server buffer instead of
-    ;; silently dropping it.
-    (_
-     (let* ((network (clatter-connection-network-id conn))
-            (buf (clatter-get-server-buffer network)))
-       (when buf
-         (clatter-insert-system
-          buf (format "[%s] %s" command (string-join (cdr params) " "))))))))
+    (pcase command
+      ;; --- Informational numerics ---
+      ((or "001" "002" "003" "004" "242" "251" "252" "253" "254" "255"
+           "265" "266")
+       (let* ((network (clatter-connection-network-id conn))
+              (buf (clatter-get-server-buffer network)))
+         (when buf
+           (clatter-insert-system buf (string-join (cdr params) " ")))))
+      ((or "305" "306") ;  RPL_UNAWAY, RPL_NOWAWAY
+       (let* ((network (clatter-connection-network-id conn))
+              (buf (clatter-get-server-buffer network))
+              (msg (string-join (cdr params) " ")))
+         (when buf
+           (clatter-insert-system buf msg))
+         (dolist (buf (clatter-channel-buffers network))
+           (clatter-insert-system buf msg)))
+       (when (clatter--prompt-format-needs-away-p)
+         (clatter--refresh-prompt)))
+      ;; --- MODE numerics ---
+      ("221"   ; RPL_UMODEIS
+       (let* ((network (clatter-connection-network-id conn))
+              (buf (clatter-get-server-buffer network))
+              (nick (nth 0 params))
+              (modes (nth 1 params)))
+         (when buf
+           (clatter-insert-system buf (format "%s is %s" nick modes)))))
+      ("324"   ; RPL_CHANNELMODEIS
+       (let* ((network (clatter-connection-network-id conn))
+              (channel (nth 1 params))
+              (buf (clatter-get-buffer network channel))
+              (modes (nth 2 params)))
+         (when buf
+           (clatter-set-channel-modes buf modes)
+           (clatter-insert-system buf (format "%s is %s" channel modes)))))
+      ("329"   ; RPL_CREATIONTIME
+       (let* ((network (clatter-connection-network-id conn))
+              (channel (nth 1 params))
+              (buf (clatter-get-buffer network channel))
+              (ctime (string-to-number (nth 2 params))))
+         (when buf
+           (clatter-insert-system
+            buf (format "%s was created at %s"
+                        channel (format-time-string "%F %T" ctime))))))
+      ((or "401" "403"  ; ERR_NOSUCHNICK, ERR_NOSUCHCHANNEL
+           "404"        ; ERR_CANNOTSENDTOCHAN
+           "475")       ; ERR_BADCHANNELKEY
+       ;; Route to the buffer named by the reply's target param (a query
+       ;; buffer for 401's nick, a channel buffer for the others), falling
+       ;; back to the server buffer.  Do not use (current-buffer): the
+       ;; process filter may run in any buffer.
+       (let* ((network (clatter-connection-network-id conn))
+              (target (nth 1 params))
+              (buf (or (clatter-get-buffer network target)
+                       (clatter-get-server-buffer network))))
+         (when buf
+           (clatter-insert-system buf (string-join (reverse (cdr params)) " ")))))
+      ("421"                            ; ERR_UNKNOWNCOMMAND
+       ;; The server rejected a command we sent.  If it was TAGMSG, the
+       ;; server (or an upstream behind a bouncer/bridge) ACKed message-tags
+       ;; but does not actually accept TAGMSG; remember that so outbound
+       ;; typing/reaction TAGMSGs stop rather than spamming 421s every
+       ;; keystroke.  Still display the error so the user sees it once.
+       (let ((rejected-cmd (nth 1 params)))
+         (when (string-equal (and rejected-cmd (upcase rejected-cmd)) "TAGMSG")
+           (setf (clatter-connection-tagmsg-rejected conn) t)))
+       (let* ((network (clatter-connection-network-id conn))
+              (buf (clatter-get-server-buffer network)))
+         (when buf
+           (clatter-insert-system
+            buf (format "[%s] %s" command (string-join (cdr params) " "))))))
+      ;; Catch-all: show any unhandled numeric (e.g. 421 ERR_UNKNOWNCOMMAND,
+      ;; 411/412/432/433/461/471-477 ...) in the server buffer instead of
+      ;; silently dropping it.
+      (_
+       (let* ((network (clatter-connection-network-id conn))
+              (buf (clatter-get-server-buffer network)))
+         (when buf
+           (clatter-insert-system
+            buf (format "[%s] %s" command (string-join (cdr params) " "))))))))
   ) ;; end of pcase / cl-block clatter-ui--on-numeric
 
 ;; --- Channel preview on hover (eldoc) ---

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -644,8 +644,8 @@ always showing fool messages."
       (should (= left-margin-width 0))
       (should (= right-margin-width 0)))))
 
-(ert-deftest clatter-test-timestamp-divider-spoken-only-and-coalesced ()
-  "Minute rows fire once per spoken minute and never for system lines."
+(ert-deftest clatter-test-timestamp-divider-coalesced ()
+  "Minute rows fire once per bucket, never twice in the same bucket."
   (let ((clatter-timestamp-side 'divider)
         (clatter-timestamp-format "%H:%M")
         (clatter-timestamp-only-if-changed nil)
@@ -657,7 +657,6 @@ always showing fool messages."
         (with-temp-buffer
           (clatter-insert-privmsg (current-buffer) "alice" "hi" conn t1)
           (clatter-insert-privmsg (current-buffer) "alice" "again" conn t1b)
-          (clatter-insert-system (current-buffer) "noise")
           (clatter-insert-privmsg (current-buffer) "bob" "yo" conn t2)
           (should (= 2 (length (clatter-test--divider-positions))))
           (should (string-match-p "— 10:12 —" (buffer-string)))
@@ -667,14 +666,34 @@ always showing fool messages."
                             (1+ (line-number-at-pos (nth 0 pos)))))))
       (clatter-test-cleanup))))
 
-(ert-deftest clatter-test-timestamp-divider-skips-silence ()
-  "System traffic alone never inserts a minute row."
+(ert-deftest clatter-test-timestamp-divider-rows-for-system-lines ()
+  "System lines open rows like any stamped line, coalesced per bucket."
   (let ((clatter-timestamp-side 'divider)
-        (clatter-timestamp-format "%H:%M"))
+        (clatter-timestamp-format "%H:%M")
+        (t1 (encode-time 0 12 10 1 1 2026))
+        (t2 (encode-time 10 12 10 1 1 2026)))
     (with-temp-buffer
-      (clatter-insert-system (current-buffer) "join")
-      (clatter-insert-system (current-buffer) "part")
-      (should-not (clatter-test--divider-positions)))))
+      (clatter--insert-message (current-buffer) "*** alice joined" nil nil t1 nil)
+      (clatter--insert-message (current-buffer) "*** bob parted" nil nil t2 nil)
+      (should (= 1 (length (clatter-test--divider-positions))))
+      (should (string-match-p "— 10:12 —" (buffer-string))))))
+
+(ert-deftest clatter-test-timestamp-divider-row-follows-opener-visibility ()
+  "A row inherits its opening line's invisible categories."
+  (let ((clatter-timestamp-side 'divider)
+        (clatter-timestamp-format "%H:%M")
+        (t1 (encode-time 0 12 10 1 1 2026)))
+    (with-temp-buffer
+      (clatter--insert-message (current-buffer) "*** alice joined" nil nil t1 'join)
+      (let ((row (text-property-any (point-min) (point-max)
+                                    'clatter-timestamp-divider t)))
+        (should row)
+        (should (eq 'join (get-text-property row 'invisible)))
+        ;; Hidden with its opener under the default spec; shown once the
+        ;; category is taken out.
+        (should (invisible-p row))
+        (let ((buffer-invisibility-spec '(other)))
+          (should-not (invisible-p row)))))))
 
 (ert-deftest clatter-test-timestamp-divider-respects-interval ()
   "Divider rows fire once per interval-sized clock bucket."

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -663,6 +663,31 @@ always showing fool messages."
           (should (string-match-p "— 10:22 —" (buffer-string))))
       (clatter-test-cleanup))))
 
+(ert-deftest clatter-test-timestamp-divider-seeds-on-setup ()
+  "A new buffer opens with a divider row; same-bucket messages reuse it."
+  (let ((clatter-timestamp-side 'divider)
+        (clatter-timestamp-divider-interval 10)
+        (clatter-timestamp-format "%H:%M")
+        (conn (clatter-test-make-connection))
+        (now (encode-time 0 12 10 1 1 2026))
+        (later (encode-time 0 22 10 1 1 2026)))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-mode)
+          (setq-local clatter--network "testnet")
+          (setq-local clatter--target "#test")
+          (cl-letf (((symbol-function 'current-time) (lambda () now)))
+            (clatter-ui-setup-buffer (current-buffer)))
+          (should (= 1 (length (clatter-test--divider-positions))))
+          (should (string-match-p "— 10:12 —" (buffer-string)))
+          ;; Same bucket: the seeded row is reused, no adjacent duplicate.
+          (clatter-insert-privmsg (current-buffer) "alice" "hi" conn now)
+          (should (= 1 (length (clatter-test--divider-positions))))
+          ;; A later bucket still opens a new row.
+          (clatter-insert-privmsg (current-buffer) "bob" "yo" conn later)
+          (should (= 2 (length (clatter-test--divider-positions)))))
+      (clatter-test-cleanup))))
+
 ;; --- Message filling ---
 
 (ert-deftest clatter-test-insert-message-fills-at-fill-column ()

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -666,6 +666,24 @@ always showing fool messages."
                             (1+ (line-number-at-pos (nth 0 pos)))))))
       (clatter-test-cleanup))))
 
+(ert-deftest clatter-test-timestamp-margin-respects-interval ()
+  "With only-if-changed, margin stamps coalesce to interval buckets too."
+  (let ((clatter-timestamp-side 'right)
+        (clatter-timestamp-only-if-changed t)
+        (clatter-timestamp-interval 10)
+        (clatter-timestamp-format "%H:%M")
+        (conn (clatter-test-make-connection))
+        (t1 (encode-time 0 12 10 1 1 2026))
+        (t2 (encode-time 0 19 10 1 1 2026))
+        (t3 (encode-time 0 22 10 1 1 2026)))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-insert-privmsg (current-buffer) "alice" "a" conn t1)
+          (clatter-insert-privmsg (current-buffer) "alice" "b" conn t2)
+          (clatter-insert-privmsg (current-buffer) "bob" "c" conn t3)
+          (should (= 2 (clatter-test--timestamp-overlay-count))))
+      (clatter-test-cleanup))))
+
 (ert-deftest clatter-test-timestamp-divider-rows-for-system-lines ()
   "System lines open rows like any stamped line, coalesced per bucket."
   (let ((clatter-timestamp-side 'divider)
@@ -698,7 +716,7 @@ always showing fool messages."
 (ert-deftest clatter-test-timestamp-divider-respects-interval ()
   "Divider rows fire once per interval-sized clock bucket."
   (let ((clatter-timestamp-side 'divider)
-        (clatter-timestamp-divider-interval 10)
+        (clatter-timestamp-interval 10)
         (clatter-timestamp-format "%H:%M")
         (conn (clatter-test-make-connection))
         (t1 (encode-time 0 12 10 1 1 2026))
@@ -718,7 +736,7 @@ always showing fool messages."
 (ert-deftest clatter-test-timestamp-divider-seeds-on-setup ()
   "A new buffer opens with a divider row; same-bucket messages reuse it."
   (let ((clatter-timestamp-side 'divider)
-        (clatter-timestamp-divider-interval 10)
+        (clatter-timestamp-interval 10)
         (clatter-timestamp-format "%H:%M")
         (conn (clatter-test-make-connection))
         (now (encode-time 0 12 10 1 1 2026))

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -534,7 +534,76 @@ always showing fool messages."
       (let ((clatter-timestamp-side nil))
         (clatter--sync-window-margins)
         (should-not (car (window-margins)))
+        (should-not (cdr (window-margins))))
+      (let ((clatter-timestamp-side 'divider))
+        (clatter--sync-window-margins)
+        (should-not (car (window-margins)))
         (should-not (cdr (window-margins)))))))
+
+(defun clatter-test--divider-positions ()
+  "Return buffer positions of minute-divider lines."
+  (clatter--navigation-property-positions 'clatter-timestamp-divider))
+
+(ert-deftest clatter-test-timestamp-divider-no-margin ()
+  "Divider timestamps do not reserve a window margin."
+  (let ((clatter-timestamp-side 'divider)
+        (clatter-timestamp-format "%H:%M"))
+    (with-temp-buffer
+      (clatter-mode)
+      (should (= left-margin-width 0))
+      (should (= right-margin-width 0)))))
+
+(ert-deftest clatter-test-timestamp-divider-spoken-only-and-coalesced ()
+  "Minute rows fire once per spoken minute and never for system lines."
+  (let ((clatter-timestamp-side 'divider)
+        (clatter-timestamp-format "%H:%M")
+        (clatter-timestamp-only-if-changed nil)
+        (conn (clatter-test-make-connection))
+        (t1 (encode-time 30 12 10 1 1 2026))
+        (t1b (encode-time 59 12 10 1 1 2026))
+        (t2 (encode-time 0 13 10 1 1 2026)))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-insert-privmsg (current-buffer) "alice" "hi" conn t1)
+          (clatter-insert-privmsg (current-buffer) "alice" "again" conn t1b)
+          (clatter-insert-system (current-buffer) "noise")
+          (clatter-insert-privmsg (current-buffer) "bob" "yo" conn t2)
+          (should (= 2 (length (clatter-test--divider-positions))))
+          (should (string-match-p "— 10:12 —" (buffer-string)))
+          (should (string-match-p "— 10:13 —" (buffer-string)))
+          (let ((pos (clatter-test--divider-positions)))
+            (should-not (eq (line-number-at-pos (nth 1 pos))
+                            (1+ (line-number-at-pos (nth 0 pos)))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-timestamp-divider-skips-silence ()
+  "System traffic alone never inserts a minute row."
+  (let ((clatter-timestamp-side 'divider)
+        (clatter-timestamp-format "%H:%M"))
+    (with-temp-buffer
+      (clatter-insert-system (current-buffer) "join")
+      (clatter-insert-system (current-buffer) "part")
+      (should-not (clatter-test--divider-positions)))))
+
+(ert-deftest clatter-test-timestamp-divider-respects-interval ()
+  "Divider rows fire once per interval-sized clock bucket."
+  (let ((clatter-timestamp-side 'divider)
+        (clatter-timestamp-divider-interval 10)
+        (clatter-timestamp-format "%H:%M")
+        (conn (clatter-test-make-connection))
+        (t1 (encode-time 0 12 10 1 1 2026))
+        (t2 (encode-time 0 19 10 1 1 2026))
+        (t3 (encode-time 0 22 10 1 1 2026)))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-insert-privmsg (current-buffer) "alice" "a" conn t1)
+          (clatter-insert-privmsg (current-buffer) "alice" "b" conn t2)
+          (clatter-insert-privmsg (current-buffer) "bob" "c" conn t3)
+          (should (= 2 (length (clatter-test--divider-positions))))
+          (should (string-match-p "— 10:12 —" (buffer-string)))
+          (should-not (string-match-p "— 10:19 —" (buffer-string)))
+          (should (string-match-p "— 10:22 —" (buffer-string))))
+      (clatter-test-cleanup))))
 
 ;; --- Message filling ---
 

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -590,13 +590,46 @@ always showing fool messages."
             (should-not (overlay-get ov 'after-string))))
       (clatter-test-cleanup))))
 
-(ert-deftest clatter-test-timestamp-inline-skips-system ()
-  "Inline timestamps omit system lines (CTCP, joins, history chrome)."
+(ert-deftest clatter-test-timestamp-inline-stamps-system ()
+  "Inline stamps the same lines margin modes stamp, system included."
   (let ((clatter-timestamp-side 'inline)
+        (clatter-timestamp-only-if-changed nil)
         (clatter-timestamp-format "%H:%M"))
     (with-temp-buffer
       (clatter-insert-system (current-buffer) "CTCP VERSION reply from knighthk")
-      (should (= 0 (clatter-test--timestamp-overlay-count))))))
+      (should (= 1 (clatter-test--timestamp-overlay-count))))))
+
+(ert-deftest clatter-test-timestamp-inline-drops-stamp-on-compact-growth ()
+  "A compact append re-checks the stamp's fit; overflow drops it."
+  (let ((clatter-timestamp-side 'inline)
+        (clatter-timestamp-only-if-changed nil)
+        (clatter-timestamp-format "%H:%M")
+        (clatter-compact-system-messages 'compact)
+        (clatter-compact-system-group-window 180)
+        (times '(100.0 110.0 120.0))
+        (long-nick (make-string (+ (frame-width) 20) ?x)))
+    (clatter-test-with-ui-connection conn
+      (ignore conn)
+      (let ((buffer (clatter-get-or-create-buffer "testnet" "#test")))
+        (cl-letf (((symbol-function 'clatter--compact-system-now)
+                   (lambda () (pop times))))
+          (clatter--insert-system-event
+           buffer 'join '(:nick "alice" :channel "#test") nil)
+          (with-current-buffer buffer
+            (should (overlay-get (clatter-test--timestamp-overlay)
+                                 'before-string)))
+          ;; A short append still fits: the stamp survives.
+          (clatter--insert-system-event
+           buffer 'join '(:nick "bob" :channel "#test") nil)
+          (with-current-buffer buffer
+            (should (overlay-get (clatter-test--timestamp-overlay)
+                                 'before-string)))
+          ;; Growing past the body width drops it, like a long message.
+          (clatter--insert-system-event
+           buffer 'join (list :nick long-nick :channel "#test") nil)
+          (with-current-buffer buffer
+            (should-not (overlay-get (clatter-test--timestamp-overlay)
+                                     'before-string))))))))
 
 (defun clatter-test--divider-positions ()
   "Return buffer positions of minute-divider lines."

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -462,6 +462,11 @@ always showing fool messages."
   (cl-count-if (lambda (overlay) (overlay-get overlay 'clatter-timestamp))
                (overlays-in (point-min) (point-max))))
 
+(defun clatter-test--timestamp-overlay ()
+  "Return the first message timestamp overlay in the current buffer."
+  (cl-find-if (lambda (overlay) (overlay-get overlay 'clatter-timestamp))
+              (overlays-in (point-min) (point-max))))
+
 (ert-deftest clatter-test-timestamps-only-if-changed-coalesces-formatted-values ()
   "Repeated formatted timestamps use one margin timestamp when enabled."
   (let ((clatter-timestamp-only-if-changed t)
@@ -538,7 +543,60 @@ always showing fool messages."
       (let ((clatter-timestamp-side 'divider))
         (clatter--sync-window-margins)
         (should-not (car (window-margins)))
+        (should-not (cdr (window-margins))))
+      (let ((clatter-timestamp-side 'inline))
+        (clatter--sync-window-margins)
+        (should-not (car (window-margins)))
         (should-not (cdr (window-margins)))))))
+
+(ert-deftest clatter-test-timestamp-inline-aligns-to-right ()
+  "Inline timestamps use an after-string aligned to the window edge."
+  (let ((clatter-timestamp-side 'inline)
+        (clatter-timestamp-format "%H:%M")
+        (clatter-timestamp-only-if-changed nil)
+        (conn (clatter-test-make-connection))
+        (time (encode-time 0 12 10 1 1 2026)))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-insert-privmsg (current-buffer) "alice" "hello" conn time)
+          (let ((ov (clatter-test--timestamp-overlay)))
+            (should ov)
+            (should-not (overlay-get ov 'after-string))
+            (let* ((before (overlay-get ov 'before-string))
+                   (display (get-text-property 0 'display before)))
+              (should (string-match-p "10:12" before))
+              (should (eq (car display) 'space))
+              (should (equal (plist-get (cdr display) :align-to) '(- right 5))))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-timestamp-inline-break-when-wrapped ()
+  "A line with no room left for the stamp gets no stamp at all."
+  (let ((clatter-timestamp-side 'inline)
+        (clatter-timestamp-format "%H:%M")
+        (clatter-timestamp-only-if-changed nil)
+        (clatter-fill-column nil)
+        (conn (clatter-test-make-connection))
+        (time (encode-time 0 12 10 1 1 2026))
+        (msg (make-string (+ (frame-width) 50) ?x)))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-insert-privmsg (current-buffer) "alice" msg conn time)
+          (let ((ov (clatter-test--timestamp-overlay)))
+            (should ov)
+            ;; No stamp row of its own: a display-string row is anchored at a
+            ;; position a neighbouring row already owns, so point cannot land
+            ;; on it and vertical motion (evil j/k) gets trapped.
+            (should-not (overlay-get ov 'before-string))
+            (should-not (overlay-get ov 'after-string))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-timestamp-inline-skips-system ()
+  "Inline timestamps omit system lines (CTCP, joins, history chrome)."
+  (let ((clatter-timestamp-side 'inline)
+        (clatter-timestamp-format "%H:%M"))
+    (with-temp-buffer
+      (clatter-insert-system (current-buffer) "CTCP VERSION reply from knighthk")
+      (should (= 0 (clatter-test--timestamp-overlay-count))))))
 
 (defun clatter-test--divider-positions ()
   "Return buffer positions of minute-divider lines."


### PR DESCRIPTION
Two new values for `clatter-timestamp-side` — `inline` and `divider` — for people who find a timestamp margin wasteful. The side decides where a timestamp goes, never whether a line gets one.

**Margin (`left`/`right`), the existing options:**

<img width="2820" height="1628" alt="20260827T073221--screenshot-shared__" src="https://github.com/user-attachments/assets/cf04dc4e-38a7-4f11-885f-1428fc305336" />

**`divider` — no margin; a minute row between messages:**

<img width="2820" height="1628" alt="20260827T073443--screenshot-shared__" src="https://github.com/user-attachments/assets/867ea088-79a7-4f4e-9aaa-87b2f943bf44" />

A row opens before any stamped line when the clock bucket changes; never two
in a row. Rows inherit the invisible categories of their opening line, so
suppressing joins hides their rows too. New buffers start with a divider so a
quiet buffer still shows when it started.

**`inline` — no margin; stamp right-aligned at the end of the message:**

<img width="2820" height="1628" alt="20260827T073122--screenshot-shared__" src="https://github.com/user-attachments/assets/083de1c7-f53c-432d-ab17-919c16bda5c8" />

This is the one I use. An overlay aligned to the window edge with `:align-to`;
redisplay positions it per window. A stamp that doesn't fit is dropped, not
wrapped (the time stays in the tooltip) — I'd rather have a pretty view that
doesn't waste space. Compact system group lines mutate after insert, so
appends and visibility changes re-run the fit check.

`clatter-timestamp-interval` buckets the clock for every side: 10 means one
mark per ten-minute mark, not "10 minutes after the last message". `divider`
always coalesces; margins and `inline` do when
`clatter-timestamp-only-if-changed` is on.

Everything is covered by ERT tests.
