### PR TITLE
fix(ui): keep inline stamps on their line

### DIFF
--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -732,17 +732,18 @@ TOOLTIP, when non-nil, becomes the stamp's `help-echo'."
                            'help-echo tooltip)))
     (overlay-put ov 'help-echo tooltip)
     (if (eq clatter-timestamp-side 'inline)
-        ;; Stamp sits on the message's last row; one that doesn't fit is
-        ;; dropped.  No fresh-row fallback: an overlay-string row has no
-        ;; buffer position of its own, so point can't land on it and
-        ;; vertical motion gets trapped.  Keep the raw stamp on the
-        ;; overlay so `clatter--timestamp-inline-refresh-at' can re-fit.
+        ;; Stamp sits on the message's last row via after-string at the
+        ;; last text char — not the newline, whose before-string wraps
+        ;; onto the next buffer line.  A stamp that doesn't fit is
+        ;; dropped.  Keep the raw stamp on the overlay so
+        ;; `clatter--timestamp-inline-refresh-at' can re-fit.
         (progn
           (overlay-put ov 'clatter-timestamp-str ts-str)
           (overlay-put ov 'clatter-timestamp-tooltip tooltip)
-          (overlay-put ov 'before-string
+          (overlay-put ov 'before-string nil)
+          (overlay-put ov 'after-string
                        (unless (clatter--timestamp-inline-break-p
-                                (overlay-start ov) ts-str)
+                                (overlay-end ov) ts-str)
                          (concat (propertize
                                   " " 'display
                                   `(space :align-to
@@ -764,7 +765,8 @@ appends lengthen it, visibility toggles change its displayed width — so
 apply the stamp again: the fit check drops or restores it, the same
 rule as at insert time."
   (when (eq clatter-timestamp-side 'inline)
-    (dolist (ov (overlays-at eol))
+    (dolist (ov (overlays-in (max (point-min) (1- eol))
+                             (min (point-max) (1+ eol))))
       (when (overlay-get ov 'clatter-timestamp)
         (when-let* ((ts-str (overlay-get ov 'clatter-timestamp-str)))
           (clatter--timestamp-overlay-apply
@@ -898,14 +900,19 @@ append at the bottom like a traditional IRC client."
                         (adaptive-fill-mode nil))
                     (fill-region start (1- (point))))))
               (when ts-str
-                (let ((ov (if (eq clatter-timestamp-side 'inline)
-                              ;; Covers the final newline; rear stays put so
-                              ;; a message inserted below can't extend it.
-                              (make-overlay (1- (point)) (point) nil t)
-                            (make-overlay start (1+ start) nil t))))
-                  (clatter--timestamp-overlay-apply ov ts-str ts-tooltip-str)
-                  (overlay-put ov 'clatter-timestamp t)
-                  (overlay-put ov 'invisible invisible)))
+                (let* ((eol (1- (point)))
+                       (ov (if (eq clatter-timestamp-side 'inline)
+                               ;; Last text char, not the newline: after-string
+                               ;; at overlay-end stays on this line.  Rear
+                               ;; advances so compact appends keep the stamp
+                               ;; at EOL without covering the next message.
+                               (and (> eol start)
+                                    (make-overlay (1- eol) eol nil t t))
+                             (make-overlay start (1+ start) nil t))))
+                  (when ov
+                    (clatter--timestamp-overlay-apply ov ts-str ts-tooltip-str)
+                    (overlay-put ov 'clatter-timestamp t)
+                    (overlay-put ov 'invisible invisible))))
               (add-text-properties start (point) line-props)
               (when msg-props
                 (add-text-properties start (point) msg-props))
@@ -1518,7 +1525,8 @@ shared layout coherent when `buffer-invisibility-spec' changes, notably when
                                       '(display nil))))
           (dolist (overlay (append (overlays-at group-start)
                                    (and newline-position
-                                        (overlays-at newline-position))))
+                                        (overlays-in (1- newline-position)
+                                                     (1+ newline-position)))))
             (when (overlay-get overlay 'clatter-timestamp)
               (overlay-put
                overlay 'invisible
@@ -1678,7 +1686,8 @@ INVISIBLE categories so smart-hidden and visible actions can share a group."
                                    'invisible
                                    (clatter--compact-system-visibility invisible))
                 (dolist (overlay (append (overlays-at start)
-                                         (overlays-at end)))
+                                         (overlays-in (max (point-min) (1- end))
+                                                      (min (point-max) (1+ end)))))
                   (when (overlay-get overlay 'clatter-timestamp)
                     (overlay-put overlay 'invisible invisible)
                     (overlay-put overlay 'clatter-compact-system-invisible

--- a/clatter-ui.el
+++ b/clatter-ui.el
@@ -751,6 +751,7 @@ TOOLTIP, when non-nil, becomes the stamp's `help-echo'."
                                  stamp))))
       ;; Apply 'default face after 'clatter-timestamp so no unwanted face
       ;; properties are inherited from text which might be at point.
+      (overlay-put ov 'after-string nil)
       (overlay-put ov 'before-string
                    (propertize " " 'display
                                `((margin ,(if (eq clatter-timestamp-side 'left)

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -659,6 +659,24 @@ always showing fool messages."
             (should (equal (overlay-get ov 'help-echo) "10:12:00"))))
       (clatter-test-cleanup))))
 
+(ert-deftest clatter-test-timestamp-margin-clears-inline-after-string ()
+  "Reapplying a margin stamp drops a leftover inline after-string."
+  (let ((clatter-timestamp-side 'inline)
+        (clatter-timestamp-format "%H:%M")
+        (clatter-timestamp-only-if-changed nil)
+        (conn (clatter-test-make-connection))
+        (time (encode-time 0 12 10 1 1 2026)))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-insert-privmsg (current-buffer) "alice" "hello" conn time)
+          (let ((ov (clatter-test--timestamp-overlay)))
+            (should (overlay-get ov 'after-string))
+            (let ((clatter-timestamp-side 'right))
+              (clatter--timestamp-overlay-apply ov "10:12")
+              (should-not (overlay-get ov 'after-string))
+              (should (overlay-get ov 'before-string)))))
+      (clatter-test-cleanup))))
+
 (ert-deftest clatter-test-timestamp-inline-stays-before-newline ()
   "Inline stamp overlay ends at the newline, not on the next message."
   (let ((clatter-timestamp-side 'inline)

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -628,10 +628,10 @@ always showing fool messages."
           (clatter-insert-privmsg (current-buffer) "alice" "hello" conn time)
           (let ((ov (clatter-test--timestamp-overlay)))
             (should ov)
-            (should-not (overlay-get ov 'after-string))
-            (let* ((before (overlay-get ov 'before-string))
-                   (display (get-text-property 0 'display before)))
-              (should (string-match-p "10:12" before))
+            (should-not (overlay-get ov 'before-string))
+            (let* ((after (overlay-get ov 'after-string))
+                   (display (get-text-property 0 'display after)))
+              (should (string-match-p "10:12" after))
               (should (eq (car display) 'space))
               (should (equal (plist-get (cdr display) :align-to) '(- right 5))))))
       (clatter-test-cleanup))))
@@ -657,6 +657,32 @@ always showing fool messages."
             (should-not (overlay-get ov 'before-string))
             (should-not (overlay-get ov 'after-string))
             (should (equal (overlay-get ov 'help-echo) "10:12:00"))))
+      (clatter-test-cleanup))))
+
+(ert-deftest clatter-test-timestamp-inline-stays-before-newline ()
+  "Inline stamp overlay ends at the newline, not on the next message."
+  (let ((clatter-timestamp-side 'inline)
+        (clatter-timestamp-format "%H:%M")
+        (clatter-timestamp-only-if-changed nil)
+        (conn (clatter-test-make-connection))
+        (t1 (encode-time 0 24 9 28 8 2026))
+        (t2 (encode-time 0 29 9 28 8 2026)))
+    (unwind-protect
+        (with-temp-buffer
+          (clatter-mode)
+          (setq-local word-wrap t)
+          (clatter-insert-privmsg (current-buffer) "alice" "hello" conn t1)
+          (clatter-insert-privmsg (current-buffer) "bob" "there" conn t2)
+          (let ((ovs (cl-remove-if-not
+                      (lambda (overlay)
+                        (overlay-get overlay 'clatter-timestamp))
+                      (overlays-in (point-min) (point-max)))))
+            (should (= (length ovs) 2))
+            (dolist (ov ovs)
+              (should-not (eq (char-after (overlay-start ov)) ?\n))
+              (should (eq (char-after (overlay-end ov)) ?\n))
+              (should (overlay-get ov 'after-string))
+              (should-not (overlay-get ov 'before-string)))))
       (clatter-test-cleanup))))
 
 (ert-deftest clatter-test-timestamp-inline-stamps-system ()
@@ -686,19 +712,19 @@ always showing fool messages."
            buffer 'join '(:nick "alice" :channel "#test") nil)
           (with-current-buffer buffer
             (should (overlay-get (clatter-test--timestamp-overlay)
-                                 'before-string)))
+                                 'after-string)))
           ;; A short append still fits: the stamp survives.
           (clatter--insert-system-event
            buffer 'join '(:nick "bob" :channel "#test") nil)
           (with-current-buffer buffer
             (should (overlay-get (clatter-test--timestamp-overlay)
-                                 'before-string)))
+                                 'after-string)))
           ;; Growing past the body width drops it, like a long message.
           (clatter--insert-system-event
            buffer 'join (list :nick long-nick :channel "#test") nil)
           (with-current-buffer buffer
             (should-not (overlay-get (clatter-test--timestamp-overlay)
-                                     'before-string))))))))
+                                     'after-string))))))))
 
 (defun clatter-test--divider-positions ()
   "Return buffer positions of minute-divider lines."


### PR DESCRIPTION
Inline timestamps were a `before-string` on the terminating newline. That overlay string wrapped onto the next message (`09:29<nick>`), glued to EOL (`online09:48`), or sat on its own visual row.

The stamp is now an `after-string` on the last text character, so it stays on the same line. Compact appends still grow the overlay via rear-advance. Switching to a margin side clears the leftover `after-string`.

Test-driven in a live GUI. Codex reviewed; the P2 (duplicate stamp after side change) is in the second commit.